### PR TITLE
generates the search according to the new all method

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/search.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/search.php.php
@@ -77,7 +77,7 @@ class <?php echo $searchClassName ?> extends CRM_Contact_Form_Search_Custom_Base
    *
    * @return string, sql
    */
-  function all($offset = 0, $rowcount = 0, $sort = NULL, $includeContactIDs = FALSE) {
+  function all($offset = 0, $rowcount = 0, $sort = NULL, $includeContactIDs = FALSE, $justIDs = FALSE) {
     // delegate to $this->sql(), $this->select(), $this->from(), $this->where(), etc.
     return $this->sql($this->select(), $offset, $rowcount, $sort, $includeContactIDs, NULL);
   }


### PR DESCRIPTION
Hi,

I am not sure how to handle that so it works with various versions, but at least the code generated will now work on the latest stable version out of the box

Fatal error: Declaration of CRM_Mycustomsearch::all() must be compatible with that of CRM_Contact_Form_Search_Interface::all() 

http://forum.civicrm.org/index.php/topic,29002.0.html
