### PR TITLE
Fixes #45 by giving civix the non-dereferenced path to the extension.

### DIFF
--- a/src/CRM/ClientBundle/ClientFactory.php
+++ b/src/CRM/ClientBundle/ClientFactory.php
@@ -16,7 +16,7 @@ class ClientFactory {
   public function get() {
     $origDir = getcwd();
 
-    list ($cmsRoot, $civicrmConfigPhp) = $this->findCivicrmConfigPhp(getcwd());
+    list ($cmsRoot, $civicrmConfigPhp) = $this->findCivicrmConfigPhp(exec("pwd"));
     if (!is_dir($cmsRoot)) {
       throw new \Exception('Failed to locate CMS. Please call civix from somewhere under the CMS root.');
     }


### PR DESCRIPTION
I didn't dig through the rest of the codebase to see which other `getcwd()`'s it might be appropriate to replace with `exec("pwd")`'s, but this seems to work.