### PR TITLE
Angular - Default module-name should be well-defined in an `_`-world

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,42 +41,28 @@ The steps for upgrading the `Upgrader` are as follows:
 
 ## Special Tasks
 
-### Upgrade to v21.09.0+: Angular Module
+### Upgrade to v21.09.0+: Angular Module (optional)
 
-When generating Angular code, the default Angular module name has traditionally matched the extension's short-name, eg
+Angular code in Civi extensions usually has one of these layouts:
 
-| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
-| -- | -- | -- |
-| `org.example.foobar` | `foobar` | `foobar` |
-| `org.example.foo-bar` | `foo_bar` | `foo_bar` (!!) |
+* (A) (default, most common) There is one Angular module, and its name exactly matches the Civi extension.
+* (B) There is one Angular module, and its name does *not* match the Civi extension.
+* (C) There are multiple Angular modules. It is impossible for them to all match.
 
-This has two problems:
-
-* If the extension has dashes or underscores, then the Angular module winds up with underscores. Underscores
-  do not map sensibly to HTML tags or attributes.
-* There is no standard prefix. By convention, most CiviCRM Angular modules use the prefix `crm` (`crm-`).
-
-In v21.09.0+, the `info.xml` may explicitly specify the Angular module, as in:
+Extensions with mismatched names (group B) may now provide a hint via `info.xml`. For example, if the extension is `foobar` and the Angular module is `crmFoobar`, then set:
 
 ```xml
-<extension key="org.example.foo-bar" type="module">
-  <file>foo_bar</file>
+<extension key="com.example.foobar" type="module">
+  <file>foobar</file>
   <civix>
-    <namespace>CRM/FooBar</namespace>
-    <angularModule>crmFooBar</namespace>
+    <angularModule>crmFoobar</angularModule>
   </civix>
 </extension>
 ```
 
-For new extensions, the `info.xml` will be set the name as follows:
+For group B, this will be a slight usability improvement - when calling `generate:angular-*` commands, the default value of `--am=...` will match the preferred name.
 
-| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
-| -- | -- | -- |
-| `org.example.foobar` | `foobar` | `crmFoobar` |
-| `org.example.foo-bar` | `foo_bar` | `crmFooBar` |
-
-Without a directive in `info.xml`, the default name will continue as before. However, you may wish to explicitly
-set the preferred name in `info.xml`.
+For group C, you will still need to specify `--am=...` on a case-by-case basis.
 
 ### Upgrade to v20.09.0+: APIv3 Entity
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -41,6 +41,43 @@ The steps for upgrading the `Upgrader` are as follows:
 
 ## Special Tasks
 
+### Upgrade to v21.09.0+: Angular Module
+
+When generating Angular code, the default Angular module name has traditionally matched the extension's short-name, eg
+
+| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
+| -- | -- | -- |
+| `org.example.foobar` | `foobar` | `foobar` |
+| `org.example.foo-bar` | `foo_bar` | `foo_bar` (!!) |
+
+This has two problems:
+
+* If the extension has dashes or underscores, then the Angular module winds up with underscores. Underscores
+  do not map sensibly to HTML tags or attributes.
+* There is no standard prefix. By convention, most CiviCRM Angular modules use the prefix `crm` (`crm-`).
+
+In v21.09.0+, the `info.xml` may explicitly specify the Angular module, as in:
+
+```xml
+<extension key="org.example.foo-bar" type="module">
+  <file>foo_bar</file>
+  <civix>
+    <namespace>CRM/FooBar</namespace>
+    <angularModule>crmFooBar</namespace>
+  </civix>
+</extension>
+```
+
+For new extensions, the `info.xml` will be set the name as follows:
+
+| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
+| -- | -- | -- |
+| `org.example.foobar` | `foobar` | `crmFoobar` |
+| `org.example.foo-bar` | `foo_bar` | `crmFooBar` |
+
+Without a directive in `info.xml`, the default name will continue as before. However, you may wish to explicitly
+set the preferred name in `info.xml`.
+
 ### Upgrade to v20.09.0+: APIv3 Entity
 
 Some versions of `generate:entity` (late 2019/early 2020) created incorrect boilerplate for APIv3.  This affected the

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -2,7 +2,6 @@
 namespace CRM\CivixBundle\Builder;
 
 use SimpleXMLElement;
-use CRM\CivixBundle\Builder\XML;
 
 /**
  * Build/update info.xml
@@ -54,6 +53,9 @@ class Info extends XML {
     $civix = $xml->addChild('civix');
     if (isset($ctx['namespace'])) {
       $civix->addChild('namespace', $ctx['namespace']);
+    }
+    if (isset($ctx['angularModuleName'])) {
+      $civix->addChild('angularModule', $ctx['angularModuleName']);
     }
 
     if (isset($ctx['typeInfo'])) {

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -74,6 +74,9 @@ class Info extends XML {
     $ctx['mainFile'] = (string) array_shift($items);
     $items = $this->get()->xpath('civix/namespace');
     $ctx['namespace'] = (string) array_shift($items);
+    $items = $this->get()->xpath('civix/angularModule');
+    $angularModule = (string) array_shift($items);
+    $ctx['angularModuleName'] = !empty($angularModule) ? $angularModule : $ctx['mainFile'];
   }
 
   /**

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -47,7 +47,7 @@ For more, see https://docs.angularjs.org/guide/directive');
     }
 
     $ctx['tsDomain'] = (string) $attrs['key'];
-    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['mainFile'];
+    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['angularModuleName'];
     $ctx['dirNameCamel'] = $this->toCamel($input->getArgument('<directive-name>'));
     $ctx['dirNameHyp'] = $this->toHyphen($input->getArgument('<directive-name>'));
 

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -36,7 +36,7 @@ class AddAngularModuleCommand extends \Symfony\Component\Console\Command\Command
       return;
     }
 
-    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['mainFile'];
+    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['angularModuleName'];
     $ctx['angularModulePhp'] = $basedir->string('ang', $ctx['angularModuleName'] . '.ang.php');
     $ctx['angularModuleJs'] = $basedir->string('ang', $ctx['angularModuleName'] . '.js');
     $ctx['angularModuleCss'] = $basedir->string('ang', $ctx['angularModuleName'] . '.css');

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -52,7 +52,7 @@ For more, see https://docs.angularjs.org/guide');
     }
 
     $ctx['tsDomain'] = (string) $attrs['key'];
-    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['mainFile'];
+    $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['angularModuleName'];
     $ctx['ctrlSuffix'] = $input->getArgument('<Ctrl>');
     $ctx['ctrlRelPath'] = $input->getArgument('<RelPath>');
     $ctx['ctrlName'] = ucwords($ctx['angularModuleName']) . $ctx['ctrlSuffix'];

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -83,6 +83,7 @@ class InitCommand extends AbstractCommand {
     $ctx['fullName'] = $name;
     $ctx['mainFile'] = Naming::createShortName($name);
     $ctx['namespace'] = 'CRM/' . Naming::createCamelName($name);
+    $ctx['angularModuleName'] = 'crm' . Naming::createCamelName($name);
 
     if ($input->getOption('author') && $input->getOption('email')) {
       $ctx['author'] = $input->getOption('author');


### PR DESCRIPTION
This is a followup to #227, which allows use of `_` in module-names. If you have underscore names and then generate Angular code, the module names are peculiar. This updates the naming convention. Below, I've reproduced the explanation from `UPGRADE.md`:

ping @colemanw 

--

When generating Angular code, the default Angular module name has traditionally matched the extension's short-name, eg

| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
| -- | -- | -- |
| `org.example.foobar` | `foobar` | `foobar` |
| `org.example.foo-bar` | `foo_bar` | `foo_bar` (!!) |

This has two problems:

* If the extension has dashes or underscores, then the Angular module winds up with underscores. Underscores
  do not map sensibly to HTML tags or attributes.
* There is no standard prefix. By convention, most CiviCRM Angular modules use the prefix `crm` (`crm-`).

In v21.09.0+, the `info.xml` may explicitly specify the Angular module, as in:

```xml
<extension key="org.example.foo-bar" type="module">
  <file>foo_bar</file>
  <civix>
    <namespace>CRM/FooBar</namespace>
    <angularModule>crmFooBar</namespace>
  </civix>
</extension>
```

For new extensions, the `info.xml` will be set the name as follows:

| __Long Name (Key)__ | __Short Name (file)__ | __Default Angular Module__ |
| -- | -- | -- |
| `org.example.foobar` | `foobar` | `crmFoobar` |
| `org.example.foo-bar` | `foo_bar` | `crmFooBar` |

Without a directive in `info.xml`, the default name will continue as before. However, you may wish to update some existing extensions to explicitly set the preferred name in `info.xml`.


