### PR TITLE
Fix #172: SQL files not written by generate:entity-boilerplate

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -25,7 +25,6 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
       );
   }
 
-
   /**
    * Note: this function replicates a fair amount of the functionality of
    * CRM_Core_CodeGen_Specification (which is a bit messy and hard to interact
@@ -95,9 +94,10 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
 
     foreach ($tables as $table) {
       $dao = new \CRM_Core_CodeGen_DAO($config, (string) $table['name'], "{$_namespace}_ExtensionUtil::ts");
-      ob_start(); // Don't display gencode's output
+      // Don't display gencode's output
+      ob_start();
       $dao->run();
-      ob_end_clean(); // Don't display gencode's output
+      ob_end_clean();
       $daoFileName = $basedir->string("{$table['base']}{$table['fileName']}");
       $output->writeln("<info>Write $daoFileName</info>");
     }

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -105,12 +105,22 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
     $schema = new \CRM_Core_CodeGen_Schema($config);
     \CRM_Core_CodeGen_Util_File::createDir($config->sqlCodePath);
     ob_start(); // Don't display gencode's output
-    $schema->generateCreateSql('auto_install.sql');
+    $data = $schema->generateCreateSql('auto_install.sql');
     ob_end_clean(); // Don't display gencode's output
-    $output->writeln("<info>Write {$basedir->string('sql/auto_install.sql')}</info>");
+    if (file_put_contents($config->sqlCodePath . '/auto_install.sql', reset($data))) {
+      $output->writeln("<info>Write {$basedir->string('sql/auto_install.sql')}</info>");
+    }
+    else {
+      $output->writeln("<error>Failed to write data to {$basedir->string('sql/auto_install.sql')}</error>");
+    }
     ob_start(); // Don't display gencode's output
-    $schema->generateDropSql('auto_uninstall.sql');
-    $output->writeln("<info>Write {$basedir->string('sql/auto_uninstall.sql')}</info>");
+    $data = $schema->generateDropSql('auto_uninstall.sql');
+    if (file_put_contents($config->sqlCodePath . '/auto_uninstall.sql', reset($data))) {
+      $output->writeln("<info>Write {$basedir->string('sql/auto_uninstall.sql')}</info>");
+    }
+    else {
+      $output->writeln("<error>Failed to write data to {$basedir->string('sql/auto_uninstall.sql')}</error>");
+    }
     ob_end_clean(); // Don't display gencode's output
     $module = new Module(Services::templating());
     $module->loadInit($ctx);


### PR DESCRIPTION
This fixes the issue by calling `file_put_contents` instead of... well... *not* calling `file_put_contents`.