### PR TITLE
Update angular page template to use controllerAs - to reflect best practice

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/angular-page.html.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/angular-page.html.php
@@ -1,7 +1,7 @@
 <div class="crm-container">
-  <div crm-ui-debug="myContact"></div>
+  <div crm-ui-debug="'<?php echo $ctrlName ?>'.myContact"></div>
 
-  <h1 crm-page-title>{{ts('About %1', {1: myContact.first_name + ' ' + myContact.last_name})}}</h1>
+  <h1 crm-page-title>{{ts('About %1', {1: '<?php echo $ctrlName ?>'.myContact.first_name + ' ' + '<?php echo $ctrlName ?>'.myContact.last_name})}}</h1>
 
   <form name="myForm" crm-ui-id-scope>
 
@@ -12,9 +12,9 @@
     </div>
 
     <div crm-ui-accordion="{title: ts('Greeting')}">
-      <p ng-show="myContact.first_name">{{ ts('Hello, %1.', {1: myContact.first_name}) }}</p>
+      <p ng-show="'<?php echo $ctrlName ?>'.myContact.first_name">{{ ts('Hello, %1.', {1: myContact.first_name}) }}</p>
 
-      <p ng-show="!myContact.first_name">{{ ts('Hello, stranger.') }}</p>
+      <p ng-show="'<?php echo $ctrlName ?>'.!myContact.first_name">{{ ts('Hello, stranger.') }}</p>
     </div>
 
     <div crm-ui-accordion="{title: ts('About Me')}">
@@ -24,14 +24,14 @@
             <input
               crm-ui-id="myForm.first_name"
               name="first_name"
-              ng-model="myContact.first_name"
+              ng-model="'<?php echo $ctrlName ?>'.myContact.first_name"
               class="crm-form-text"
               placeholder="{{ts('First')}}"
               />
             <input
               crm-ui-id="myForm.last_name"
               name="last_name"
-              ng-model="myContact.last_name"
+              ng-model="'<?php echo $ctrlName ?>'.myContact.last_name"
               class="crm-form-text"
               placeholder="{{ts('Last')}}"
               />

--- a/src/CRM/CivixBundle/Resources/views/Code/angular-page.js.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/angular-page.js.php
@@ -3,6 +3,7 @@
   angular.module('<?php echo $angularModuleName ?>').config(function($routeProvider) {
       $routeProvider.when('/<?php echo $ctrlRelPath ?>', {
         controller: '<?php echo $ctrlName ?>',
+        controllerAs : '<?php echo $ctrlName ?>',
         templateUrl: '<?php echo $htmlName ?>',
 
         // If you need to look up data when opening the page, list it out
@@ -27,11 +28,12 @@
     // The ts() and hs() functions help load strings for this module.
     var ts = $scope.ts = CRM.ts('<?php echo $tsDomain ?>');
     var hs = $scope.hs = crmUiHelp({file: '<?php echo $hlpName ?>'}); // See: templates/<?php echo $hlpName ?>.hlp
+    var vm = this;
 
     // We have myContact available in JS. We also want to reference it in HTML.
-    $scope.myContact = myContact;
+    vm.myContact = myContact;
 
-    $scope.save = function save() {
+    vm.save = function save() {
       return crmStatus(
         // Status messages. For defaults, just use "{}"
         {start: ts('Saving...'), success: ts('Saved')},


### PR DESCRIPTION
Top item when you look up angular best practices is to use controllerAs syntax - effectively namespacing.

This is also a thing if we ever want to migrate to angular.

Not sure the impact on the prettiness of the example but we should comply somehow with best practice