### PR TITLE
box.json - Include `images/placeholder.png`

### DIFF
--- a/box.json
+++ b/box.json
@@ -14,6 +14,10 @@
             "in": "vendor"
         },
         {
+            "name": "*.png",
+            "in": "images"
+        },
+        {
             "name": "bootstrap.php",
             "in": "vendor/nikic/php-parser/lib"
         },


### PR DESCRIPTION
The README should embed a placeholder for a screenshot.  This worked
correctly with a git-based copy of `civix`, but `civix.phar` didn't have the
file, leading it to malfunction.  Adding the file fixes it.