### PR TITLE
Use helper function to get extension directory path

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
@@ -34,7 +34,7 @@ class <?php echo $_namespace ?>_Upgrader_Base {
   protected $extensionDir;
 
   /**
-   * @var revisionNumber[]
+   * @var array
    *   sorted numerically
    */
   private $revisions;
@@ -50,10 +50,9 @@ class <?php echo $_namespace ?>_Upgrader_Base {
    */
   public static function instance() {
     if (!self::$instance) {
-      // FIXME auto-generate
       self::$instance = new <?php echo $_namespace ?>_Upgrader(
         '<?php echo $fullName ?>',
-        realpath(__DIR__ . '/../../../')
+        E::path()
       );
     }
     return self::$instance;


### PR DESCRIPTION
@totten This fixes an issue with the upgrader when run via a core extension - found through eventcart - https://github.com/civicrm/civicrm-core/pull/17339/commits/ad331419797b6071e64d340dd5ca72ad713cc3af

Use the `E::path()` helper to get the path of the extension instead of relying on parent parent parent of current dir..

Also one typo in variable definition.