### PR TITLE
Define and use `E::ts()` helper function (etal)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -13,6 +13,16 @@ your module to match the newer templates, then use this procedure:
 
 ## Upgrade: Test Files
 
+### Upgrade to v17.08.1+
+
+civix v17.08.1+ introduces a new helper class. You can generate following the "General" upgrade procedure (above). No other changes are required.
+
+Optionally, if you want to *use* this helper class, then add a line like this to your other `*.php` files:
+
+```php
+use CRM_Myextension_ExtensionUtil as E;
+```
+
 ### Upgrade v16.03.2+
 
 Prior to civix v16.03, civix included the commands `civix generate:test` and `civix test`.  Beginning with v16.03, civix templates now

--- a/src/CRM/CivixBundle/Resources/views/Code/api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/api.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * <?php echo $entityNameCamel ?>.<?php echo $actionNameCamel ?> API specification (optional)

--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * <?php echo $entityNameCamel ?>.create API specification (optional)

--- a/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 class <?php echo $baoClassName ?> extends <?php echo $daoClassName ?> {
 

--- a/src/CRM/CivixBundle/Resources/views/Code/form.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/form.php.php
@@ -1,13 +1,16 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * Form controller class
  *
  * @see https://wiki.civicrm.org/confluence/display/CRMDOC/QuickForm+Reference
  */
-class <?php echo preg_replace(':/:','_',$fullClassName) ?> extends CRM_Core_Form {
+class <?php echo preg_replace(':/:', '_', $fullClassName) ?> extends CRM_Core_Form {
   public function buildQuickForm() {
 
     // add form elements
@@ -21,7 +24,7 @@ class <?php echo preg_replace(':/:','_',$fullClassName) ?> extends CRM_Core_Form
     $this->addButtons(array(
       array(
         'type' => 'submit',
-        'name' => ts('Submit'),
+        'name' => E::ts('Submit'),
         'isDefault' => TRUE,
       ),
     ));
@@ -34,7 +37,7 @@ class <?php echo preg_replace(':/:','_',$fullClassName) ?> extends CRM_Core_Form
   public function postProcess() {
     $values = $this->exportValues();
     $options = $this->getColorOptions();
-    CRM_Core_Session::setStatus(ts('You picked color "%1"', array(
+    CRM_Core_Session::setStatus(E::ts('You picked color "%1"', array(
       1 => $options[$values['favorite_color']],
     )));
     parent::postProcess();
@@ -42,14 +45,14 @@ class <?php echo preg_replace(':/:','_',$fullClassName) ?> extends CRM_Core_Form
 
   public function getColorOptions() {
     $options = array(
-      '' => ts('- select -'),
-      '#f00' => ts('Red'),
-      '#0f0' => ts('Green'),
-      '#00f' => ts('Blue'),
-      '#f0f' => ts('Purple'),
+      '' => E::ts('- select -'),
+      '#f00' => E::ts('Red'),
+      '#0f0' => E::ts('Green'),
+      '#00f' => E::ts('Blue'),
+      '#f0f' => E::ts('Purple'),
     );
     foreach (array('1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e') as $f) {
-      $options["#{$f}{$f}{$f}"] = ts('Grey (%1)', array(1 => $f));
+      $options["#{$f}{$f}{$f}"] = E::ts('Grey (%1)', array(1 => $f));
     }
     return $options;
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -19,7 +19,7 @@ class <?php echo $_namespace ?>_ExtensionUtil {
    */
   public static function ts($text, $params = array()) {
     if (!array_key_exists('domain', $params)) {
-      $params['domain'] = self::LONG_NAME;
+      $params['domain'] = array(self::LONG_NAME, NULL);
     }
     return ts($text, $params);
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -15,7 +15,17 @@ class <?php echo $_namespace ?>_ExtensionUtil {
   const PATH = __DIR__;
 
   /**
-   * Translate a string, using the extension's `domain`.
+   * Translate a string using the extension's domain.
+   *
+   * If the extension doesn't have a specific translation
+   * for the string, fallback to the default translations.
+   *
+   * @param string $text
+   *   Canonical message text (generally en_US).
+   * @param array $params
+   * @return string
+   *   Translated text.
+   * @see ts
    */
   public static function ts($text, $params = array()) {
     if (!array_key_exists('domain', $params)) {

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -13,7 +13,6 @@ class <?php echo $_namespace ?>_ExtensionUtil {
   const SHORT_NAME = "<?php echo $mainFile; ?>";
   const LONG_NAME = "<?php echo $fullName; ?>";
   const CLASS_PREFIX = "<?php echo $_namespace; ?>";
-  const PATH = __DIR__;
 
   /**
    * Translate a string using the extension's domain.
@@ -56,7 +55,8 @@ class <?php echo $_namespace ?>_ExtensionUtil {
    *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
   public static function path($file = NULL) {
-    return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    // return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+    return __DIR__ . ($path === NULL ? '' : (DIRECTORY_SEPARATOR . $file));
   }
 
   /**

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -1,9 +1,39 @@
 <?php
 echo "<?php\n";
-$_namespace = preg_replace(':/:','_',$namespace);
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+
+/**
+ * The ExtensionUtil class provides small stubs for accessing resources of this
+ * extension.
+ */
+class <?php echo $_namespace ?>_ExtensionUtil {
+  const SHORT_NAME = "<?php echo $mainFile; ?>";
+  const LONG_NAME = "<?php echo $fullName; ?>";
+  const PATH = __DIR__;
+
+  /**
+   * Translate a string, using the extension's `domain`.
+   */
+  public static function ts($text, $params = array()) {
+    if (!array_key_exists('domain', $params)) {
+      $params['domain'] = self::LONG_NAME;
+    }
+    return ts($text, $params);
+  }
+
+  public static function url($file = NULL) {
+    return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
+  }
+  public static function path($file = NULL) {
+    return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+  }
+
+}
+
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * (Delegated) Implements hook_civicrm_config().
@@ -193,7 +223,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_managed(&$entities) {
     $es = include $file;
     foreach ($es as $e) {
       if (empty($e['module'])) {
-        $e['module'] = '<?php echo $fullName ?>';
+        $e['module'] = E::LONG_NAME;
       }
       $entities[] = $e;
       if (empty($e['params']['version'])) {
@@ -225,7 +255,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_caseTypes(&$caseTypes) {
       // throw new CRM_Core_Exception($errorMessage);
     }
     $caseTypes[$name] = array(
-      'module' => '<?php echo $fullName ?>',
+      'module' => E::LONG_NAME,
       'name' => $name,
       'file' => $file,
     );
@@ -251,7 +281,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_angularModules(&$angularModules)
     $name = preg_replace(':\.ang\.php$:', '', basename($file));
     $module = include $file;
     if (empty($module['ext'])) {
-      $module['ext'] = '<?php echo $fullName ?>';
+      $module['ext'] = E::LONG_NAME;
     }
     $angularModules[$name] = $module;
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -12,6 +12,7 @@ $_namespace = preg_replace(':/:', '_', $namespace);
 class <?php echo $_namespace ?>_ExtensionUtil {
   const SHORT_NAME = "<?php echo $mainFile; ?>";
   const LONG_NAME = "<?php echo $fullName; ?>";
+  const CLASS_PREFIX = "<?php echo $_namespace; ?>";
   const PATH = __DIR__;
 
   /**
@@ -56,6 +57,18 @@ class <?php echo $_namespace ?>_ExtensionUtil {
    */
   public static function path($file = NULL) {
     return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
+  }
+
+  /**
+   * Get the name of a class within this extension.
+   *
+   * @param string $suffix
+   *   Ex: 'Page_HelloWorld' or 'Page\\HelloWorld'.
+   * @return string
+   *   Ex: 'CRM_Foo_Page_HelloWorld'.
+   */
+  public static function findClass($suffix) {
+    return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
 
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -34,9 +34,26 @@ class <?php echo $_namespace ?>_ExtensionUtil {
     return ts($text, $params);
   }
 
+  /**
+   * Get the URL of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
   public static function url($file = NULL) {
     return CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME, $file);
   }
+
+  /**
+   * Get the path of a resource file (in this extension).
+   *
+   * @param string|NULL $file
+   *   Ex: 'css/foo.css'.
+   * @return string
+   *   Ex: '/var/www/example.org/sites/default/ext/org.example.foo/css/foo.css'.
+   */
   public static function path($file = NULL) {
     return CRM_Core_Resources::singleton()->getPath(self::LONG_NAME, $file);
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -1,8 +1,10 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
 require_once '<?php echo $mainFile ?>.civix.php';
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * Implements hook_civicrm_config().
@@ -142,7 +144,7 @@ function <?php echo $mainFile ?>_civicrm_preProcess($formName, &$form) {
  *
 function <?php echo $mainFile ?>_civicrm_navigationMenu(&$menu) {
   _<?php echo $mainFile ?>_civix_insert_navigation_menu($menu, NULL, array(
-    'label' => ts('The Page', array('domain' => '<?php echo $fullName ?>')),
+    'label' => E::ts('The Page'),
     'name' => 'the_page',
     'url' => 'civicrm/the-page',
     'permission' => 'access CiviReport,access CiviContribute',

--- a/src/CRM/CivixBundle/Resources/views/Code/page.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/page.php.php
@@ -1,12 +1,14 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
-class <?php echo preg_replace(':/:','_',$fullClassName) ?> extends CRM_Core_Page {
+class <?php echo preg_replace(':/:', '_', $fullClassName) ?> extends CRM_Core_Page {
 
   public function run() {
     // Example: Set the page-title dynamically; alternatively, declare a static title in xml/Menu/*.xml
-    CRM_Utils_System::setTitle(ts('<?php echo $shortClassName ?>'));
+    CRM_Utils_System::setTitle(E::ts('<?php echo $shortClassName ?>'));
 
     // Example: Assign a variable for use in a template
     $this->assign('currentTime', date('Y-m-d H:i:s'));

--- a/src/CRM/CivixBundle/Resources/views/Code/report.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/report.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 class <?php echo $reportClassName ?> extends CRM_Report_Form {
 
@@ -17,7 +19,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
         'dao' => 'CRM_Contact_DAO_Contact',
         'fields' => array(
           'sort_name' => array(
-            'title' => ts('Contact Name'),
+            'title' => E::ts('Contact Name'),
             'required' => TRUE,
             'default' => TRUE,
             'no_repeat' => TRUE,
@@ -27,7 +29,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
             'required' => TRUE,
           ),
           'first_name' => array(
-            'title' => ts('First Name'),
+            'title' => E::ts('First Name'),
             'no_repeat' => TRUE,
           ),
           'id' => array(
@@ -35,7 +37,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
             'required' => TRUE,
           ),
           'last_name' => array(
-            'title' => ts('Last Name'),
+            'title' => E::ts('Last Name'),
             'no_repeat' => TRUE,
           ),
           'id' => array(
@@ -45,7 +47,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
         ),
         'filters' => array(
           'sort_name' => array(
-            'title' => ts('Contact Name'),
+            'title' => E::ts('Contact Name'),
             'operator' => 'like',
           ),
           'id' => array(
@@ -63,7 +65,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
             'no_repeat' => TRUE,
           ),
           'join_date' => array(
-            'title' => ts('Join Date'),
+            'title' => E::ts('Join Date'),
             'default' => TRUE,
           ),
           'source' => array('title' => 'Source'),
@@ -73,12 +75,12 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
             'operatorType' => CRM_Report_Form::OP_DATE,
           ),
           'owner_membership_id' => array(
-            'title' => ts('Membership Owner ID'),
+            'title' => E::ts('Membership Owner ID'),
             'operatorType' => CRM_Report_Form::OP_INT,
           ),
           'tid' => array(
             'name' => 'membership_type_id',
-            'title' => ts('Membership Types'),
+            'title' => E::ts('Membership Types'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Member_PseudoConstant::membershipType(),
@@ -91,14 +93,14 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
         'alias' => 'mem_status',
         'fields' => array(
           'name' => array(
-            'title' => ts('Status'),
+            'title' => E::ts('Status'),
             'default' => TRUE,
           ),
         ),
         'filters' => array(
           'sid' => array(
             'name' => 'id',
-            'title' => ts('Status'),
+            'title' => E::ts('Status'),
             'type' => CRM_Utils_Type::T_INT,
             'operatorType' => CRM_Report_Form::OP_MULTISELECT,
             'options' => CRM_Member_PseudoConstant::membershipStatus(NULL, NULL, 'label'),
@@ -112,8 +114,8 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
           'street_address' => NULL,
           'city' => NULL,
           'postal_code' => NULL,
-          'state_province_id' => array('title' => ts('State/Province')),
-          'country_id' => array('title' => ts('Country')),
+          'state_province_id' => array('title' => E::ts('State/Province')),
+          'country_id' => array('title' => E::ts('Country')),
         ),
         'grouping' => 'contact-fields',
       ),
@@ -129,7 +131,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
   }
 
   function preProcess() {
-    $this->assign('reportTitle', ts('Membership Detail Report'));
+    $this->assign('reportTitle', E::ts('Membership Detail Report'));
     parent::preProcess();
   }
 
@@ -312,7 +314,7 @@ class <?php echo $reportClassName ?> extends CRM_Report_Form {
           $this->_absoluteUrl
         );
         $rows[$rowNum]['civicrm_contact_sort_name_link'] = $url;
-        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = ts("View Contact Summary for this Contact.");
+        $rows[$rowNum]['civicrm_contact_sort_name_hover'] = E::ts("View Contact Summary for this Contact.");
         $entryFound = TRUE;
       }
 

--- a/src/CRM/CivixBundle/Resources/views/Code/search.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/search.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * A custom contact search
@@ -17,16 +19,16 @@ class <?php echo $searchClassName ?> extends CRM_Contact_Form_Search_Custom_Base
    * @return void
    */
   function buildForm(&$form) {
-    CRM_Utils_System::setTitle(ts('My Search Title'));
+    CRM_Utils_System::setTitle(E::ts('My Search Title'));
 
     $form->add('text',
       'household_name',
-      ts('Household Name'),
+      E::ts('Household Name'),
       TRUE
     );
 
-    $stateProvince = array('' => ts('- any state/province -')) + CRM_Core_PseudoConstant::stateProvince();
-    $form->addElement('select', 'state_province_id', ts('State/Province'), $stateProvince);
+    $stateProvince = array('' => E::ts('- any state/province -')) + CRM_Core_PseudoConstant::stateProvince();
+    $form->addElement('select', 'state_province_id', E::ts('State/Province'), $stateProvince);
 
     // Optionally define default search values
     $form->setDefaults(array(
@@ -64,10 +66,10 @@ class <?php echo $searchClassName ?> extends CRM_Contact_Form_Search_Custom_Base
   function &columns() {
     // return by reference
     $columns = array(
-      ts('Contact Id') => 'contact_id',
-      ts('Contact Type') => 'contact_type',
-      ts('Name') => 'sort_name',
-      ts('State') => 'state_province',
+      E::ts('Contact Id') => 'contact_id',
+      E::ts('Contact Type') => 'contact_type',
+      E::ts('Name') => 'sort_name',
+      E::ts('State') => 'state_province',
     );
     return $columns;
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/test-e2e.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-e2e.php.php
@@ -4,8 +4,10 @@ echo "<?php\n";
 if ($testNamespace) {
   echo "namespace $testNamespace;\n";
 }
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 use Civi\Test\EndToEndInterface;
 
 /**

--- a/src/CRM/CivixBundle/Resources/views/Code/test-headless.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-headless.php.php
@@ -4,8 +4,10 @@ echo "<?php\n";
 if ($testNamespace) {
   echo "namespace $testNamespace;\n";
 }
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;

--- a/src/CRM/CivixBundle/Resources/views/Code/test-legacy.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-legacy.php.php
@@ -4,8 +4,10 @@ echo "<?php\n";
 if ($testNamespace) {
   echo "namespace $testNamespace;\n";
 }
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 use Civi\Test\HeadlessInterface;
 
 /**

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
@@ -1,9 +1,10 @@
 <?php
 echo "<?php\n";
-$_namespace = preg_replace(':/:','_',$namespace);
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * Base class which provides helpers to execute upgrade logic

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -1,7 +1,8 @@
 <?php
 echo "<?php\n";
-$_namespace = preg_replace(':/:','_',$namespace);
+$_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
  * Collection of upgrade steps.
@@ -92,9 +93,9 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
   public function upgrade_4202() {
     $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
 
-    $this->addTask(ts('Process first step'), 'processPart1', $arg1, $arg2);
-    $this->addTask(ts('Process second step'), 'processPart2', $arg3, $arg4);
-    $this->addTask(ts('Process second step'), 'processPart3', $arg5);
+    $this->addTask(E::ts('Process first step'), 'processPart1', $arg1, $arg2);
+    $this->addTask(E::ts('Process second step'), 'processPart2', $arg3, $arg4);
+    $this->addTask(E::ts('Process second step'), 'processPart3', $arg5);
     return TRUE;
   }
   public function processPart1($arg1, $arg2) { sleep(10); return TRUE; }
@@ -116,7 +117,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
     $maxId = CRM_Core_DAO::singleValueQuery('SELECT coalesce(max(id),0) FROM civicrm_contribution');
     for ($startId = $minId; $startId <= $maxId; $startId += self::BATCH_SIZE) {
       $endId = $startId + self::BATCH_SIZE - 1;
-      $title = ts('Upgrade Batch (%1 => %2)', array(
+      $title = E::ts('Upgrade Batch (%1 => %2)', array(
         1 => $startId,
         2 => $endId,
       ));


### PR DESCRIPTION
Civi's `ts()` function (PHP) works with extensions, but it's cumbersome to do it correctly -- you have to include the `domain` parameter, and many people aren't aware of this (or do it inconsistently).

(_Update_: Similar usability issues affect `CRM_Core_Resources::singleton()->getUrl()` and `CRM_Core_Resources::singleton()->getPath()`.)

== Before ==

Code generated by `civix` directly calls the `ts()` function, but it's fairly inconsistent/unreliable about passing the `domain`.

== After ==

 * The autogenerated helper file (`mymodule.civix.php`) defines a helper class `CRM_Mymodule_ExtensionUtil`.
 * The expression `use CRM_Mymodule_ExtensionUtil as E;` is included in all other autogenerated PHP files.
 * The `E`  class supports several helpers. Many of these functions were available before, but they were more verbose.
   * `E::ts($text)` -- Translate a string (using the extensions' translation file)
   * `E::path($file)` -- Get the path to a resource file (within this extension)
   * `E::url($file)` -- Get the URL to a resource file (within this extension)
   * `E::findClass($suffix)` -- Get the full name of a class (within this extension)
   * `E::LONG_NAME` -- The full length key for this extension (`org.example.foobar`)
   * `E::SHORT_NAME` -- The abbreviated key for this extension (`foobar`)

== Acceptance criteria / Evaluation tasks ==

 * Ensure that all generated PHP files comply with the new convention.
 * Prepare communications/messaging for developers about the new notation.
 * Re-test all code-generators to ensure they output valid code.