### PR TITLE
prevent untidy warning when xpath missing

### DIFF
--- a/src/CRM/CivixBundle/Command/InfoGetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoGetCommand.php
@@ -37,7 +37,7 @@ class InfoGetCommand extends Command {
     $this
       ->setName('info:get')
       ->setDescription('Read a field from the info.xml file')
-      ->addOption('xpath', 'x', InputOption::VALUE_REQUIRED, '(REQIRED) The XPath expression of the field')
+      ->addOption('xpath', 'x', InputOption::VALUE_REQUIRED, '(REQUIRED) The XPath expression of the field')
       ->setHelp("Read a single field from the info.xml file.
 
 Examples:
@@ -57,8 +57,9 @@ Common fields:\n * " . implode("\n * ", $fields) . "\n");
 
     $xpath = $input->getOption('xpath');
     if (is_null($xpath)) {
-      $help = new HelpCommand();
-      $help->setCommand($this);
+      // missing xpath value so provide help
+      $help = $this->getApplication()->get('help');
+      $help->setCommand($this); // tell help to provide specific help for this function
       return $help->run($input, $output);
     }
     foreach ($info->get()->xpath($xpath) as $node) {

--- a/src/CRM/CivixBundle/Command/InfoGetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoGetCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\HelpCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -36,7 +37,7 @@ class InfoGetCommand extends Command {
     $this
       ->setName('info:get')
       ->setDescription('Read a field from the info.xml file')
-      ->addOption('xpath', 'x', InputOption::VALUE_REQUIRED, 'The XPath expression of the field')
+      ->addOption('xpath', 'x', InputOption::VALUE_REQUIRED, '(REQIRED) The XPath expression of the field')
       ->setHelp("Read a single field from the info.xml file.
 
 Examples:
@@ -54,7 +55,13 @@ Common fields:\n * " . implode("\n * ", $fields) . "\n");
     $info->load($ctx);
     $info->get();
 
-    foreach ($info->get()->xpath($input->getOption('xpath')) as $node) {
+    $xpath = $input->getOption('xpath');
+    if (is_null($xpath)) {
+      $help = new HelpCommand();
+      $help->setCommand($this);
+      return $help->run($input, $output);
+    }
+    foreach ($info->get()->xpath($xpath) as $node) {
       echo (string) $node;
       echo "\n";
     }


### PR DESCRIPTION
according to symfony docs its impossible to have a "required" option

(if user specifies the option then it is possible to require a value)

the way around this seems to be to use an "argument"...

I'm assuming that we wouldn't be keen to alter the signature now - but this patch at leasts give more useful output (i was getting a couple of pages of stack trace with `civix info:get `)

hope this is helpful!