### PR TITLE
Ensure that Extension Ts function is used in place of ts in DAOs and output…

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -73,19 +73,21 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
       $xmlString = file_get_contents($xmlSchema);
       $dom->loadXML($xmlString);
       $xml = simplexml_import_dom($dom);
-
+      if (!$xml) {
+        $output->writeln('<error>There is an error in the XML for ' . $xmlSchema . '</error>');
+        continue;
+      }
       $specification->getTable($xml, $database, $tables);
 
       $tables[(string) $xml->name]['sourceFile'] = $xmlSchema;
       $config->tables = $tables;
-
-      $dao = new \CRM_Core_CodeGen_DAO($config, (string) $xml->name);
+      $_namespace = ' ' . preg_replace(':/:', '_', $ctx['namespace']);
+      $dao = new \CRM_Core_CodeGen_DAO($config, (string) $xml->name, "{$_namespace}_ExtensionUtil::ts");
       ob_start(); // Don't display gencode's output
       $dao->run();
       ob_end_clean(); // Don't display gencode's output
       $daoFileName = $basedir->string("{$xml->base}/DAO/{$xml->class}.php");
       $output->writeln("<info>Write $daoFileName</info>");
-
     }
 
     $schema = new \CRM_Core_CodeGen_Schema($config);


### PR DESCRIPTION
… error if XML cannot properly be consumed

This depends on https://github.com/civicrm/civicrm-core/pull/12986 and has been tested in an extension locally, I found that when running the civix command if the schema xml wasn't right no error would be generated and a random .DAO file would be created