### PR TITLE
valid license identifier

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "civicrm/civix",
     "description": "CiviCRM Extension CLI",
     "homepage": "https://github.com/totten/civix",
-    "license": "AGPLv3",
+    "license": "AGPL-3.0",
     "require": {
         "symfony/class-loader": "v2.0.12",
         "symfony/console": "v2.0.12",


### PR DESCRIPTION
v. minor improvement - just playing around with civix and composer and noticed (with 'compose validate') that 'License "AGPLv3" is not a valid SPDX license identifier'.
