### PR TITLE
Update cv to ~0.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "license": "AGPL-3.0",
     "require": {
         "php": ">=7.1.3",
-        "civicrm/cv": "~0.2",
+        "civicrm/cv": "~0.3",
         "symfony/console": "~2.8|^3|^4",
         "symfony/process": "~2.8|^3|^4",
         "symfony/templating": "~2.8|^3|^4",

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,76 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5965a5afd47bc4073f54d0f46c752105",
+    "content-hash": "2657bb1a380de3d114e5c3d216f9e369",
     "packages": [
         {
-            "name": "civicrm/cv",
-            "version": "v0.2.3",
+            "name": "civicrm/composer-downloads-plugin",
+            "version": "v2.1.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/civicrm/cv.git",
-                "reference": "e391193c0d1de6183adb83578551f0b646595b7b"
+                "url": "https://github.com/civicrm/composer-downloads-plugin.git",
+                "reference": "8722bc7d547315be39397a3078bb51ee053ca269"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/civicrm/cv/zipball/e391193c0d1de6183adb83578551f0b646595b7b",
-                "reference": "e391193c0d1de6183adb83578551f0b646595b7b",
+                "url": "https://api.github.com/repos/civicrm/composer-downloads-plugin/zipball/8722bc7d547315be39397a3078bb51ee053ca269",
+                "reference": "8722bc7d547315be39397a3078bb51ee053ca269",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0",
+                "composer-plugin-api": "^1.1",
+                "php": ">=5.6",
+                "togos/gitignore": "~1.1.1"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "friendsofphp/php-cs-fixer": "^2.3",
+                "phpunit/phpunit": "^5.7",
+                "totten/process-helper": "^1.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "LastCall\\DownloadsPlugin\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "LastCall\\DownloadsPlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rob Bayliss",
+                    "email": "rob@lastcallmedia.com"
+                },
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "Composer plugin for downloading additional files within any composer package.",
+            "time": "2019-08-28T00:33:51+00:00"
+        },
+        {
+            "name": "civicrm/cv",
+            "version": "v0.3.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/cv.git",
+                "reference": "f2a348a4c2f20537f84eb6b8f03c2e40cdf3cd6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/cv/zipball/f2a348a4c2f20537f84eb6b8f03c2e40cdf3cd6c",
+                "reference": "f2a348a4c2f20537f84eb6b8f03c2e40cdf3cd6c",
+                "shasum": ""
+            },
+            "require": {
+                "civicrm/composer-downloads-plugin": "~2.1",
+                "php": ">=5.6.0",
                 "psy/psysh": "@stable",
                 "symfony/console": "~2.8|^3",
                 "symfony/filesystem": "~2.8|^3",
@@ -31,6 +83,15 @@
                 "bin/cv"
             ],
             "type": "library",
+            "extra": {
+                "downloads": {
+                    "box": {
+                        "url": "https://github.com/humbug/box/releases/download/3.8.4/box.phar",
+                        "path": "bin/box",
+                        "type": "phar"
+                    }
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Civi\\Cv\\": "src/"
@@ -47,7 +108,7 @@
                 }
             ],
             "description": "CLI tool for CiviCRM",
-            "time": "2018-03-01T01:44:50+00:00"
+            "time": "2020-10-24T00:19:13+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -851,6 +912,39 @@
                 }
             ],
             "time": "2020-06-01T01:10:09+00:00"
+        },
+        {
+            "name": "togos/gitignore",
+            "version": "1.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/TOGoS/PHPGitIgnore.git",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/TOGoS/PHPGitIgnore/zipball/32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "reference": "32bc0830e4123f670adcbf5ddda5bef362f4f4d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.2"
+            },
+            "require-dev": {
+                "togos/simpler-test": "1.1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "TOGoS_GitIgnore_": "src/main/php/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Parser for .gitignore (and sparse-checkout, and anything else using the same format) files",
+            "time": "2019-04-19T19:16:58+00:00"
         },
         {
             "name": "totten/license-data",


### PR DESCRIPTION
cv version .2 doesn't work with php 7.4 is the main thing, but also why not.

I'd updated composer.json locally a long time ago for something else that wasn't working - completely forgot about that so I can't say what it was.

e.g. https://civicrm.stackexchange.com/questions/38061/getting-error-when-using-civix-generatemodule-or-civix-generateentity-curly-br