### PR TITLE
Do not generate cache result file in phpunit8

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,6 +7,7 @@
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php"
+         cacheResult="false"
 >
   <testsuites>
     <testsuite name="Civix Test Suite">

--- a/src/CRM/CivixBundle/Builder/PhpUnitXML.php
+++ b/src/CRM/CivixBundle/Builder/PhpUnitXML.php
@@ -19,6 +19,7 @@ class PhpUnitXML extends XML {
     $xml->addAttribute('convertWarningsToExceptions', 'true');
     $xml->addAttribute('processIsolation', 'false');
     $xml->addAttribute('stopOnFailure', 'false');
+    $xml->addAttribute('cacheResult', 'false');
     $xml->addAttribute('bootstrap', 'tests/phpunit/bootstrap.php');
     $this->set($xml);
 


### PR DESCRIPTION
as per https://github.com/civicrm/civicrm-core/pull/20356 and https://stackoverflow.com/questions/55091768/what-is-phpunit-result-cache

ping @eileenmcnaughton @totten 