### PR TITLE
Bug in form template path

### DIFF
--- a/src/CRM/CivixBundle/Command/AddFormCommand.php
+++ b/src/CRM/CivixBundle/Command/AddFormCommand.php
@@ -24,6 +24,7 @@ class AddFormCommand extends AbstractAddPageCommand {
   }
 
   protected function createTplName(InputInterface $input, $ctx) {
+    $namespace = str_replace('/', '_', $ctx['namespace']);
     return $ctx['namespace'] . '/Form/' . $ctx['shortClassName'] . '.tpl';
   }
 

--- a/src/CRM/CivixBundle/Command/AddFormCommand.php
+++ b/src/CRM/CivixBundle/Command/AddFormCommand.php
@@ -24,8 +24,7 @@ class AddFormCommand extends AbstractAddPageCommand {
   }
 
   protected function createTplName(InputInterface $input, $ctx) {
-    $namespace = str_replace('/', '_', $ctx['namespace']);
-    return $ctx['namespace'] . '/Form/' . $ctx['shortClassName'] . '.tpl';
+    return $ctx['namespace'] . '/Form/' . str_replace('_', '/', $ctx['shortClassName']) . '.tpl';
   }
 
 }

--- a/tests/make-example.sh
+++ b/tests/make-example.sh
@@ -49,6 +49,7 @@ pushd $WORKINGDIR
     # $CIVIX $VERBOSITY generate:custom-xml -f --data="FIXME" --uf="FIXME"
     $CIVIX $VERBOSITY generate:entity MyEntity
     $CIVIX $VERBOSITY generate:form MyForm civicrm/my-form
+    $CIVIX $VERBOSITY generate:form My_StuffyForm civicrm/my-stuffy-form
     $CIVIX $VERBOSITY generate:page MyPage civicrm/my-page
     $CIVIX $VERBOSITY generate:report MyReport CiviContribute
     $CIVIX $VERBOSITY generate:search MySearch


### PR DESCRIPTION
Hi again,

I am surprised this has slipped through undetected/reported. Maybe I am missing something but I think this was a bug / is a fix:

**Before:**
```
buildkit@civicrm:~/build/chatbot/sites/all/modules/civicrm/tools/extensions/civicrm-chatbot$ civix generate:form Admin_Facebook civicrm/admin/chat/facebook
...
Write /buildkit/build/chatbot/sites/all/modules/civicrm/tools/extensions/civicrm-chatbot/templates/CRM/Chatbot/Form/Admin_Facebook.tpl
```
**After**
```
buildkit@civicrm:~/build/chatbot/sites/all/modules/civicrm/tools/extensions/civicrm-chatbot$ civix generate:form Admin_Facebook civicrm/admin/chat/facebook
Write /buildkit/build/chatbot/sites/all/modules/civicrm/tools/extensions/civicrm-chatbot/templates/CRM/Chatbot/Form/Admin/Facebook.tpl
```