### PR TITLE
generate:angular-page - improve help text

### DIFF
--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -25,6 +25,9 @@ class AddAngularPageCommand extends \Symfony\Component\Console\Command\Command {
 are loaded underneath it. For example, if a page the path
 "about/me", then the URL would be "civicrm/a/#/about/me".
 
+Before generating an angular page, you\'ll need to generate a module using:
+  civix generate:angular-module
+
 To add a new Angular-absed page, this command autogenerates three things:
  * A route (JS)
  * A controller (JS)


### PR DESCRIPTION
Clarify that an Angular module must be generated first
https://civicrm.stackexchange.com/questions/18837/unknown-path-when-viewing-a-newly-generated-angular-page