### PR TITLE
updates for Windows

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -34,7 +34,7 @@ function cv($cmd, $decode = 'json') {
 
   // Execute `cv` in the original folder. This is a work-around for
   // phpunit/codeception, which seem to manipulate PWD.
-  $cmd = sprintf('cd %s; %s', escapeshellarg(getenv('PWD')), $cmd);
+  $cmd = sprintf('cd %s && %s', escapeshellarg(getenv('PWD')), $cmd);
 
   $process = proc_open($cmd, $descriptorSpec, $pipes, __DIR__);
   putenv("CV_OUTPUT=$oldOutput");


### PR DESCRIPTION
Semicolon doesn't separate commands on windows but && should work everywhere.

As an aside it's been a while since I updated this fork, but at least I'm consistent ... he he


![58841559-69090480-8638-11e9-92be-522f7aed7f95](https://user-images.githubusercontent.com/2967821/58843786-0e74a600-8642-11e9-89af-73d7df394752.gif)
