### PR TITLE
new command to generate boilerplate from XML schema file

### DIFF
--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -8,6 +8,7 @@ use CRM\CivixBundle\Command\AddApiCommand;
 use CRM\CivixBundle\Command\AddCaseTypeCommand;
 use CRM\CivixBundle\Command\AddCustomDataCommand;
 use CRM\CivixBundle\Command\AddEntityCommand;
+use CRM\CivixBundle\Command\AddDaosCommand;
 use CRM\CivixBundle\Command\AddFormCommand;
 use CRM\CivixBundle\Command\AddPageCommand;
 use CRM\CivixBundle\Command\AddReportCommand;
@@ -54,6 +55,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new AddCaseTypeCommand();
     $commands[] = new AddCustomDataCommand();
     $commands[] = new AddEntityCommand();
+    $commands[] = new AddDaosCommand();
     $commands[] = new AddFormCommand();
     $commands[] = new AddPageCommand();
     $commands[] = new AddReportCommand();

--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -8,7 +8,7 @@ use CRM\CivixBundle\Command\AddApiCommand;
 use CRM\CivixBundle\Command\AddCaseTypeCommand;
 use CRM\CivixBundle\Command\AddCustomDataCommand;
 use CRM\CivixBundle\Command\AddEntityCommand;
-use CRM\CivixBundle\Command\AddDaosCommand;
+use CRM\CivixBundle\Command\AddEntityBoilerplateCommand;
 use CRM\CivixBundle\Command\AddFormCommand;
 use CRM\CivixBundle\Command\AddPageCommand;
 use CRM\CivixBundle\Command\AddReportCommand;
@@ -55,7 +55,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new AddCaseTypeCommand();
     $commands[] = new AddCustomDataCommand();
     $commands[] = new AddEntityCommand();
-    $commands[] = new AddDaosCommand();
+    $commands[] = new AddEntityBoilerplateCommand();
     $commands[] = new AddFormCommand();
     $commands[] = new AddPageCommand();
     $commands[] = new AddReportCommand();

--- a/src/CRM/CivixBundle/Builder/Module.php
+++ b/src/CRM/CivixBundle/Builder/Module.php
@@ -35,7 +35,21 @@ class Module implements Builder {
       TRUE,
       $this->templateEngine
     );
+
+    $ctx['entityTypes'] = $this->generateEntityTypes("{$ctx['basedir']}/xml/schema/CRM/*/*.entityType.php");
+
     $moduleCivix->save($ctx, $output);
   }
 
+  private function generateEntityTypes($glob){
+    foreach(glob($glob) as $entityFile){
+      $entities = include $entityFile;
+      foreach ($entities as $entity) {
+        $entityTypes[$entity['class']] = $entity;
+      }
+    }
+
+    $entityTypes = var_export($entityTypes, TRUE);
+    return $entityTypes;
+  }
 }

--- a/src/CRM/CivixBundle/Builder/Module.php
+++ b/src/CRM/CivixBundle/Builder/Module.php
@@ -42,6 +42,7 @@ class Module implements Builder {
   }
 
   private function generateEntityTypes($glob){
+    $entityTypes =[];
     foreach(glob($glob) as $entityFile){
       $entities = include $entityFile;
       foreach ($entities as $entity) {

--- a/src/CRM/CivixBundle/Command/AddDaosCommand.php
+++ b/src/CRM/CivixBundle/Command/AddDaosCommand.php
@@ -20,7 +20,7 @@ class AddDaosCommand extends \Symfony\Component\Console\Command\Command {
   protected function configure() {
     $this
       ->setName('generate:daos')
-      ->setDescription('Create DAOs and mysql schema based on this extensions xml schema definition files')
+      ->setDescription('Create DAOs and mysql schema based on this extensions xml schema definition files (*EXPERIMENTAL AND INCOMPLETE*)')
       ->setHelp(
         "Create DAOs and mysql schema based on this extensions xml schema definition files\n" .
         "\n" .

--- a/src/CRM/CivixBundle/Command/AddDaosCommand.php
+++ b/src/CRM/CivixBundle/Command/AddDaosCommand.php
@@ -1,0 +1,104 @@
+<?php
+namespace CRM\CivixBundle\Command;
+
+use CRM\CivixBundle\Services;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use CRM\CivixBundle\Builder\Collection;
+use CRM\CivixBundle\Builder\Dirs;
+use CRM\CivixBundle\Builder\Info;
+use CRM\CivixBundle\Builder\PhpData;
+use CRM\CivixBundle\Builder\Template;
+use CRM\CivixBundle\Utils\Path;
+use Exception;
+
+class AddDaosCommand extends \Symfony\Component\Console\Command\Command {
+  const API_VERSION = 3;
+
+  protected function configure() {
+    $this
+      ->setName('generate:daos')
+      ->setDescription('Create DAOs and mysql schema based on this extensions xml schema definition files')
+      ->setHelp(
+        "Create DAOs and mysql schema based on this extensions xml schema definition files\n" .
+        "\n" .
+        "Typically, one will have created / updated on or more xml/CRM/NameSpace/EntityName.xml files\n" .
+        "before running this command.\n"
+      );
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    // load Civi to get access to civicrm_api_get_function_name
+    Services::boot(['output' => $output]);
+    $civicrm_api3 = Services::api3();
+    if (!$civicrm_api3 || !$civicrm_api3->local) {
+      $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
+      return;
+    }
+
+    $ctx = [];
+    $ctx['type'] = 'module';
+    $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
+    $basedir = new Path($ctx['basedir']);
+
+    $info = new Info($basedir->string('info.xml'));
+    $info->load($ctx);
+    $attrs = $info->get()->attributes();
+    if ($attrs['type'] != 'module') {
+      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
+      return;
+    }
+
+    $xmlSchemaGlob = "xml/schema/{$ctx['namespace']}/*.xml";
+    $absXmlSchemaGlob = $basedir->string($xmlSchemaGlob);
+    // var_dump(($absXmlSchemaGlob));
+    $xmlSchemas = glob($absXmlSchemaGlob);
+
+    if(!count($xmlSchemas)){
+      throw new Exception("Could not find files matching '$xmlSchemaGlob'. You may want to run `civix generate:entity` before running this command.");
+    }
+
+    $specification = new \CRM_Core_CodeGen_Specification;
+    $specification->buildVersion = \CRM_Utils_System::majorVersion();
+
+    $config = new \stdClass;
+    $config->phpCodePath = $basedir->string('');
+    $config->sqlCodePath = $basedir->string('sql/');
+
+    foreach($xmlSchemas as $xmlSchema){
+
+      $dom = new \DomDocument();
+      $xmlString = file_get_contents($xmlSchema);
+      $dom->loadXML($xmlString);
+      $xml = simplexml_import_dom($dom);
+
+      $specification->getTable($xml, $database, $tables);
+
+      $tables[(string) $xml->name]['sourceFile'] = $xmlSchema;
+      $config->tables = $tables;
+
+      $dao = new \CRM_Core_CodeGen_DAO($config, (string) $xml->name);
+      ob_start(); // Don't display gencode's output
+      $dao->run();
+      ob_end_clean(); // Don't display gencode's output
+      $daoFileName = $basedir->string("{$xml->base}/DAO/{$xml->class}.php");
+      $output->writeln("<info>Write $daoFileName</info>");
+
+    }
+
+    $schema = new \CRM_Core_CodeGen_Schema($config);
+    \CRM_Core_CodeGen_Util_File::createDir($config->sqlCodePath);
+    ob_start(); // Don't display gencode's output
+    $schema->generateCreateSql('auto_install.sql');
+    ob_end_clean(); // Don't display gencode's output
+    $output->writeln("<info>Write {$basedir->string('sql/auto_install.sql')}</info>");
+    ob_start(); // Don't display gencode's output
+    $schema->generateDropSql('auto_uninstall.sql');
+    $output->writeln("<info>Write {$basedir->string('sql/auto_uninstall.sql')}</info>");
+    ob_end_clean(); // Don't display gencode's output
+
+  }
+
+}

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -2,30 +2,26 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Services;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use CRM\CivixBundle\Builder\Collection;
-use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Builder\PhpData;
-use CRM\CivixBundle\Builder\Template;
+use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
 
-class AddDaosCommand extends \Symfony\Component\Console\Command\Command {
+class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Command {
   const API_VERSION = 3;
 
   protected function configure() {
     $this
-      ->setName('generate:daos')
-      ->setDescription('Create DAOs and mysql schema based on this extensions xml schema definition files (*EXPERIMENTAL AND INCOMPLETE*)')
+      ->setName('generate:entity-boilerplate')
+      ->setDescription('Generates boilerplate code for entities based on xml schema definition files (*EXPERIMENTAL AND INCOMPLETE*)')
       ->setHelp(
-        "Create DAOs and mysql schema based on this extensions xml schema definition files\n" .
+        "Creates DAOs, mysql install and uninstall instructions, and an appropriate\n" .
+        "hook_civicrm_entityTypes based on this extension's xml schema files.\n" .
         "\n" .
-        "Typically, one will have created / updated on or more xml/CRM/NameSpace/EntityName.xml files\n" .
-        "before running this command.\n"
+        "Typically you will run this command after creating or updating one or more\n" .
+        "xml/schema/CRM/NameSpace/EntityName.xml files.\n"
       );
   }
 

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -95,6 +95,9 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
     $output->writeln("<info>Write {$basedir->string('sql/auto_uninstall.sql')}</info>");
     ob_end_clean(); // Don't display gencode's output
 
+    $module = new Module(Services::templating());
+    $module->loadInit($ctx);
+    $module->save($ctx, $output);
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -98,6 +98,12 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
     $module = new Module(Services::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
+
+    $upgraderClass = str_replace('/', '_', $ctx['namespace']).'_Upgrader';
+    if(!class_exists($upgraderClass)){
+      $output->writeln('<comment>You are missing an upgrader class. Your generated SQL files will not be executed on enable and uninstall. Fix this by running `civix generate:upgrader`.</comment>');
+    }
+
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -98,6 +98,8 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
 
     $ext->init($ctx);
     $ext->save($ctx, $output);
-  }
 
+    $output->writeln('<comment>You may want to run `civix generate:entity-boilerplate`, and uninstall and re-enable the extension to update your entities.</comment>');
+
+  }
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -446,3 +446,26 @@ function _<?php echo $mainFile ?>_civix_civicrm_alterSettingsFolders(&$metaDataF
     $metaDataFolders[] = $settingsDir;
   }
 }
+
+/**
+ * (Delegated) Implements hook_civicrm_entityTypes().
+ *
+ * Find any *.entityType.php files, merge their content, and return.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+
+<?php
+// Add appropriate indentation
+foreach(explode("\n", $entityTypes) as $k => $l){
+  if($k){
+    $entityTypeLines[$k] = '  '.$l;
+  }else{
+    $entityTypeLines[$k] = $l;
+  }
+}
+$entityTypes = implode("\n", $entityTypeLines);
+?>
+function _<?php echo $mainFile ?>_civix_civicrm_entityTypes(&$entityTypes) {
+  $entityTypes += <?php echo $entityTypes ?>;
+}

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -467,5 +467,5 @@ foreach(explode("\n", $entityTypes) as $k => $l){
 $entityTypes = implode("\n", $entityTypeLines);
 ?>
 function _<?php echo $mainFile ?>_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes += <?php echo $entityTypes ?>;
+  $entityTypes = array_merge($entityTypes, <?php echo $entityTypes ?>);
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -126,6 +126,17 @@ function <?php echo $mainFile ?>_civicrm_alterSettingsFolders(&$metaDataFolders 
   _<?php echo $mainFile ?>_civix_civicrm_alterSettingsFolders($metaDataFolders);
 }
 
+/**
+ * Implements hook_civicrm_entityTypes().
+ *
+ * Declare entity types provided by this module.
+ *
+ * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_entityTypes
+ */
+function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes) {
+  _<?php echo $mainFile ?>_civix_civicrm_entityTypes($entityTypes);
+}
+
 // --- Functions below this ship commented out. Uncomment as required. ---
 
 /**

--- a/tests/make-example.sh
+++ b/tests/make-example.sh
@@ -42,7 +42,14 @@ pushd $WORKINGDIR
   fi
 
   # generate module and try all the generators
-  echo n | $CIVIX $VERBOSITY generate:module $EXMODULE
+  $CIVIX $VERBOSITY generate:module $EXMODULE --enable=no
+
+  STATUS=$(cv ext:list -L /org.civicrm.civixexample/ --out=list --columns=status)
+  if [ "$STATUS" = "installed" ]; then
+    echo "Error: The example extension was installed prematurely"
+    exit 1
+  fi
+
   pushd $EXMODULE
     $CIVIX $VERBOSITY generate:api MyEntity MyAction
     $CIVIX $VERBOSITY generate:case-type MyLabel MyName

--- a/tests/make-example.sh
+++ b/tests/make-example.sh
@@ -55,6 +55,7 @@ pushd $WORKINGDIR
     $CIVIX $VERBOSITY generate:case-type MyLabel MyName
     # $CIVIX $VERBOSITY generate:custom-xml -f --data="FIXME" --uf="FIXME"
     $CIVIX $VERBOSITY generate:entity MyEntity
+    $CIVIX $VERBOSITY generate:entity-boilerplate
     $CIVIX $VERBOSITY generate:form MyForm civicrm/my-form
     $CIVIX $VERBOSITY generate:page MyPage civicrm/my-page
     $CIVIX $VERBOSITY generate:report MyReport CiviContribute


### PR DESCRIPTION
Hey there,

Automatically creating DAO files and the associated SQL statements for install / uninstall has been missing from civix for a while. It is a pain to do this manually: (step 4 of https://docs.civicrm.org/dev/en/latest/extensions/civix/#generate-entity).

This PR adds a new command `civix generate:daos` to automate that step.

The expected workflow is that you have run `civix generate:entity` 1 or more times to generate entities, and have edited the schema xml files to your liking. You then run `civix generate:daos` which generates DAOs and creates auto install / uninstall sql for the extension as a whole.

The approach I took was to reuse the bare minimum from `CRM_Core_CodeGen_*` rather than try do it the civix way. It is admitedly a bit hacky, and I would understand if there were reasons to not include it in civix, but on the other hand, it is better than nothing.

I have added `(*EXPERIMENTAL AND INCOMPLETE*)` to the command to enourage you to accept the PR :)