### PR TITLE
Optionally manage the default license, author, and email for new extensions.

### DIFF
--- a/app/config/parameters.dist.yml
+++ b/app/config/parameters.dist.yml
@@ -1,4 +1,9 @@
 parameters:
+    ## Default values for generated extensions
+    author:
+    email:
+    license:
+
     ## To allow "civix" to manipulate your developmental instance
     ## of CiviCRM, you should configure local or remote API access.
 

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -24,6 +24,9 @@ class ConfigGetCommand extends ContainerAwareCommand {
 
   protected function getInterestingParameters() {
     return array(
+      'author',
+      'email',
+      'license',
       'civicrm_api3_conf_path',
       'civicrm_api3_server',
       'civicrm_api3_path',


### PR DESCRIPTION
Example usage:

```
civix config:set email info@civicrm.org 
civix config:set license AGPL-3.0
```

If no value has been set, then fallback to reading "git config" or using 
hard-coded defaults.
