### PR TITLE
generate:api - Explicitly prefer singleword action names

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
@@ -48,7 +48,7 @@ class <?php echo $testClassName ?> extends \PHPUnit\Framework\TestCase implement
    * Note how the function name begins with the word "test".
    */
   public function testApiExample() {
-    $result = civicrm_api3('<?php echo $entityNameCamel ?>', '<?php echo $actionNameCamel ?>', array('magicword' => 'sesame'));
+    $result = civicrm_api3('<?php echo $entityNameCamel ?>', '<?php echo $actionNameLower ?>', array('magicword' => 'sesame'));
     $this->assertEquals('Twelve', $result['values'][12]['name']);
   }
 

--- a/tests/make-example.sh
+++ b/tests/make-example.sh
@@ -51,7 +51,8 @@ pushd $WORKINGDIR
   fi
 
   pushd $EXMODULE
-    $CIVIX $VERBOSITY generate:api MyEntity MyAction
+    $CIVIX $VERBOSITY generate:api MyEntity Myaction
+    $CIVIX $VERBOSITY generate:api MyEntity myaction2
     $CIVIX $VERBOSITY generate:case-type MyLabel MyName
     # $CIVIX $VERBOSITY generate:custom-xml -f --data="FIXME" --uf="FIXME"
     $CIVIX $VERBOSITY generate:entity MyEntityFour


### PR DESCRIPTION
The proximate reason for change -- `tests/make-example.sh` was using CamelCase actions, and it passed on macOS, but it didn't pass on Linux. I'd like the test to give consistent output on both platforms.

It may be that there are semi-legit ways to get actions working with CamelCase and/or under_score_case, e.g.

* Use a file-name like `MyEntity/Myaction.php` but call it as `MyEntity, MyAction`. This seemed to work in one Linux trial for calling `MyAction`, but calls weren't interchangeable with `my_action`. 
* Don't generate standalone action files. Put all the actions into a combined per-entity file. However, this doesn't fit well into civix's   mental model of "call generator => produce well-defined PHP file".

I haven't re-tested these possiblities to be sure, but -- even if they work -- the ultimate result would be a codebase that's a bit brittle (e.g. if you put a CamelCase action in the per-entity file, and if you later try to reorganize with per-action files, then you find out the hard-way that it's not portable). Moreover, I don't really want to spend much more time debugging APIv3 names when APIv4 is preferred for new development.

This change just further enshrines the work-around we've been using in APIv3 - ie don't try CamelCase or under_score_case, just use singleword.

Practical consequences, compare these commands:

```
civix generate:api MyEntity Myaction
## ^^ Previously accepted and portable.
## Still accepted.

civix generate:api MyEntity myaction
## ^^ Previously rejected. As written, it may or may not have worked.
## Now accepted as equivalent to "Myaction" (above).

civix generate:api MyEntity MyAction
## ^^ Previously accepted, but results were not portable, 
## so experienced folks wouldn't do it anyway.
## Now accepted as equivalent to "Myaction" (above).
```