### PR TITLE
order mgd files before including

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -266,6 +266,7 @@ function _<?php echo $mainFile ?>_civix_find_files($dir, $pattern) {
  */
 function _<?php echo $mainFile ?>_civix_civicrm_managed(&$entities) {
   $mgdFiles = _<?php echo $mainFile ?>_civix_find_files(__DIR__, '*.mgd.php');
+  sort($mgdFiles);
   foreach ($mgdFiles as $file) {
     $es = include $file;
     foreach ($es as $e) {


### PR DESCRIPTION
Order is important when managing entities: one must create dependencies before creating dependent entities. Custum groups need to be created before custom fields, option groups before option values, etc.

One way of doing this is to ensure that dependencies appropriate order in the same file. This breaks down if dependencies are split across files.

Alphabetically sorting the managed files before including them allows one to define managed entities like this
```
managed
├── 01-ContactType.mgd.php
├── 05-CustomGroup.mgd.php
└── 06-CustomField.mgd.php
```

Aside: a more sophisticated `CRM_Core_ManagedEntities` might be cleverer about trying to 'satisfy dependencies' before giving up ( [something like this](https://gist.github.com/michaelmcandrew/21754058092bfd63504490f59ae19944)) but in the mean time, this is a decent approach, IMO.