### PR TITLE
Civix was not capitalising filenames in the extension filespace - the API likes capitalised file names.

### DIFF
--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -58,8 +58,8 @@ class AddApiCommand extends ContainerAwareCommand
             throw new Exception("Action name must be alphanumeric camel-case");
         }
 
-        $ctx['entityNameCamel'] = $input->getArgument('entityName');
-        $ctx['actionNameCamel'] = $input->getArgument('actionName');
+        $ctx['entityNameCamel'] = ucfirst($input->getArgument('entityName'));
+        $ctx['actionNameCamel'] = ucfirst($input->getArgument('actionName'));
         $ctx['apiFunction'] = strtolower(civicrm_api_get_function_name($ctx['entityNameCamel'], $ctx['actionNameCamel'], self::API_VERSION));
         $ctx['apiFile'] = $basedir->string('api', 'v3', $ctx['entityNameCamel'], $ctx['actionNameCamel'] . '.php');
 


### PR DESCRIPTION
following on from http://forum.civicrm.org/index.php/topic,26554.0.html, I realised that the sms api wasn't working because it was expecting Contact/Sms.php, not contact/sms.php (which is what get created if you forget to capitalise your API entities and actions.
