### PR TITLE
Normalize path to xml file in generated DAO files

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -83,7 +83,8 @@ class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Com
       $specification->getTable($xml, $database, $tables);
       $name = (string) $xml->name;
       $tables[$name]['name'] = $name;
-      $tables[$name]['sourceFile'] = $xmlSchema;
+      $sourcePath = strstr($xmlSchema, "/xml/schema/{$ctx['namespace']}/");
+      $tables[$name]['sourceFile'] = $ctx['fullName'] . $sourcePath;
     }
 
     $config->tables = $tables;


### PR DESCRIPTION
Overview
----------
Cleans up the "generated from" comment in each DAO file to start from the extension rather than what is often the developer's home directory.

Before
-----------
Comment says `Generated from /home/colemanw/bknix/build/d7/web/sites/default/files/civicrm/ext/org.civicrm.volunteer/xml/schema/CRM/Volunteer/Project.xml`

After
-----------
Comment says `Generated from org.civicrm.volunteer/xml/schema/CRM/Volunteer/Project.xml`