### PR TITLE
Allow underscores in module names

### DIFF
--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -5,7 +5,6 @@ use CRM\CivixBundle\Builder\CopyFile;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Services;
 use CRM\CivixBundle\Utils\Naming;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -18,6 +17,7 @@ use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
 
 class InitCommand extends AbstractCommand {
+
   protected function configure() {
     Services::templating();
     $this
@@ -134,7 +134,7 @@ class InitCommand extends AbstractCommand {
     $civicrm_api3 = Services::api3();
 
     if ($civicrm_api3 && $civicrm_api3->local && version_compare(\CRM_Utils_System::version(), '4.3.dev', '>=')) {
-      $siteName = \CRM_Utils_System::baseURL(); // \CRM_Core_Config::singleton()->userSystem->cmsRootPath();
+      $siteName = \CRM_Utils_System::baseURL(); /* \CRM_Core_Config::singleton()->userSystem->cmsRootPath(); */
 
       $output->writeln("<info>Refresh extension list for \"$siteName\"</info>");
       if (!$civicrm_api3->Extension->refresh(['local' => TRUE, 'remote' => FALSE])) {

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -32,7 +32,7 @@ class InitCommand extends AbstractCommand {
         "Create a new CiviCRM Module-Extension (Regenerate module.civix.php if ext.name not specified)\n" .
         "\n" .
         "<comment>Identification:</comment>\n" .
-        "  Keys must be lowercase alphanumeric (with dashes allowed).\n" .
+        "  Keys must be lowercase alphanumeric (with dashes and underscores allowed).\n" .
         "\n" .
         "  Optionally, you may use a Java-style prefix (reverse domain name).\n" .
         "\n" .

--- a/src/CRM/CivixBundle/Utils/Naming.php
+++ b/src/CRM/CivixBundle/Utils/Naming.php
@@ -13,9 +13,9 @@ class Naming {
    */
   public static function isValidFullName($fullName) {
     return
-      preg_match('/^[a-z][a-z0-9\.\-]*$/', $fullName)
-      && !preg_match('/[\.\-][\.\-]/', $fullName)
-      && !preg_match('/[\.\-]$/', $fullName);
+      preg_match('/^[a-z][-_a-z0-9\.]*$/', $fullName)
+      && !preg_match('/[-_\.][-_\.]/', $fullName)
+      && !preg_match('/[-_\.]$/', $fullName);
   }
 
   /**

--- a/tests/make-example.sh
+++ b/tests/make-example.sh
@@ -4,7 +4,7 @@
 BUILDDIR="$1"
 BUILDNAME="$2"
 WORKINGDIR="$BUILDDIR/build/$BUILDNAME/web/sites/all/modules/civicrm/tools/extensions"
-EXMODULE=org.civicrm.civixexample
+EXMODULE=${EXMODULE:-org.civicrm.civixexample}
 
 # validate environment
 if [ -z "$BUILDNAME" ]; then


### PR DESCRIPTION
Previously the command `civix generate:module "search_kit"` would throw `'Malformed package name'`

Note: I moved the `-` character to the beginning of each `[]` block for readability; dashes do not need to be escaped if they are the first character.