### PR TITLE
Use pretty array syntax in civix logic

### DIFF
--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -45,7 +45,7 @@ class Application extends \Symfony\Component\Console\Application {
    * @return array of Symfony Command objects
    */
   public function createCommands($context = 'default') {
-    $commands = array();
+    $commands = [];
     $commands[] = new AddAngularDirectiveCommand();
     $commands[] = new AddAngularModuleCommand();
     $commands[] = new AddAngularPageCommand();

--- a/src/CRM/CivixBundle/Builder/Collection.php
+++ b/src/CRM/CivixBundle/Builder/Collection.php
@@ -8,7 +8,7 @@ use Symfony\Component\Console\Output\OutputInterface;
  * A collection of builders
  */
 class Collection implements Builder {
-  public function __construct($builders = array()) {
+  public function __construct($builders = []) {
     $this->builders = $builders;
   }
 

--- a/src/CRM/CivixBundle/Builder/CopyClass.php
+++ b/src/CRM/CivixBundle/Builder/CopyClass.php
@@ -58,9 +58,9 @@ class CopyClass implements Builder {
       $output->writeln("<info>Write " . $this->tgtFile . "</info>");
       $content = file_get_contents($clazz->getFileName(), TRUE);
       // FIXME parser
-      $content = strtr($content, array(
+      $content = strtr($content, [
         $this->srcClassName => $this->tgtClassName,
-      ));
+      ]);
       if (is_callable($this->filter)) {
         $content = call_user_func($this->filter, $content);
       }

--- a/src/CRM/CivixBundle/Builder/License.php
+++ b/src/CRM/CivixBundle/Builder/License.php
@@ -43,11 +43,11 @@ class License implements Builder {
     }
     else {
       $output->writeln("<info>Write " . $this->path . "</info>");
-      $text = strtr($this->license->getText(), array(
+      $text = strtr($this->license->getText(), [
         '<YEAR>' => date('Y'),
         '<OWNER>' => sprintf('%s <%s>', $ctx['author'], $ctx['email']),
         '<TITLE>' => sprintf('Package: %s', $ctx['fullName']),
-      ));
+      ]);
       file_put_contents($this->path, $text);
     }
   }

--- a/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
+++ b/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
@@ -13,9 +13,9 @@ class PHPUnitGenerateInitFiles {
    */
   public function initPhpunitBootstrap($bootstrapFile, &$ctx, OutputInterface $output) {
     if (!file_exists($bootstrapFile)) {
-      $dirs = new Dirs(array(
+      $dirs = new Dirs([
         dirname($bootstrapFile),
-      ));
+      ]);
       $dirs->save($ctx, $output);
 
       $output->writeln(sprintf('<info>Write %s</info>', $bootstrapFile));
@@ -42,4 +42,5 @@ class PHPUnitGenerateInitFiles {
       $output->writeln(sprintf('<comment>Skip %s: file already exists</comment>', $phpunitXmlFile));
     }
   }
+
 }

--- a/src/CRM/CivixBundle/Builder/PhpUnitXML.php
+++ b/src/CRM/CivixBundle/Builder/PhpUnitXML.php
@@ -23,7 +23,7 @@ class PhpUnitXML extends XML {
     $xml->addAttribute('bootstrap', 'tests/phpunit/bootstrap.php');
     $this->set($xml);
 
-    $this->addTestSuite('My Test Suite', array('./tests/phpunit'));
+    $this->addTestSuite('My Test Suite', ['./tests/phpunit']);
 
     $this->get()
       ->addChild('filter')

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -29,7 +29,7 @@ abstract class AbstractAddPageCommand extends Command {
       throw new Exception("Class name should be valid (alphanumeric beginning with uppercase)");
     }
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $ctx['shortClassName'] = $input->getArgument('<ClassName>');
@@ -51,11 +51,11 @@ abstract class AbstractAddPageCommand extends Command {
       throw new Exception("Class name looks suspicious. Please note the final class would be \"{$ctx['fullClassName']}\"");
     }
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       $basedir->string('xml', 'Menu'),
       dirname($phpFile),
       dirname($tplFile),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     $menu = new Menu($basedir->string('xml', 'Menu', $ctx['mainFile'] . '.xml'));

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -33,7 +33,7 @@ For more, see https://docs.angularjs.org/guide/directive');
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     //// Figure out template data ////
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -60,17 +60,17 @@ For more, see https://docs.angularjs.org/guide/directive');
     }
 
     $ctx['jsPath'] = $basedir->string('ang', $ctx['angularModuleName'], $ctx['baseFileName'] . '.js');
-    $ctx['htmlName'] = implode('/', array('~', $ctx['angularModuleName'], $ctx['baseFileName'] . '.html'));
+    $ctx['htmlName'] = implode('/', ['~', $ctx['angularModuleName'], $ctx['baseFileName'] . '.html']);
     $ctx['htmlPath'] = $basedir->string('ang', $ctx['angularModuleName'], $ctx['baseFileName'] . '.html');
 
     //// Construct files ////
     $output->writeln("<info>Initialize Angular directive \"" . $ctx['dirNameHyp'] . "\" (aka \"" . $ctx['dirNameCamel'] . "\")</info>");
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['jsPath']),
       dirname($ctx['htmlPath']),
-    ));;
+    ]);;
 
     $ext->builders['js'] = new Template('angular-dir.js.php', $ctx['jsPath'], FALSE, Services::templating());
     $ext->builders['html'] = new Template('angular-dir.html.php', $ctx['htmlPath'], FALSE, Services::templating());

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -23,7 +23,7 @@ class AddAngularModuleCommand extends \Symfony\Component\Console\Command\Command
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     //// Figure out template data ////
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -45,26 +45,26 @@ class AddAngularModuleCommand extends \Symfony\Component\Console\Command\Command
     $output->writeln("<info>Initialize Angular module \"" . $ctx['angularModuleName'] . "\"</info>");
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['angularModulePhp']),
       dirname($ctx['angularModuleJs']),
-    ));;
+    ]);;
 
     if (!file_exists($ctx['angularModulePhp'])) {
-      $angModMeta = array(
-        'js' => array(
+      $angModMeta = [
+        'js' => [
           'ang/' . $ctx['angularModuleName'] . '.js',
           'ang/' . $ctx['angularModuleName'] . '/*.js',
           'ang/' . $ctx['angularModuleName'] . '/*/*.js',
-        ),
-        'css' => array(
+        ],
+        'css' => [
           'ang/' . $ctx['angularModuleName'] . '.css',
-        ),
-        'partials' => array(
+        ],
+        'partials' => [
           'ang/' . $ctx['angularModuleName'],
-        ),
-        'settings' => array(),
-      );
+        ],
+        'settings' => [],
+      ];
       $header = "// This file declares an Angular module which can be autoloaded\n"
         . "// in CiviCRM. See also:\n"
         . "// http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_angularModules\n";

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -38,7 +38,7 @@ For more, see https://docs.angularjs.org/guide');
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     //// Figure out template data ////
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -57,7 +57,7 @@ For more, see https://docs.angularjs.org/guide');
     $ctx['ctrlRelPath'] = $input->getArgument('<RelPath>');
     $ctx['ctrlName'] = ucwords($ctx['angularModuleName']) . $ctx['ctrlSuffix'];
     $ctx['jsPath'] = $basedir->string('ang', $ctx['angularModuleName'], $ctx['ctrlSuffix'] . '.js');
-    $ctx['htmlName'] = implode('/', array('~', $ctx['angularModuleName'], $ctx['ctrlSuffix'] . '.html'));
+    $ctx['htmlName'] = implode('/', ['~', $ctx['angularModuleName'], $ctx['ctrlSuffix'] . '.html']);
     $ctx['htmlPath'] = $basedir->string('ang', $ctx['angularModuleName'], $ctx['ctrlSuffix'] . '.html');
     $ctx['hlpName'] = 'CRM' . '/' . $ctx['angularModuleName'] . '/' . $ctx['ctrlSuffix'];
     $ctx['hlpPath'] = $basedir->string('templates', $ctx['hlpName'] . '.hlp');
@@ -66,11 +66,11 @@ For more, see https://docs.angularjs.org/guide');
     $output->writeln("<info>Initialize Angular page \"" . $ctx['ctrlName'] . "\" (civicrm/a/#/" . $ctx['ctrlRelPath'] . ")</info>");
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['jsPath']),
       dirname($ctx['htmlPath']),
       dirname($ctx['hlpPath']),
-    ));;
+    ]);;
 
     $ext->builders['ctrl.js'] = new Template('angular-page.js.php', $ctx['jsPath'], FALSE, Services::templating());
     $ext->builders['html'] = new Template('angular-page.html.php', $ctx['htmlPath'], FALSE, Services::templating());

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -19,7 +19,7 @@ class AddApiCommand extends Command {
   const API_VERSION = 3;
 
   public static function getSchedules() {
-    return array('Daily', 'Hourly', 'Always');
+    return ['Daily', 'Hourly', 'Always'];
   }
 
   protected function configure() {
@@ -33,14 +33,14 @@ class AddApiCommand extends Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return;
     }
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -80,9 +80,9 @@ class AddApiCommand extends Command {
 
     $ctx['testClassName'] = "api_v3_{$ctx['entityNameCamel']}_{$ctx['actionNameCamel']}Test";
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       dirname($ctx['apiFile']),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     if (!file_exists($ctx['apiFile'])) {
@@ -96,11 +96,11 @@ class AddApiCommand extends Command {
 
     if ($input->getOption('schedule')) {
       if (!file_exists($ctx['apiCronFile'])) {
-        $mgdEntities = array(
-          array(
+        $mgdEntities = [
+          [
             'name' => 'Cron:' . $ctx['entityNameCamel'] . '.' . $ctx['actionNameCamel'],
             'entity' => 'Job',
-            'params' => array(
+            'params' => [
               'version' => 3,
               'name' => sprintf('Call %s.%s API', $ctx['entityNameCamel'], $ctx['actionNameCamel']),
               'description' => sprintf('Call %s.%s API', $ctx['entityNameCamel'], $ctx['actionNameCamel']),
@@ -108,9 +108,9 @@ class AddApiCommand extends Command {
               'api_entity' => $ctx['entityNameCamel'],
               'api_action' => $ctx['actionNameCamel'],
               'parameters' => '',
-            ),
-          ),
-        );
+            ],
+          ],
+        ];
         $header = "// This file declares a managed database record of type \"Job\".\n"
           . "// The record will be automatically inserted, updated, or deleted from the\n"
           . "// database as appropriate. For more details, see \"hook_civicrm_managed\" at:\n"
@@ -124,9 +124,9 @@ class AddApiCommand extends Command {
       }
     }
 
-    $test_dirs = new Dirs(array(
+    $test_dirs = new Dirs([
       dirname($ctx['apiTestFile']),
-    ));
+    ]);
     $test_dirs->save($ctx, $output);
     if (!file_exists($ctx['apiTestFile'])) {
       $output->writeln(sprintf('<info>Write %s</info>', $ctx['apiTestFile']));

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -23,7 +23,7 @@ class AddCaseTypeCommand extends \Symfony\Component\Console\Command\Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("Requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
@@ -41,7 +41,7 @@ class AddCaseTypeCommand extends \Symfony\Component\Console\Command\Command {
       throw new Exception("Name should be valid (alphanumeric beginning with uppercase)");
     }
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $ctx['caseTypeLabel'] = $input->getArgument('<Label>');
@@ -57,9 +57,9 @@ class AddCaseTypeCommand extends \Symfony\Component\Console\Command\Command {
       return;
     }
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       $basedir->string('xml', 'case'),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     $xmlFile = $basedir->string('xml', 'case', $ctx['caseTypeName'] . '.xml');

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -24,14 +24,14 @@ class AddCustomDataCommand extends \Symfony\Component\Console\Command\Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>generate:custom-xml requires access to local CiviCRM instance. Configure civicrm_api3_conf_path.</error>");
       return;
     }
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -44,9 +44,9 @@ class AddCustomDataCommand extends \Symfony\Component\Console\Command\Command {
       return;
     }
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       $basedir->string('xml'),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     if ($input->getArgument('<CustomDataFile.xml>')) {
@@ -60,8 +60,8 @@ class AddCustomDataCommand extends \Symfony\Component\Console\Command\Command {
       return;
     }
     $customDataXML = new CustomDataXML(
-      $input->getOption('data') ? explode(',', $input->getOption('data')) : array(),
-      $input->getOption('uf') ? explode(',', $input->getOption('uf')) : array(),
+      $input->getOption('data') ? explode(',', $input->getOption('data')) : [],
+      $input->getOption('uf') ? explode(',', $input->getOption('uf')) : [],
       $customDataXMLFile,
       $input->getOption('force')
     );

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -26,14 +26,14 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return;
     }
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -70,12 +70,12 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     $ctx['entityTypeFile'] = $basedir->string('xml', 'schema', $ctx['namespace'], $input->getArgument('<EntityName>') . '.entityType.php');
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['apiFile']),
       dirname($ctx['daoClassFile']),
       dirname($ctx['baoClassFile']),
       dirname($ctx['schemaFile']),
-    ));
+    ]);
     $ext->builders['dirs']->save($ctx, $output);
 
     $ext->builders['api.php'] = new Template('entity-api.php.php', $ctx['apiFile'], FALSE, Services::templating());
@@ -83,13 +83,13 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     $ext->builders['entity.xml'] = new Template('entity-schema.xml.php', $ctx['schemaFile'], FALSE, Services::templating());
 
     if (!file_exists($ctx['entityTypeFile'])) {
-      $mgdEntities = array(
-        array(
+      $mgdEntities = [
+        [
           'name' => $ctx['entityNameCamel'],
           'class' => $ctx['daoClassName'],
           'table' => $ctx['tableName'],
-        ),
-      );
+        ],
+      ];
       $header = "// This file declares a new entity type. For more details, see \"hook_civicrm_entityTypes\" at:\n"
         . "// http://wiki.civicrm.org/confluence/display/CRMDOC/Hook+Reference";
       $ext->builders['entityType.php'] = new PhpData($ctx['entityTypeFile'], $header);

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -28,7 +28,7 @@ class AddReportCommand extends \Symfony\Component\Console\Command\Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     //// Figure out template data and put it in $ctx ////
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -67,28 +67,28 @@ class AddReportCommand extends \Symfony\Component\Console\Command\Command {
     $output->writeln("<info>Initialize report " . $ctx['reportClassName'] . "</info>");
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['reportClassFile']),
       dirname($ctx['reportMgdFile']),
       dirname($ctx['reportTplFile']),
-    ));
+    ]);
 
     // Register the report in the DB using api/v3/ReportTemplate and hook_civicrm_managed
     if (!file_exists($ctx['reportMgdFile'])) {
-      $mgdEntities = array(
-        array(
+      $mgdEntities = [
+        [
           'name' => $ctx['reportClassName'],
           'entity' => 'ReportTemplate',
-          'params' => array(
+          'params' => [
             'version' => 3,
             'label' => $input->getArgument('<ClassName>'),
             'description' => sprintf("%s (%s)", $input->getArgument('<ClassName>'), $ctx['fullName']),
             'class_name' => $ctx['reportClassName'],
             'report_url' => $ctx['reportUrl'],
             'component' => $input->getArgument('<CiviComponent>') == 'null' ? '' : $input->getArgument('<CiviComponent>'),
-          ),
-        ),
-      );
+          ],
+        ],
+      ];
       $header = "// This file declares a managed database record of type \"ReportTemplate\".\n"
         . "// The record will be automatically inserted, updated, or deleted from the\n"
         . "// database as appropriate. For more details, see \"hook_civicrm_managed\" at:\n"
@@ -100,7 +100,7 @@ class AddReportCommand extends \Symfony\Component\Console\Command\Command {
     // Create .php & .tpl by either copying from core source tree or using a civix template
     if ($srcClassName = $input->getOption('copy')) {
       // To locate the original file, we need to bootstrap Civi and search the include path
-      Services::boot(array('output' => $output));
+      Services::boot(['output' => $output]);
       $civicrm_api3 = Services::api3();
       if (!$civicrm_api3 || !$civicrm_api3->local) {
         $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
@@ -126,7 +126,7 @@ class AddReportCommand extends \Symfony\Component\Console\Command\Command {
    * @return array(string)
    */
   protected function getReportComponents() {
-    return array(
+    return [
       'CiviCampaign',
       'CiviCase',
       'CiviContribute',
@@ -136,7 +136,7 @@ class AddReportCommand extends \Symfony\Component\Console\Command\Command {
       'CiviMember',
       'CiviPledge',
       'null',
-    );
+    ];
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -28,7 +28,7 @@ class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     //// Figure out template data ////
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -51,25 +51,25 @@ class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
     $output->writeln("<info>Initialize search " . $ctx['searchClassName'] . "</info>");
 
     $ext = new Collection();
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       dirname($ctx['searchClassFile']),
       dirname($ctx['searchMgdFile']),
-    ));
+    ]);
     ;
 
     if (!file_exists($ctx['searchMgdFile'])) {
-      $mgdEntities = array(
-        array(
+      $mgdEntities = [
+        [
           'name' => $ctx['searchClassName'],
           'entity' => 'CustomSearch',
-          'params' => array(
+          'params' => [
             'version' => 3,
             'label' => $input->getArgument('<ClassName>'),
             'description' => sprintf("%s (%s)", $input->getArgument('<ClassName>'), $ctx['fullName']),
             'class_name' => $ctx['searchClassName'],
-          ),
-        ),
-      );
+          ],
+        ],
+      ];
       $header = "// This file declares a managed database record of type \"CustomSearch\".\n"
         . "// The record will be automatically inserted, updated, or deleted from the\n"
         . "// database as appropriate. For more details, see \"hook_civicrm_managed\" at:\n"
@@ -80,7 +80,7 @@ class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
 
     if ($srcClassName = $input->getOption('copy')) {
       // we need bootstrap to set up include path to locate file -- but that's it
-      Services::boot(array('output' => $output));
+      Services::boot(['output' => $output]);
       $civicrm_api3 = Services::api3();
       if (!$civicrm_api3 || !$civicrm_api3->local) {
         $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
@@ -99,9 +99,9 @@ class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
             // conferring with the flowers
             // consulting with the rain
             // if i only had a parser
-            return strtr($phpSrc, array(
+            return strtr($phpSrc, [
               $origTplFile => $ctx['searchTplRelFile'],
-            ));
+            ]);
           }
         );
         $ext->builders['page.tpl.php'] = new CopyFile('templates/' . $origTplFile, $ctx['searchTplFile'], FALSE);
@@ -123,7 +123,7 @@ class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
    * @return string
    */
   protected static function findTpl($srcClassName) {
-    $formValues = array();
+    $formValues = [];
     $search = new $srcClassName($formValues);
     return $search->templateFile();
   }

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -53,7 +53,7 @@ as separate groups:
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -73,12 +73,12 @@ as separate groups:
   }
 
   protected function getTestTemplate($type) {
-    $templates = array(
+    $templates = [
       'e2e' => 'test-e2e.php.php',
       'headless' => 'test-headless.php.php',
       'legacy' => 'test-legacy.php.php',
       'phpunit' => 'test-phpunit.php.php',
-    );
+    ];
     if (isset($templates[$type])) {
       return $templates[$type];
     }
@@ -108,12 +108,12 @@ as separate groups:
     $parts = explode('\\', $fullClassName);
     $ctx['testClass'] = array_pop($parts);
     $ctx['testNamespace'] = implode('\\', $parts);
-    $testFile = strtr($fullClassName, array('_' => '/', '\\' => '/')) . '.php';
+    $testFile = strtr($fullClassName, ['_' => '/', '\\' => '/']) . '.php';
     $testPath = $basedir->string('tests', 'phpunit', $testFile);
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       dirname($testPath),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     if (!file_exists($testPath)) {

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -21,7 +21,7 @@ class AddUpgraderCommand extends \Symfony\Component\Console\Command\Command {
   protected function execute(InputInterface $input, OutputInterface $output) {
     // TODO validate that hook_civicrm_upgrade has been implemented
 
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -34,11 +34,11 @@ class AddUpgraderCommand extends \Symfony\Component\Console\Command\Command {
       return;
     }
 
-    $dirs = new Dirs(array(
+    $dirs = new Dirs([
       $basedir->string('sql'),
       $basedir->string($ctx['namespace']),
       $basedir->string($ctx['namespace'], 'Upgrader'),
-    ));
+    ]);
     $dirs->save($ctx, $output);
 
     $phpFile = $basedir->string($ctx['namespace'], 'Upgrader.php');

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -16,7 +16,7 @@ class BuildCommand extends \Symfony\Component\Console\Command\Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
@@ -30,7 +30,7 @@ class BuildCommand extends \Symfony\Component\Console\Command\Command {
     }
 
     $ctx['zipFile'] = $basedir->string('build', $ctx['fullName'] . '.zip');
-    $cmdArgs = array(
+    $cmdArgs = [
       '-r',
       $ctx['zipFile'],
       $ctx['fullName'],
@@ -39,7 +39,7 @@ class BuildCommand extends \Symfony\Component\Console\Command\Command {
       '*~',
       '*.bak',
       '*.git*',
-    );
+    ];
     $cmd = 'zip ' . implode(' ', array_map('escapeshellarg', $cmdArgs));
 
     chdir($basedir->string('..'));

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -22,11 +22,11 @@ class ConfigGetCommand extends \Symfony\Component\Console\Command\Command {
   }
 
   protected function getInterestingParameters() {
-    return array(
+    return [
       'author',
       'email',
       'license',
-    );
+    ];
   }
 
 }

--- a/src/CRM/CivixBundle/Command/ConfigSetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigSetCommand.php
@@ -20,7 +20,7 @@ class ConfigSetCommand extends \Symfony\Component\Console\Command\Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $ctx = array();
+    $ctx = [];
     $ext = new Collection();
 
     $output->writeln("<info></info>");
@@ -31,7 +31,7 @@ class ConfigSetCommand extends \Symfony\Component\Console\Command\Command {
     $ext->loadInit($ctx);
     $data = $ext->builders['ini']->get();
     if (!is_array($data)) {
-      $data = array('parameters' => array());
+      $data = ['parameters' => []];
     }
     $data['parameters'][$input->getArgument('key')] = $input->getArgument('value');
     $ext->builders['ini']->set($data);

--- a/src/CRM/CivixBundle/Command/InfoGetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoGetCommand.php
@@ -18,7 +18,7 @@ use Exception;
 class InfoGetCommand extends Command {
 
   protected function configure() {
-    $fields = array(
+    $fields = [
       'file',
       'name',
       'description',
@@ -32,7 +32,7 @@ class InfoGetCommand extends Command {
       'civix/namespace',
       'urls/url[@desc="Documentation"]',
       'urls/url[@desc="Support"]',
-    );
+    ];
 
     $this
       ->setName('info:get')
@@ -51,7 +51,7 @@ Common fields:\n * " . implode("\n * ", $fields) . "\n");
   protected function execute(InputInterface $input, OutputInterface $output) {
     $basedir = new Path(\CRM\CivixBundle\Application::findExtDir());
     $info = new Info($basedir->string('info.xml'));
-    $ctx = array();
+    $ctx = [];
     $info->load($ctx);
     $info->get();
 

--- a/src/CRM/CivixBundle/Command/InfoSetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoSetCommand.php
@@ -17,7 +17,7 @@ use Exception;
 class InfoSetCommand extends Command {
 
   protected function configure() {
-    $fields = array(
+    $fields = [
       'file',
       'name',
       'description',
@@ -31,7 +31,7 @@ class InfoSetCommand extends Command {
       'civix/namespace',
       'urls/url[@desc="Documentation"]',
       'urls/url[@desc="Support"]',
-    );
+    ];
 
     $this
       ->setName('info:set')
@@ -52,7 +52,7 @@ Common fields:
   protected function execute(InputInterface $input, OutputInterface $output) {
     $basedir = new Path(\CRM\CivixBundle\Application::findExtDir());
     $info = new Info($basedir->string('info.xml'));
-    $ctx = array();
+    $ctx = [];
     $info->load($ctx);
     $info->get();
 

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -31,7 +31,7 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $ctx = array();
+    $ctx = [];
     $ctx['type'] = 'module';
     if (!$input->getArgument('<full.ext.name>')) {
       // Refresh existing module
@@ -86,13 +86,13 @@ class InitCommand extends AbstractCommand {
 
     $output->writeln("<info>Initalize module " . $ctx['fullName'] . "</info>");
     $basedir = new Path($ctx['basedir']);
-    $ext->builders['dirs'] = new Dirs(array(
+    $ext->builders['dirs'] = new Dirs([
       $basedir->string('build'),
       $basedir->string('templates'),
       $basedir->string('xml'),
       $basedir->string('images'),
       $basedir->string($ctx['namespace']),
-    ));
+    ]);
     $ext->builders['info'] = new Info($basedir->string('info.xml'));
     $ext->builders['module'] = new Module(Services::templating());
     $ext->builders['license'] = new License($licenses->get($ctx['license']), $basedir->string('LICENSE.txt'), FALSE);
@@ -111,20 +111,20 @@ class InitCommand extends AbstractCommand {
    * @return bool TRUE on success; FALSE if there's no site or if there's an error
    */
   protected function tryEnable(InputInterface $input, OutputInterface $output, $key) {
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
     if ($civicrm_api3 && $civicrm_api3->local && version_compare(\CRM_Utils_System::version(), '4.3.dev', '>=')) {
       $siteName = \CRM_Utils_System::baseURL(); // \CRM_Core_Config::singleton()->userSystem->cmsRootPath();
 
       $output->writeln("<info>Refresh extension list for \"$siteName\"</info>");
-      if (!$civicrm_api3->Extension->refresh(array('local' => TRUE, 'remote' => FALSE))) {
+      if (!$civicrm_api3->Extension->refresh(['local' => TRUE, 'remote' => FALSE])) {
         $output->writeln("<error>Refresh error: " . $civicrm_api3->errorMsg() . "</error>");
         return FALSE;
       }
 
       if ($this->confirm($input, $output, "Enable extension ($key) in \"$siteName\"? [Y/n] ")) {
         $output->writeln("<info>Enable extension ($key) in \"$siteName\"</info>");
-        if (!$civicrm_api3->Extension->install(array('key' => $key))) {
+        if (!$civicrm_api3->Extension->install(['key' => $key])) {
           $output->writeln("<error>Install error: " . $civicrm_api3->errorMsg() . "</error>");
         }
       }

--- a/src/CRM/CivixBundle/Command/PingCommand.php
+++ b/src/CRM/CivixBundle/Command/PingCommand.php
@@ -13,9 +13,9 @@ class PingCommand extends \Symfony\Component\Console\Command\Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
-    if ($civicrm_api3->Contact->Get(array('option.limit' => 1))) {
+    if ($civicrm_api3->Contact->Get(['option.limit' => 1])) {
       if (empty($civicrm_api3->result->values[0]->contact_type)) {
         $output->writeln('<error>Ping failed: Site reported that it found no contacts</error>');
       }

--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -40,7 +40,7 @@ class TestRunCommand extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(array('output' => $output));
+    Services::boot(['output' => $output]);
     $basedir = new Path(getcwd());
 
     $output->writeln("<comment>Warning: 'civix test' deprecated.  Run phpunit4 directly from the extension directory instead.</comment>");
@@ -88,10 +88,10 @@ class TestRunCommand extends Command {
       return;
     }
 
-    $tests_dir = implode(DIRECTORY_SEPARATOR, array(getcwd(), 'tests', 'phpunit'));
+    $tests_dir = implode(DIRECTORY_SEPARATOR, [getcwd(), 'tests', 'phpunit']);
 
     // Prepare the command
-    $command = array();
+    $command = [];
     $command[] = $phpunit_bin;
     $command[] = '--include-path';
     $command[] = $tests_dir;
@@ -114,7 +114,7 @@ class TestRunCommand extends Command {
     // Run phpunit with our "tests" directory
     chdir("$civicrm_root/tools");
     $process = new Process(
-      call_user_func_array(array('\CRM\CivixBundle\Command\TestRunCommand', 'createPhpShellCommand'), $command),
+      call_user_func_array(['\CRM\CivixBundle\Command\TestRunCommand', 'createPhpShellCommand'], $command),
       NULL, NULL, NULL, self::TIMEOUT
     );
     $process->run(function ($type, $buffer) use ($output) {
@@ -179,8 +179,8 @@ class TestRunCommand extends Command {
     $cacheDir = Services::cacheDir();
     $file = $cacheDir->string("civix-phpunit.{$key}.php");
     if ($clear || !file_exists($file) || filemtime($file) < time() - self::BOOTSTRAP_TTL) {
-      $template_vars = array();
-      $template_vars['civicrm_setting'] = array();
+      $template_vars = [];
+      $template_vars['civicrm_setting'] = [];
       // disable extension searching
       $template_vars['civicrm_setting']['Extension Preferences']['ext_repo_url'] = FALSE;
       // use the same source tree for linked Civi runtime and test Civi runtime

--- a/src/CRM/CivixBundle/Services.php
+++ b/src/CRM/CivixBundle/Services.php
@@ -14,13 +14,13 @@ class Services {
 
   protected static $cache;
 
-  public static function boot($options = array()) {
+  public static function boot($options = []) {
     if (!isset(self::$cache['boot'])) {
       $cwd = getcwd();
-      $options = array_merge(array('prefetch' => FALSE), $options);
+      $options = array_merge(['prefetch' => FALSE], $options);
       Bootstrap::singleton()->boot($options);
       \CRM_Core_Config::singleton();
-      \CRM_Utils_System::loadBootStrap(array(), FALSE);
+      \CRM_Utils_System::loadBootStrap([], FALSE);
       chdir($cwd);
       self::$cache['boot'] = 1;
     }
@@ -67,7 +67,7 @@ class Services {
         self::$cache['config'] = parse_ini_file($file, TRUE);
       }
       else {
-        self::$cache['config'] = array();
+        self::$cache['config'] = [];
       }
     }
     return self::$cache['config'];
@@ -78,10 +78,10 @@ class Services {
    */
   public static function configDir() {
     if (!isset(self::$cache['configDir'])) {
-      $homes = array(
+      $homes = [
         getenv('HOME'), // Unix
         getenv('USERPROFILE'), // Windows
-      );
+      ];
       foreach ($homes as $home) {
         if (!empty($home)) {
           self::$cache['configDir'] = new Path($home . '/.civix');

--- a/src/CRM/CivixBundle/Utils/Path.php
+++ b/src/CRM/CivixBundle/Utils/Path.php
@@ -44,7 +44,7 @@ class Path {
    */
   public function mkdir($mode = 0777) {
     $args = func_get_args();
-    $dir = call_user_func_array(array($this, 'string'), $args);
+    $dir = call_user_func_array([$this, 'string'], $args);
     if (!is_dir($dir)) {
       return mkdir($dir, $mode, TRUE);
     }


### PR DESCRIPTION
This is extracted from #115. It only impacts the civix logic -- it does *not* change any of the templates.

To test, I used `tests/make-example.sh` (as described in README.md) to ensure that the `civix` outputs the same code before and after the patch.