### PR TITLE
#139 Improve alterSettingsFolders hook.

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -437,14 +437,8 @@ function _<?php echo $mainFile ?>_civix_fixNavigationMenuItems(&$nodes, &$maxNav
  * @link http://wiki.civicrm.org/confluence/display/CRMDOC/hook_civicrm_alterSettingsFolders
  */
 function _<?php echo $mainFile ?>_civix_civicrm_alterSettingsFolders(&$metaDataFolders = NULL) {
-  static $configured = FALSE;
-  if ($configured) {
-    return;
-  }
-  $configured = TRUE;
-
   $settingsDir = __DIR__ . DIRECTORY_SEPARATOR . 'settings';
-  if (is_dir($settingsDir) && !in_array($settingsDir, $metaDataFolders)) {
+  if (!in_array($settingsDir, $metaDataFolders) && is_dir($settingsDir)) {
     $metaDataFolders[] = $settingsDir;
   }
 }


### PR DESCRIPTION
The use of static caching in this function is unhelpful for tests & we get the same
benefit by moving the in_array check to before the
is_dir check - meaning we won't do a file check unless it is not present

(Just found this patch locally & realised it must have been written when agreed in #139 but never opened - @totten I can't merge to this repo)