### PR TITLE
Additional features for the civix test command.

### DIFF
--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -31,9 +31,11 @@ class TestRunCommand extends ContainerAwareCommand {
     $this
       ->setName('test')
       ->setDescription('Run a unit test')
-      ->addArgument('<TestClass>', InputArgument::REQUIRED, 'Test class name (eg "CRM_Myextension_MyTest")')
+      ->addArgument('<TestClass>', InputArgument::OPTIONAL, 'Test class name (eg "CRM_Myextension_MyTest")')
       ->addOption('clear', NULL, InputOption::VALUE_NONE, 'Clear the cached PHPUnit bootstrap data')
-      ->addOption('filter', NULL, InputOption::VALUE_REQUIRED, 'Restrict tests by name (regex)');
+      ->addOption('filter', NULL, InputOption::VALUE_REQUIRED, 'Restrict tests by name (regex)')
+      ->addOption('configuration', 'c', InputOption::VALUE_NONE, 'Run all the tests as configured in the phpunit.xml in the root directory of your extension.')
+      ->addOption('debug', NULL, InputOption::VALUE_NONE, 'Run PHPUnit in debug mode.');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
@@ -91,9 +93,17 @@ class TestRunCommand extends ContainerAwareCommand {
     $command[] = $tests_dir;
     $command[] = '--bootstrap';
     $command[] = $phpunit_boot;
+    $command[] = '--colors';
     if ($input->getOption('filter')) {
       $command[] = '--filter';
       $command[] = $input->getOption('filter');
+    }
+    if ($input->getOption('configuration')) {
+      $command[] = '--configuration';
+      $command[] = $basedir->string('phpunit.xml');
+    }
+    if ($input->getOption('debug')) {
+      $command[] = '--debug';
     }
     $command[] = $input->getArgument('<TestClass>');
 


### PR DESCRIPTION
I added a couple of additional options that can be passed to the civix test
command to make it easier to run and debug tests.

The first thing I did was make the Test Class argument optional because...

I needed a way to run all of the test classes for my extension at once and
couldn't find a good way to do this as currently implemented. So, I added a
--configuration option that will use PHPUnit's --configuration option to run
the tests as defined in a phpunit.xml file in the root of the extension.

I also added a --debug option as I've found the output with that option
incredibly helpful for tracking long test runs.

Finally, I added --colors option as I like the color output for an immediate
notification of pass or failure for the test run.