### PR TITLE
extensions/extensions-directory#18 Update the boilerplate README

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/readme.md.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/readme.md.php
@@ -9,12 +9,12 @@ The extension is licensed under [<?php echo $license ?>](LICENSE.txt).
 
 ## Requirements
 
-* PHP v7.0+
+* PHP v7.2+
 * CiviCRM (*FIXME: Version number*)
 
 ## Installation (Web UI)
 
-This extension has not yet been published for installation via the web UI.
+Learn more about installing CiviCRM extensions in the [CiviCRM Sysadmin Guide](https://docs.civicrm.org/sysadmin/en/latest/customize/extensions/).
 
 ## Installation (CLI, Zip)
 
@@ -36,7 +36,7 @@ git clone https://github.com/FIXME/<?php echo $fullName; ?>.git
 cv en <?php echo $mainFile . "\n"; ?>
 ```
 
-## Usage
+## Getting Started
 
 (* FIXME: Where would a new user navigate to get started? What changes would they see? *)
 


### PR DESCRIPTION
Buncles a few proposed changes to the default README:

* Require PHP 7.2 instead of 7.0, since that is what CiviCRM core recommends
* Cut the installation instructions and refer to the sysadmin guide instead
* Replace "Usage" with "Getting Started" as per https://lab.civicrm.org/extensions/extensions-directory/-/issues/18