### PR TITLE
remove the static $configured guard from h_c_alterSettingsFolder

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -437,11 +437,6 @@ function _<?php echo $mainFile ?>_civix_fixNavigationMenuItems(&$nodes, &$maxNav
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
  */
 function _<?php echo $mainFile ?>_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
 
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
   if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {


### PR DESCRIPTION
see https://github.com/totten/civix/issues/139

I don't think a upgrade notice is that necessary. I was forgetting that that file is auto-generated and easy to refresh.

That said, if lots of people start getting bitten by this, we might want to reconsider.