### PR TITLE
Fix non-sensical variable setting

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -272,10 +272,10 @@ function _<?php echo $mainFile ?>_civix_civicrm_managed(&$entities) {
       if (empty($e['module'])) {
         $e['module'] = E::LONG_NAME;
       }
-      $entities[] = $e;
       if (empty($e['params']['version'])) {
         $e['params']['version'] = '3';
       }
+      $entities[] = $e;
     }
   }
 }


### PR DESCRIPTION
The lines moved are meaningless unless moved per this PR (arguably they should be removed or the function that uses these determines the version, but if they are there they should be right)