### PR TITLE
Ensure that using civix info:set -x version -t xxx generates valid xml

### DIFF
--- a/src/CRM/CivixBundle/Command/InfoSetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoSetCommand.php
@@ -62,7 +62,7 @@ Common fields:
       return 1;
     }
     foreach ($elements as $element) {
-      $element->{0} = $input->getOption('to');
+      $element[0] = $input->getOption('to');
     }
 
     $info->save($ctx, $output);


### PR DESCRIPTION
ping @totten this fixes a bug in the mosaico build process as shown by https://test.civicrm.org/view/Tools/job/Tool-Publish-mosaico/125/console I copied across a patched phar version to bknix-old as publisher and confirmed it fixed the build job as per https://test.civicrm.org/view/Tools/job/Tool-Publish-mosaico/126/