### PR TITLE
Fix up entity api template

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
@@ -5,11 +5,11 @@ $_namespace = preg_replace(':/:', '_', $namespace);
 use <?php echo $_namespace ?>_ExtensionUtil as E;
 
 /**
- * <?php echo $entityNameCamel ?>.create API specification (optional)
+ * <?php echo $entityNameCamel ?>.create API specification (optional).
  * This is used for documentation and validation.
  *
  * @param array $spec description of fields supported by this API call
- * @return void
+ *
  * @see https://docs.civicrm.org/dev/en/latest/framework/api-architecture/
  */
 function _<?php echo $apiFunctionPrefix ?>create_spec(&$spec) {
@@ -17,21 +17,27 @@ function _<?php echo $apiFunctionPrefix ?>create_spec(&$spec) {
 }
 
 /**
- * <?php echo $entityNameCamel ?>.create API
+ * <?php echo $entityNameCamel ?>.create API.
  *
  * @param array $params
- * @return array API result descriptor
+ *
+ * @return array
+ *   API result descriptor
+ *
  * @throws API_Exception
  */
 function <?php echo $apiFunctionPrefix ?>create($params) {
-  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, <?php echo $entityNameCamel; ?>);
 }
 
 /**
- * <?php echo $entityNameCamel ?>.delete API
+ * <?php echo $entityNameCamel ?>.delete API.
  *
  * @param array $params
- * @return array API result descriptor
+ *
+ * @return array
+ *   API result descriptor
+ *
  * @throws API_Exception
  */
 function <?php echo $apiFunctionPrefix ?>delete($params) {
@@ -39,12 +45,15 @@ function <?php echo $apiFunctionPrefix ?>delete($params) {
 }
 
 /**
- * <?php echo $entityNameCamel ?>.get API
+ * <?php echo $entityNameCamel ?>.get API.
  *
  * @param array $params
- * @return array API result descriptor
+ *
+ * @return array
+ *   API result descriptor
+ *
  * @throws API_Exception
  */
 function <?php echo $apiFunctionPrefix ?>get($params) {
-  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params);
+  return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, FALSE, <?php echo $entityNameCamel; ?>);
 }


### PR DESCRIPTION
@totten and another one 
- comment blocks closer to full drupal spec (we don't enforce it all but for templates....)
- pass the entity name to create & get. This is pretty important as you MUST do this if you want to enable custom data for your api (you also need to add an option value). This removes a trap for young players