### PR TITLE
phpunit bootstrap - Work-around for issues with running phpunit in symlinked dirs

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,10 @@ The steps for upgrading the `Upgrader` are as follows:
 
 ## Special Tasks
 
+### Upgrade to v18.02.0+: PHPUnit (Optional)
+
+The template for `tests/phpunit/bootstrap.php` changed slightly to make `phpunit` work in symlinked directory structures. You may want to manually apply the changes from https://github.com/totten/civix/pull/121.
+
 ### Upgrade to v17.10.0+: Test Files
 
 The PHPUnit bootstrap file (`tests/phpunit/bootstrap.php`) has been updated to support autoloading of utility classes within your extensions `tests` folder. To follow this revised convention, update `bootstrap.php`. After the the call to `eval(...);`, say:

--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -31,6 +31,11 @@ function cv($cmd, $decode = 'json') {
   $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
   $oldOutput = getenv('CV_OUTPUT');
   putenv("CV_OUTPUT=json");
+
+  // Execute `cv` in the original folder. This is a work-around for
+  // phpunit/codeception, which seem to manipulate PWD.
+  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
   putenv("CV_OUTPUT=$oldOutput");
   fclose($pipes[0]);


### PR DESCRIPTION
There was add an odd phenomenon when an extension is moved to a symlinked dir, e.g.

```
ln -s ~/src/org.example.foo civicrm/tools/extensions/org.example.foo
```

If you navigated into the folder and called `cv` directly (e.g.  `cv api contact.get` or `cv php:boot`), then it worked fine.  However, if you navigated into the same folder and called `phpunit` (which then called `cv php:boot`), then they'd fail. Empirically, `phpunit` does the equivalent of `chdir(realpath(getcwd()))` (although I haven't traced how/why).

This patch provides a work-around in the template. You may need to update the `tests/phpunit/bootstrap.php` to benefit from it.