### PR TITLE
Update array formatting on generated entityTypes

### DIFF
--- a/src/CRM/CivixBundle/Builder/Module.php
+++ b/src/CRM/CivixBundle/Builder/Module.php
@@ -42,15 +42,13 @@ class Module implements Builder {
   }
 
   private function generateEntityTypes($glob){
-    $entityTypes =[];
+    $entityTypes = [];
     foreach(glob($glob) as $entityFile){
       $entities = include $entityFile;
       foreach ($entities as $entity) {
         $entityTypes[$entity['class']] = $entity;
       }
     }
-
-    $entityTypes = var_export($entityTypes, TRUE);
     return $entityTypes;
   }
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -476,16 +476,25 @@ function _<?php echo $mainFile ?>_civix_civicrm_alterSettingsFolders(&$metaDataF
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
 <?php
+$entityTypeLines = '';
+$count = count($entityTypes);
+$thisLineCount = 1;
 // Add appropriate indentation
-foreach(explode("\n", $entityTypes) as $k => $l){
-  if($k){
-    $entityTypeLines[$k] = '  '.$l;
-  }else{
-    $entityTypeLines[$k] = $l;
+foreach($entityTypes as $entityName => $entityKeys) {
+  $entityTypeLines .= "\n    '$entityName' => [\n";
+  foreach ($entityKeys as $key => $value) {
+    $entityTypeLines .= "      '$key' => '{$value}',\n";
+  }
+  if ($thisLineCount < $count) {
+    $entityTypeLines .= '    ],';
+    $thisLineCount++;
+  }
+  else {
+    $entityTypeLines .= "    ],\n  ";
   }
 }
-$entityTypes = implode("\n", $entityTypeLines);
+
 ?>
 function _<?php echo $mainFile ?>_civix_civicrm_entityTypes(&$entityTypes) {
-  $entityTypes = array_merge($entityTypes, <?php echo $entityTypes ?>);
+  $entityTypes = array_merge($entityTypes, [<?php echo $entityTypeLines ?>]);
 }


### PR DESCRIPTION
This fixes our formatting issue with generated entity types (using old array(), extraneous space).

I have tested with no entities, 1 entity & 2

<img width="584" alt="Screen Shot 2020-07-03 at 12 48 22 PM" src="https://user-images.githubusercontent.com/336308/86420692-81f85380-bd2b-11ea-92e6-95e13fcf0301.png">
