### PR TITLE
Builder\Info - Generate '<classloader>/<psr4>' to support APIv4

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,18 @@ The steps for upgrading the `Upgrader` are as follows:
 
 ## Special Tasks
 
+### Upgrade to v19.11.0+: APIv4 and PSR-4
+
+APIv4 looks for classes in the `Civi\Api4` namespace and `Civi/Api4` folder. 
+To support generation of APIv4 code, the `info.xml` should have a
+corresponding classloader:
+
+```xml
+  <classloader>
+    <psr4 prefix="Civi\" path="Civi" />
+  </classloader>
+```
+
 ### Upgrade to v19.06.2+: PHPUnit (Optional; #155)
 
 The templates for PHPUnit tests have been updated to match a major

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -42,6 +42,14 @@ class Info extends XML {
     $xml->addChild('compatibility')->addChild('ver', '5.0');
     $xml->addChild('comments', 'This is a new, undeveloped module');
 
+    // APIv4 will look for classes+files matching 'Civi/Api4', and
+    // classes for this ext should be 'Civi\MyExt', so this is the
+    // simplest default.
+    $classloader = $xml->addChild('classloader');
+    $classloaderRule = $classloader->addChild('psr4');
+    $classloaderRule->addAttribute('prefix', 'Civi\\');
+    $classloaderRule->addAttribute('path', 'Civi');
+
     // store extra metadata to facilitate code manipulation
     $civix = $xml->addChild('civix');
     if (isset($ctx['namespace'])) {


### PR DESCRIPTION
APIv4 looks for classes in the `Civi\Api4` namespace and `Civi/Api4` folder.  To support generation of APIv4 code, the `info.xml` should have a corresponding classloader:

```xml
  <classloader>
    <psr4 prefix="Civi\" path="Civi" />
  </classloader>
```

This revision:

* Includes the default on new modules
* Adds a note for people updating existing modules