### PR TITLE
Remove safe-mode as it is php5.4

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -3,7 +3,7 @@ echo "<?php\n";
 ?>
 
 ini_set('memory_limit', '2G');
-ini_set('safe_mode', 0);
+
 // phpcs:disable
 eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
@@ -27,11 +27,11 @@ $loader->register();
  * @throws \RuntimeException
  *   If the command terminates abnormally.
  */
-function cv($cmd, $decode = 'json') {
+function cv(string $cmd, $decode = 'json'): string {
   $cmd = 'cv ' . $cmd;
-  $descriptorSpec = array(0 => array("pipe", "r"), 1 => array("pipe", "w"), 2 => STDERR);
+  $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
   $oldOutput = getenv('CV_OUTPUT');
-  putenv("CV_OUTPUT=json");
+  putenv('CV_OUTPUT=json');
 
   // Execute `cv` in the original folder. This is a work-around for
   // phpunit/codeception, which seem to manipulate PWD.
@@ -51,7 +51,7 @@ function cv($cmd, $decode = 'json') {
 
     case 'phpcode':
       // If the last output is /*PHPCODE*/, then we managed to complete execution.
-      if (substr(trim($result), 0, 12) !== "/*BEGINPHP*/" || substr(trim($result), -10) !== "/*ENDPHP*/") {
+      if (substr(trim($result), 0, 12) !== '/*BEGINPHP*/' || substr(trim($result), -10) !== '/*ENDPHP*/') {
         throw new \RuntimeException("Command failed ($cmd):\n$result");
       }
       return $result;

--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -22,12 +22,13 @@ $loader->register();
  *   The rest of the command to send.
  * @param string $decode
  *   Ex: 'json' or 'phpcode'.
- * @return string
+ * @return mixed
  *   Response output (if the command executed normally).
+ *   For 'raw' or 'phpcode', this will be a string. For 'json', it could be any JSON value.
  * @throws \RuntimeException
  *   If the command terminates abnormally.
  */
-function cv(string $cmd, $decode = 'json'): string {
+function cv(string $cmd, string $decode = 'json') {
   $cmd = 'cv ' . $cmd;
   $descriptorSpec = [0 => ['pipe', 'r'], 1 => ['pipe', 'w'], 2 => STDERR];
   $oldOutput = getenv('CV_OUTPUT');


### PR DESCRIPTION
Other minor fixups to preferred php (as per inspections) which I opened this to demonstrate https://github.com/civicrm/civicrm-core/pull/19834