### PR TITLE
Remove extra function parameter when inserting submenus

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -401,7 +401,7 @@ function _<?php echo $mainFile ?>_civix_insert_navigation_menu(&$menu, $path, $i
         if (!isset($entry['child'])) {
           $entry['child'] = array();
         }
-        $found = _<?php echo $mainFile ?>_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item, $key);
+        $found = _<?php echo $mainFile ?>_civix_insert_navigation_menu($entry['child'], implode('/', $path), $item);
       }
     }
     return $found;


### PR DESCRIPTION
_bla_civix_insert_navigation_menu only takes 3 params; don't call it with 4