### PR TITLE
Update mkdocs.yml template for mkdocs 2.5+

### DIFF
--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -108,6 +108,7 @@ class InitCommand extends AbstractCommand {
     $basedir = new Path($ctx['basedir']);
     $ext->builders['dirs'] = new Dirs([
       $basedir->string('build'),
+      $basedir->string('docs'),
       $basedir->string('templates'),
       $basedir->string('xml'),
       $basedir->string('images'),
@@ -117,6 +118,8 @@ class InitCommand extends AbstractCommand {
     $ext->builders['module'] = new Module(Services::templating());
     $ext->builders['license'] = new License($licenses->get($ctx['license']), $basedir->string('LICENSE.txt'), FALSE);
     $ext->builders['readme'] = new Template('readme.md.php', $basedir->string('README.md'), FALSE, Services::templating());
+    $ext->builders['mkdocs'] = new Template('mkdocs.yml.php', $basedir->string('mkdocs.yml'), FALSE, Services::templating());
+    $ext->builders['docindex'] = new Template('index.md.php', $basedir->string('docs/index.md'), FALSE, Services::templating());
     $ext->builders['screenshot'] = new CopyFile(dirname(dirname(dirname(dirname(__DIR__)))) . '/images/placeholder.png', $basedir->string('images/screenshot.png'), FALSE);
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);

--- a/src/CRM/CivixBundle/Resources/views/Code/index.md.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/index.md.php
@@ -1,0 +1,19 @@
+# <?php echo $fullName; ?>
+
+## Overview
+
+FIXME
+
+### Features
+
+* FIXME
+
+## Requirements
+
+* CiviCRM x.y or higher
+
+## Known Issues
+
+* None yet!
+
+## Future plans

--- a/src/CRM/CivixBundle/Resources/views/Code/mkdocs.yml.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/mkdocs.yml.php
@@ -1,0 +1,19 @@
+site_name: <?php echo "$fullName\n"; ?>
+repo_url: https://lab.civicrm.org/extensions/FIXME
+theme: material
+
+pages:
+- Home: index.md
+
+markdown_extensions:
+  - attr_list
+  - admonition
+  - def_list
+  - codehilite(guess_lang=false)
+  - toc(permalink=true)
+  - pymdownx.superfences
+  - pymdownx.inlinehilite
+  - pymdownx.tilde
+  - pymdownx.betterem
+  - pymdownx.mark
+  - pymdownx.magiclink

--- a/src/CRM/CivixBundle/Resources/views/Code/mkdocs.yml.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/mkdocs.yml.php
@@ -9,8 +9,10 @@ markdown_extensions:
   - attr_list
   - admonition
   - def_list
-  - codehilite(guess_lang=false)
-  - toc(permalink=true)
+  - codehilite
+      guess_lang: false
+  - toc:
+      permalink: true
   - pymdownx.superfences
   - pymdownx.inlinehilite
   - pymdownx.tilde


### PR DESCRIPTION
The markdown_extensions syntax has changed, but the current publishing infrastructure doesn't support the new stuff yet. Splitting this into a separate PR