### PR TITLE
Convert deprecated function CRM_Core_BAO_Setting::getItem

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
@@ -259,7 +259,7 @@ class <?php echo $_namespace ?>_Upgrader_Base {
 
   private function getCurrentRevisionDeprecated() {
     $key = $this->extensionName . ':version';
-    if ($revision = CRM_Core_BAO_Setting::getItem('Extension', $key)) {
+    if ($revision = \Civi::settings()->get($key)) {
       $this->revisionStorageIsDeprecated = TRUE;
     }
     return $revision;


### PR DESCRIPTION
I don't think this line gets called much, but when doing a grep every extension that has an upgrader shows up. I haven't tested this - I guess it comes up if you try to update a really old extension.