### PR TITLE
Fix regex extracting hostname from base URL

### DIFF
--- a/src/CRM/ClientBundle/ClientFactory.php
+++ b/src/CRM/ClientBundle/ClientFactory.php
@@ -85,7 +85,7 @@ class ClientFactory {
     // Now we have a Config object, we can set it from the Base URL.
     if ($_SERVER['HTTP_HOST'] == 'localhost') {
       $_SERVER['HTTP_HOST'] = preg_replace(
-        '!^https?://([^/]+)/$!i',
+        '!^https?://([^/]+)/.*$!i',
         '$1',
         $config->userFrameworkBaseURL);
     }


### PR DESCRIPTION
This fixes Drupal bootstrap for installs where the base URL is not the
root of the host. (Such as https://example.com/dcivi/ rather than just
https://example.com/ )