### PR TITLE
Api file cleanup

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/api.php.php
@@ -9,7 +9,7 @@ use <?php echo $_namespace ?>_ExtensionUtil as E;
  * This is used for documentation and validation.
  *
  * @param array $spec description of fields supported by this API call
- * @return void
+ *
  * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
  */
 function _<?php echo $apiFunction ?>_spec(&$spec) {
@@ -20,26 +20,29 @@ function _<?php echo $apiFunction ?>_spec(&$spec) {
  * <?php echo $entityNameCamel ?>.<?php echo $actionNameCamel ?> API
  *
  * @param array $params
- * @return array API result descriptor
+ *
+ * @return array
+ *   API result descriptor
+ *
  * @see civicrm_api3_create_success
- * @see civicrm_api3_create_error
+ *
  * @throws API_Exception
  */
 function <?php echo $apiFunction ?>($params) {
   if (array_key_exists('magicword', $params) && $params['magicword'] == 'sesame') {
     $returnValues = array(
       // OK, return several data rows
-      12 => array('id' => 12, 'name' => 'Twelve'),
-      34 => array('id' => 34, 'name' => 'Thirty four'),
-      56 => array('id' => 56, 'name' => 'Fifty six'),
+      12 => ['id' => 12, 'name' => 'Twelve'],
+      34 => ['id' => 34, 'name' => 'Thirty four'],
+      56 => ['id' => 56, 'name' => 'Fifty six'],
     );
-    // ALTERNATIVE: $returnValues = array(); // OK, success
-    // ALTERNATIVE: $returnValues = array("Some value"); // OK, return a single value
+    // ALTERNATIVE: $returnValues = []; // OK, success
+    // ALTERNATIVE: $returnValues = ["Some value"]; // OK, return a single value
 
-    // Spec: civicrm_api3_create_success($values = 1, $params = array(), $entity = NULL, $action = NULL)
+    // Spec: civicrm_api3_create_success($values = 1, $params = [], $entity = NULL, $action = NULL)
     return civicrm_api3_create_success($returnValues, $params, '<?php echo $entityNameCamel; ?>', '<?php echo $actionNameCamel; ?>');
   }
   else {
-    throw new API_Exception(/*errorMessage*/ 'Everyone knows that the magicword is "sesame"', /*errorCode*/ 1234);
+    throw new API_Exception(/*errorMessage*/ 'Everyone knows that the magicword is "sesame"');
   }
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/api.php.php
@@ -43,6 +43,6 @@ function <?php echo $apiFunction ?>($params) {
     return civicrm_api3_create_success($returnValues, $params, '<?php echo $entityNameCamel; ?>', '<?php echo $actionNameCamel; ?>');
   }
   else {
-    throw new API_Exception(/*errorMessage*/ 'Everyone knows that the magicword is "sesame"');
+    throw new API_Exception(/*error_message*/ 'Everyone knows that the magicword is "sesame"', /*error_code*/ 'magicword_incorrect');
   }
 }


### PR DESCRIPTION
@totten  a little more cleanup
- array syntax
- comment block tidying
- we don't really recommend error codes so removed that
- we don't return civicrm_api3_create_error so removed that too