### PR TITLE
Update PHP. Use symfony varExporter for prettier output

### DIFF
--- a/bin/civix
+++ b/bin/civix
@@ -2,8 +2,13 @@
 <?php
 ini_set('display_errors', 1);
 if (PHP_SAPI !== 'cli') {
-  echo "civix is a command-line tool\n";
+  fwrite(STDERR, "civix is a command-line tool. It requires PHP_SAPI=cli.\n");
   exit(1);
+}
+if (version_compare(phpversion(), '7.1.3', '<')) {
+  fwrite(STDERR, "This version of civix requires PHP 7.1.3.\n");
+  fwrite(STDERR, "For PHP 7.0 or older, see civix v20.06.0 or older.\n");
+  exit(2);
 }
 $found = 0;
 $autoloaders = array(
@@ -18,6 +23,7 @@ foreach ($autoloaders as $autoloader) {
   }
 }
 if (!$found) {
-  die("Failed to find autoloader");
+  fwrite(STDERR, "Failed to find autoloader\n");
+  exit(3);
 }
 \CRM\CivixBundle\Application::main(__DIR__);

--- a/composer.json
+++ b/composer.json
@@ -4,13 +4,14 @@
     "homepage": "https://github.com/totten/civix",
     "license": "AGPL-3.0",
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4",
         "civicrm/cv": "~0.2",
         "symfony/console": "~2.8|^3|^4",
         "symfony/process": "~2.8|^3|^4",
         "symfony/templating": "~2.8|^3|^4",
         "symfony/var-dumper": "~2.8|^3|^4",
-        "totten/license-data": "dev-master"
+        "totten/license-data": "dev-master",
+        "symfony/var-exporter": "^4.4"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -4,14 +4,14 @@
     "homepage": "https://github.com/totten/civix",
     "license": "AGPL-3.0",
     "require": {
-        "php": ">=5.4",
+        "php": ">=7.1.3",
         "civicrm/cv": "~0.2",
         "symfony/console": "~2.8|^3|^4",
         "symfony/process": "~2.8|^3|^4",
         "symfony/templating": "~2.8|^3|^4",
         "symfony/var-dumper": "~2.8|^3|^4",
-        "totten/license-data": "dev-master",
-        "symfony/var-exporter": "^4.4"
+        "symfony/var-exporter": "^4.4",
+        "totten/license-data": "dev-master"
     },
     "autoload": {
         "psr-0": {
@@ -22,6 +22,9 @@
         "bin/civix"
     ],
     "config": {
+        "platform": {
+          "php": "7.1.3"
+        },
         "bin-dir": "bin"
     },
     "authors": [

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d625fb0027921ff57c8c646ecece402d",
+    "content-hash": "3db45b985ef4f7b805ac7d143933ebfd",
     "packages": [
         {
             "name": "civicrm/cv",
@@ -123,6 +123,7 @@
                     "homepage": "http://www.acci.cz"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2014-04-08T15:00:19+00:00"
         },
         {
@@ -167,6 +168,7 @@
                     "homepage": "http://www.acci.cz/"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2015-04-20T18:58:01+00:00"
         },
         {
@@ -777,6 +779,80 @@
             "time": "2016-12-06T16:05:07+00:00"
         },
         {
+            "name": "symfony/var-exporter",
+            "version": "v4.4.10",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "f311af6e44fefedbd4f1e23e97607ef0f917bfcc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/f311af6e44fefedbd4f1e23e97607ef0f917bfcc",
+                "reference": "f311af6e44fefedbd4f1e23e97607ef0f917bfcc",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.4.9|^5.0.9"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-06-01T01:10:09+00:00"
+        },
+        {
             "name": "totten/license-data",
             "version": "dev-master",
             "source": {
@@ -816,7 +892,8 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.3.3"
+        "php": ">=5.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3db45b985ef4f7b805ac7d143933ebfd",
+    "content-hash": "5965a5afd47bc4073f54d0f46c752105",
     "packages": [
         {
             "name": "civicrm/cv",
@@ -892,8 +892,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.4"
+        "php": ">=7.1.3"
     },
     "platform-dev": [],
+    "platform-overrides": {
+        "php": "7.1.3"
+    },
     "plugin-api-version": "1.1.0"
 }

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
 use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\VarExporter\VarExporter;
 
 /**
  * Read/write a serialized data file based on PHP's var_export() format
@@ -75,7 +76,7 @@ class PhpData implements Builder {
       $content .= $this->header;
     }
     $content .= "\nreturn ";
-    $content .= var_export($this->data, TRUE);
+    $content .= VarExporter::export($this->data);
     $content .= ";\n";
     file_put_contents($this->path, $content);
   }

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -76,7 +76,14 @@ class PhpData implements Builder {
       $content .= $this->header;
     }
     $content .= "\nreturn ";
-    $content .= VarExporter::export($this->data);
+    $content .= preg_replace_callback('/^ +/m',
+      // VarExporter indents with 4x spaces. Civi/Drupal code standard is 2x spaces.
+      function($m) {
+        $spaces = $m[0];
+        return substr($spaces, 0, ceil(strlen($spaces) / 2));
+      },
+      VarExporter::export($this->data)
+    );
     $content .= ";\n";
     file_put_contents($this->path, $content);
   }


### PR DESCRIPTION
Before
--------
Generated php files such as `*.ang.php` would not look so great, with bad indentation and old array syntax.

After
------
Should look much better.