### PR TITLE
AddEntityCommand - Generate APIv3 unit-test

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
@@ -1,0 +1,69 @@
+<?php
+echo "<?php\n";
+?>
+
+use Civi\Test\HeadlessInterface;
+use Civi\Test\HookInterface;
+use Civi\Test\TransactionalInterface;
+
+/**
+ * <?php echo $entityNameCamel ?> API Test Case
+ * @group headless
+ */
+class <?php echo $testApi3ClassName ?> extends \PHPUnit\Framework\TestCase implements HeadlessInterface, HookInterface, TransactionalInterface {
+  use \Civi\Test\Api3TestTrait;
+
+  /**
+   * Set up for headless tests.
+   *
+   * Civi\Test has many helpers, like install(), uninstall(), sql(), and sqlFile().
+   *
+   * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
+   */
+  public function setUpHeadless() {
+    return \Civi\Test::headless()
+      ->installMe(__DIR__)
+      ->apply();
+  }
+
+  /**
+   * The setup() method is executed before the test is executed (optional).
+   */
+  public function setUp() {
+    $table = CRM_Core_DAO_AllCoreTables::getTableForEntityName(<?php var_export($entityNameCamel); ?>);
+    $this->assertTrue($table && CRM_Core_DAO::checkTableExists($table), 'There was a problem with extension installation. Table for ' . <?php var_export($entityNameCamel); ?> . ' not found.');
+    parent::setUp();
+  }
+
+  /**
+   * The tearDown() method is executed after the test was executed (optional)
+   * This can be used for cleanup.
+   */
+  public function tearDown() {
+    parent::tearDown();
+  }
+
+  /**
+   * Simple example test case.
+   *
+   * Note how the function name begins with the word "test".
+   */
+  public function testCreateGetDelete() {
+    // Boilerplate entity has one data field -- 'contact_id'.
+    // Put some data in, read it back out, and delete it.
+
+    $created = $this->callAPISuccess(<?php var_export($entityNameCamel); ?>, 'create', [
+      'contact_id' => 1,
+    ]);
+    $this->assertTrue(is_numeric($created['id']));
+
+    $get = $this->callAPISuccess(<?php var_export($entityNameCamel); ?>, 'get', []);
+    $this->assertEquals(1, $get['count']);
+    $this->assertEquals(1, $get['values'][$created['id']]['contact_id']);
+
+    $this->callAPISuccess(<?php var_export($entityNameCamel); ?>, 'delete', [
+      'id' => $created['id'],
+    ]);
+  }
+
+}


### PR DESCRIPTION
This improves test-coverage for APIv3 entities in two ways:

* The command `generate:entity` will create a file `tests/phpunit/api/v3/MyEntityTest.php`.
* The QA script `bash tests/make-example.sh` calls `generate:entity` and subsequently runs `phpunit` on all generated tests. Therefore, it runs

This is motivated by #193, which revealed that `generate:entity` regressed in two ways circa 19.10. I've confirmed that this unit-test would complain about both of the problems.

I've only added the patch for APIv3 (b/c that had the last bug), but an APIv4 patch should look pretty similar and is patch-welcome.

Ping @twomice @eileenmcnaughton @colemanw 
