### PR TITLE
Do not bundle the .git directory in extension downloads.

### DIFF
--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -38,6 +38,7 @@ class BuildCommand extends \Symfony\Component\Console\Command\Command {
       'build/*',
       '*~',
       '*.bak',
+      '*.git*',
     );
     $cmd = 'zip ' . implode(' ', array_map('escapeshellarg', $cmdArgs));
 


### PR DESCRIPTION
This should reduce the size of generated extension zips.

Refs #103.