### PR TITLE
generate foreign keys in DAOs

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -25,11 +25,18 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
       );
   }
 
+
+/**
+ * Note: this function replicates a fair amount of the functionality of
+ * CRM_Core_CodeGen_Specification (which is a bit messy and hard to interact
+ * with). It's tempting to completely rewrite / rethink entity generation. Until
+ * then...
+ */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    // load Civi to get access to civicrm_api_get_function_name
     Services::boot(['output' => $output]);
     $civicrm_api3 = Services::api3();
-    if (!$civicrm_api3 || !$civicrm_api3->local) {
+
+    if(!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return;
     }
@@ -38,18 +45,17 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $basedir = new Path($ctx['basedir']);
-
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
     $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
+
+    if($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
       return;
     }
 
     $xmlSchemaGlob = "xml/schema/{$ctx['namespace']}/*.xml";
     $absXmlSchemaGlob = $basedir->string($xmlSchemaGlob);
-    // var_dump(($absXmlSchemaGlob));
     $xmlSchemas = glob($absXmlSchemaGlob);
 
     if(!count($xmlSchemas)){
@@ -58,30 +64,32 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
 
     $specification = new \CRM_Core_CodeGen_Specification;
     $specification->buildVersion = \CRM_Utils_System::majorVersion();
-
     $config = new \stdClass;
     $config->phpCodePath = $basedir->string('');
     $config->sqlCodePath = $basedir->string('sql/');
 
     foreach($xmlSchemas as $xmlSchema){
-
       $dom = new \DomDocument();
       $xmlString = file_get_contents($xmlSchema);
       $dom->loadXML($xmlString);
       $xml = simplexml_import_dom($dom);
-
       $specification->getTable($xml, $database, $tables);
+      $name = (string) $xml->name;
+      $tables[$name]['name'] = $name;
+      $tables[$name]['sourceFile'] = $xmlSchema;
+    }
 
-      $tables[(string) $xml->name]['sourceFile'] = $xmlSchema;
-      $config->tables = $tables;
+    $this->orderTables($tables);
+    $this->resolveForeignKeys($tables);
+    $config->tables = $tables;
 
-      $dao = new \CRM_Core_CodeGen_DAO($config, (string) $xml->name);
+    foreach($tables as $table){
+      $dao = new \CRM_Core_CodeGen_DAO($config, (string) $table['name']);
       ob_start(); // Don't display gencode's output
       $dao->run();
       ob_end_clean(); // Don't display gencode's output
-      $daoFileName = $basedir->string("{$xml->base}/DAO/{$xml->class}.php");
+      $daoFileName = $basedir->string("{$table['base']}{$table['fileName']}");
       $output->writeln("<info>Write $daoFileName</info>");
-
     }
 
     $schema = new \CRM_Core_CodeGen_Schema($config);
@@ -94,16 +102,55 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
     $schema->generateDropSql('auto_uninstall.sql');
     $output->writeln("<info>Write {$basedir->string('sql/auto_uninstall.sql')}</info>");
     ob_end_clean(); // Don't display gencode's output
-
     $module = new Module(Services::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
-
     $upgraderClass = str_replace('/', '_', $ctx['namespace']).'_Upgrader';
+
     if(!class_exists($upgraderClass)){
       $output->writeln('<comment>You are missing an upgrader class. Your generated SQL files will not be executed on enable and uninstall. Fix this by running `civix generate:upgrader`.</comment>');
     }
 
   }
 
+  function orderTables(&$tables){
+
+    $ordered = [];
+
+    while(count($tables)){
+      $x++;if($x==6) exit;
+      foreach($tables as $k => $table) {
+        if(!isset($table['foreignKey'])){
+          $ordered[$k] = $table;
+          unset($tables[$k]);
+        }
+        foreach($table['foreignKey'] as $fKey) {
+          if(in_array($fKey['table'], array_keys($tables))) {
+            continue;
+          }
+          $ordered[$k] = $table;
+          unset($tables[$k]);
+        }
+      }
+    }
+    $tables = $ordered;
+  }
+
+  function resolveForeignKeys(&$tables) {
+    foreach($tables as &$table) {
+      if(isset($table['foreignKey'])){
+        foreach($table['foreignKey'] as &$key) {
+          if(isset($tables[$key['table']])){
+            $key['className'] = $tables[$key['table']]['className'];
+            $key['fileName'] = $tables[$key['table']]['fileName'];
+            $table['fields'][$key['name']]['FKClassName'] = $key['className'];
+          }else{
+            $key['className'] = \CRM_Core_DAO_AllCoreTables::getClassForTable($key['table']);
+            $key['fileName'] = $key['className'].'.php';
+            $table['fields'][$key['name']]['FKClassName'] = $key['className'];
+          }
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
Previously, `generate:entity-boilerplate` ignored any FKs specified in the xml and as a result, FKs were missing from the generated SQL. An oversight that this PR fixes.

This PR required writing a resolveForeignKeys() function, inspired by CRM_Core_CodeGen_Specification::resolveForeignKeys().

I initially tried calling CRM_Core_CodeGen_Specification::resolveForeignKeys() but don't think that CRM_Core_CodeGen... is written in a way that makes this possible/practical.

Given that we are now creating foreign keys (and that we are not disabling fk checks while creating our schema, we have to create the tables in order, hence the new function orderTables().