### PR TITLE
Add type=Number to id field in generated schema

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-schema.xml.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-schema.xml.php
@@ -14,6 +14,9 @@ echo '<?xml version="1.0" encoding="iso-8859-1" ?>'."\n";
     <type>int unsigned</type>
     <required>true</required>
     <comment>Unique <?php echo $entityNameCamel ?> ID</comment>
+    <html>
+      <type>Number</type>
+    </html>
   </field>
   <primaryKey>
     <name>id</name>


### PR DESCRIPTION
Metadata-based UIs like Search Kit can use these `<html><type>` tags to render the field appropriately.