### PR TITLE
Automate detection of new entity types

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -200,6 +200,24 @@ function _<?php echo $mainFile ?>_civix_civicrm_managed(&$entities) {
 }
 
 /**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+function _<?php echo $mainFile ?>_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypeFiles = _<?php echo $mainFile ?>_civix_find_files(__DIR__, '*.entityType.php');
+  foreach ($entityTypeFiles as $file) {
+    $ets = include $file;
+    foreach ($ets as $et) {
+      $name = $et['name'];
+      $entityTypes[$name] = $et;
+    }
+  }
+}
+
+/**
  * (Delegated) Implements hook_civicrm_caseTypes().
  *
  * Find any and return any files matching "xml/case/*.xml"

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -98,6 +98,17 @@ function <?php echo $mainFile ?>_civicrm_managed(&$entities) {
 }
 
 /**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * Declare entity types provided by this module.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes) {
+  _<?php echo $mainFile ?>_civix_civicrm_entityTypes($entityTypes);
+}
+
+/**
  * Implements hook_civicrm_caseTypes().
  *
  * Generate a list of case-types.


### PR DESCRIPTION
Running `civix generate:entity` creates a `<name>.entityType.php` file very similar in structure to the `.mgd.php` files, but doesn't appear to be automatically detected similarly.  This patch eliminates the need to manually define `hook_civicrm_entityTypes`. 