### PR TITLE
define managed entities with api3 by default

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -196,6 +196,9 @@ function _<?php echo $mainFile ?>_civix_civicrm_managed(&$entities) {
         $e['module'] = '<?php echo $fullName ?>';
       }
       $entities[] = $e;
+      if (empty($e['params']['version'])) {
+        $e['params']['version'] = '3';
+      }
     }
   }
 }


### PR DESCRIPTION
At this point in time, I think it makes sense to presume that managed entities are defined using api3.

Please merge if you agree :)