### PR TITLE
generate:entity - Table name should be in camel-case

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -12,6 +12,8 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
+use CRM\CivixBundle\Utils\Naming;
+
 use Exception;
 
 class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
@@ -51,7 +53,7 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     }
 
     $ctx['entityNameCamel'] = ucfirst($input->getArgument('<EntityName>'));
-    $ctx['tableName'] = 'civicrm_' . strtolower($input->getArgument('<EntityName>'));
+    $ctx['tableName'] = 'civicrm_' . Naming::camelToSnake($input->getArgument('<EntityName>'));
     if (function_exists('civicrm_api_get_function_name')) {
       $ctx['apiFunctionPrefix'] = strtolower(civicrm_api_get_function_name($ctx['entityNameCamel'], '', self::API_VERSION));
     }

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -22,9 +22,18 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
   protected function configure() {
     $this
       ->setName('generate:entity')
-      ->setDescription('Add a new API/BAO/GenCode entity to a CiviCRM Module-Extension (*EXPERIMENTAL AND INCOMPLETE*)')
+      ->setDescription('Add a new API/BAO/GenCode entity to a CiviCRM Module-Extension (*EXPERIMENTAL*)')
       ->addArgument('<EntityName>', InputArgument::REQUIRED, 'The brief, unique name of the entity")')
-      ->addOption('table-name', NULL, InputOption::VALUE_OPTIONAL, 'The SQL table name. (Default: derived from entity name)');
+      ->addOption('table-name', NULL, InputOption::VALUE_OPTIONAL, 'The SQL table name. (see usage)')
+      ->setHelp('Add a new API/BAO/GenCode entity to a CiviCRM Module-Extension.
+This command is experimental. Developer discretion is advised.
+
+In most cases generate:entity is able to derive a suitable snake_case table name
+from The CamelCase <EntityName>. However, in some instances (notably when the
+entity contains a number or a capitalised acronym) the table name may differ
+from your expectations. In these cases, you may wish to set the table name
+explicity.');
+
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -23,7 +23,8 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     $this
       ->setName('generate:entity')
       ->setDescription('Add a new API/BAO/GenCode entity to a CiviCRM Module-Extension (*EXPERIMENTAL AND INCOMPLETE*)')
-      ->addArgument('<EntityName>', InputArgument::REQUIRED, 'The brief, unique name of the entity")');
+      ->addArgument('<EntityName>', InputArgument::REQUIRED, 'The brief, unique name of the entity")')
+      ->addOption('table-name', NULL, InputOption::VALUE_OPTIONAL, 'The SQL table name. (Default: derived from entity name)');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
@@ -53,7 +54,7 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     }
 
     $ctx['entityNameCamel'] = ucfirst($input->getArgument('<EntityName>'));
-    $ctx['tableName'] = Naming::createTableName($input->getArgument('<EntityName>'));
+    $ctx['tableName'] = $input->getOption('table-name') ? $input->getOption('table-name') : Naming::createTableName($input->getArgument('<EntityName>'));
     if (function_exists('civicrm_api_get_function_name')) {
       $ctx['apiFunctionPrefix'] = strtolower(civicrm_api_get_function_name($ctx['entityNameCamel'], '', self::API_VERSION));
     }

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -53,7 +53,7 @@ class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
     }
 
     $ctx['entityNameCamel'] = ucfirst($input->getArgument('<EntityName>'));
-    $ctx['tableName'] = 'civicrm_' . Naming::camelToSnake($input->getArgument('<EntityName>'));
+    $ctx['tableName'] = Naming::createTableName($input->getArgument('<EntityName>'));
     if (function_exists('civicrm_api_get_function_name')) {
       $ctx['apiFunctionPrefix'] = strtolower(civicrm_api_get_function_name($ctx['entityNameCamel'], '', self::API_VERSION));
     }

--- a/src/CRM/CivixBundle/Utils/Naming.php
+++ b/src/CRM/CivixBundle/Utils/Naming.php
@@ -57,4 +57,8 @@ class Naming {
     return $camelCase;
   }
 
+  public static function camelToSnake($camel){
+    return strtolower(implode('_',array_filter(preg_split('/(?=[A-Z])/',$camel))));
+  }
+
 }

--- a/src/CRM/CivixBundle/Utils/Naming.php
+++ b/src/CRM/CivixBundle/Utils/Naming.php
@@ -57,8 +57,16 @@ class Naming {
     return $camelCase;
   }
 
-  public static function camelToSnake($camel){
-    return strtolower(implode('_',array_filter(preg_split('/(?=[A-Z])/',$camel))));
+  /**
+   * Generate a table name for an entity.
+   *
+   * @param string $entity
+   *   Ex: 'FooBar'
+   * @return string
+   *   Ex: 'civicrm_foo_bar'
+   */
+  public static function createTableName($entity) {
+    return 'civicrm_' . strtolower(implode('_', array_filter(preg_split('/(?=[A-Z])/', $entity))));
   }
 
 }

--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -49,14 +49,22 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($expectCamel, Naming::createCamelName($name));
   }
 
+  public function getTableNameExamples() {
+    return [
+      // [$inputEntityName, $expectTableName]
+      ['Foo', 'civicrm_foo'],
+      ['Foobar', 'civicrm_foobar'],
+      ['FooBar', 'civicrm_foo_bar'],
+      ['FooBar2', 'civicrm_foo_bar2'],
+      ['Foo2Bar', 'civicrm_foo2_bar'],
+    ];
+  }
+
   /**
-   * @dataProvider getFullNameExamples
+   * @dataProvider getTableNameExamples
    */
-  public function testCamelToSnake($ignore1, $ignore2, $snake, $camel) {
-    if ($camel === NULL) {
-      return;
-    }
-    $this->assertEquals($snake, Naming::camelToSnake($camel));
+  public function testCreateTableName($inputEntityName, $expectTableName) {
+    $this->assertEquals($expectTableName, Naming::createTableName($inputEntityName));
   }
 
 }

--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -49,4 +49,14 @@ class NamingTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($expectCamel, Naming::createCamelName($name));
   }
 
+  /**
+   * @dataProvider getFullNameExamples
+   */
+  public function testCamelToSnake($ignore1, $ignore2, $snake, $camel) {
+    if ($camel === NULL) {
+      return;
+    }
+    $this->assertEquals($snake, Naming::camelToSnake($camel));
+  }
+
 }


### PR DESCRIPTION
`civix generate:entity ChatUser`

Previously made table names like `civicrm_chatuser`

Now makes table names like `civicrm_chat_user`