### PR TITLE
Hodgepodge of cleanups

### DIFF
--- a/src/CRM/CivixBundle/Builder/CopyClass.php
+++ b/src/CRM/CivixBundle/Builder/CopyClass.php
@@ -55,7 +55,7 @@ class CopyClass implements Builder {
       $output->writeln("<error>Skip " . $this->tgtFile . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write " . $this->tgtFile . "</info>");
+      $output->writeln("<info>Write</info> " . $this->tgtFile);
       $content = file_get_contents($clazz->getFileName(), TRUE);
       // FIXME parser
       $content = strtr($content, [

--- a/src/CRM/CivixBundle/Builder/CopyFile.php
+++ b/src/CRM/CivixBundle/Builder/CopyFile.php
@@ -44,7 +44,7 @@ class CopyFile implements Builder {
       $output->writeln("<error>Skip " . $this->to . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write " . $this->to . "</info>");
+      $output->writeln("<info>Write</info> " . $this->to);
       $content = file_get_contents($this->from, TRUE);
       file_put_contents($this->to, $content);
     }

--- a/src/CRM/CivixBundle/Builder/CustomDataXML.php
+++ b/src/CRM/CivixBundle/Builder/CustomDataXML.php
@@ -49,7 +49,7 @@ class CustomDataXML implements Builder {
       $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write " . $this->path . "</info>");
+      $output->writeln("<info>Write</info> " . $this->path);
       file_put_contents($this->path, $this->export->toXML());
     }
   }

--- a/src/CRM/CivixBundle/Builder/Ini.php
+++ b/src/CRM/CivixBundle/Builder/Ini.php
@@ -68,7 +68,7 @@ class Ini implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write " . $this->path . "</info>");
+    $output->writeln("<info>Write</info> " . $this->path);
 
     $content = '';
     foreach ($this->data as $topKey => $data) {

--- a/src/CRM/CivixBundle/Builder/License.php
+++ b/src/CRM/CivixBundle/Builder/License.php
@@ -42,7 +42,7 @@ class License implements Builder {
       $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write " . $this->path . "</info>");
+      $output->writeln("<info>Write</info> " . $this->path);
       $text = strtr($this->license->getText(), [
         '<YEAR>' => date('Y'),
         '<OWNER>' => sprintf('%s <%s>', $ctx['author'], $ctx['email']),

--- a/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
+++ b/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
@@ -18,7 +18,7 @@ class PHPUnitGenerateInitFiles {
       ]);
       $dirs->save($ctx, $output);
 
-      $output->writeln(sprintf('<info>Write %s</info>', $bootstrapFile));
+      $output->writeln(sprintf('<info>Write</info> %s', $bootstrapFile));
       file_put_contents($bootstrapFile, Services::templating()
         ->render('phpunit-boot-cv.php.php', $ctx));
     }

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -69,7 +69,7 @@ class PhpData implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write " . $this->path . "</info>");
+    $output->writeln("<info>Write</info> " . $this->path);
 
     $content = "<?php\n";
     if ($this->header) {

--- a/src/CRM/CivixBundle/Builder/Template.php
+++ b/src/CRM/CivixBundle/Builder/Template.php
@@ -44,7 +44,7 @@ class Template implements Builder {
       $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write " . $this->path . "</info>");
+      $output->writeln("<info>Write</info> " . $this->path);
       file_put_contents($this->path, $this->templateEngine->render($this->template, $ctx));
     }
   }

--- a/src/CRM/CivixBundle/Builder/Template.php
+++ b/src/CRM/CivixBundle/Builder/Template.php
@@ -1,9 +1,8 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
-use SimpleXMLElement;
-use DOMDocument;
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -11,16 +10,24 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 class Template implements Builder {
 
-  protected $template, $path, $xml, $templateEngine, $enable;
+  protected $template;
+  protected $path;
+  protected $xml;
+  protected $templateEngine;
+  protected $enable;
 
   /**
-   * @param $overwrite scalar; TRUE (always overwrite), FALSE (preserve with error), 'ignore' (preserve quietly)
+   * @param string $template
+   * @param string $path
+   * @param bool|string $overwrite TRUE (always overwrite), FALSE (preserve with error), 'ignore' (preserve quietly)
+   * @param \Symfony\Component\Templating\EngineInterface|null $templateEngine
+   * @param
    */
-  public function __construct($template, $path, $overwrite, $templateEngine) {
+  public function __construct(string $template, string $path, $overwrite, $templateEngine = NULL) {
     $this->template = $template;
     $this->path = $path;
     $this->overwrite = $overwrite;
-    $this->templateEngine = $templateEngine;
+    $this->templateEngine = $templateEngine ?: Services::templating();
     $this->enable = FALSE;
   }
 
@@ -37,6 +44,10 @@ class Template implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
+    $parent = dirname($this->path);
+    if (!is_dir($parent)) {
+      mkdir($parent, Dirs::MODE, TRUE);
+    }
     if (file_exists($this->path) && $this->overwrite === 'ignore') {
       // do nothing
     }

--- a/src/CRM/CivixBundle/Builder/XML.php
+++ b/src/CRM/CivixBundle/Builder/XML.php
@@ -59,7 +59,7 @@ class XML implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write " . $this->path . "</info>");
+    $output->writeln("<info>Write</info> " . $this->path);
 
     // force pretty printing with encode/decode cycle
     $outXML = $this->get()->saveXML();

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -73,7 +73,7 @@ abstract class AbstractAddPageCommand extends Command {
     }
 
     if (!file_exists($phpFile)) {
-      $output->writeln(sprintf('<info>Write %s</info>', $phpFile));
+      $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
       file_put_contents($phpFile, Services::templating()
         ->render($this->getPhpTemplate($input), $ctx));
     }
@@ -82,7 +82,7 @@ abstract class AbstractAddPageCommand extends Command {
     }
 
     if (!file_exists($tplFile)) {
-      $output->writeln(sprintf('<info>Write %s</info>', $tplFile));
+      $output->writeln(sprintf('<info>Write</info> %s', $tplFile));
       file_put_contents($tplFile, Services::templating()
         ->render($this->getTplTemplate($input), $ctx));
     }

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -5,7 +5,6 @@ use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
@@ -15,6 +14,7 @@ use CRM\CivixBundle\Utils\Path;
 use Exception;
 
 abstract class AbstractAddPageCommand extends Command {
+
   protected function configure() {
     $this
       ->addArgument('<ClassName>', InputArgument::REQUIRED, 'Base name of the controller class name (eg "MyPage")')

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -4,13 +4,13 @@ namespace CRM\CivixBundle\Command;
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractCommand extends Command {
+
   protected function configure() {
     $this->addOption('yes', NULL, InputOption::VALUE_NONE, 'Answer yes to any questions');
   }

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -1,6 +1,8 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
+use CRM\CivixBundle\Builder\Info;
+use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,6 +26,17 @@ abstract class AbstractCommand extends Command {
     $helper = $this->getHelper('question');
     $question = new ConfirmationQuestion($message, $default);
     return (bool) $helper->ask($input, $output, $question);
+  }
+
+  protected function getModuleInfo(&$ctx): Info {
+    $basedir = new Path(\CRM\CivixBundle\Application::findExtDir());
+    $info = new Info($basedir->string('info.xml'));
+    $info->load($ctx);
+    $attrs = $info->get()->attributes();
+    if ($attrs['type'] != 'module') {
+      throw new \RuntimeException('Wrong extension type: ' . $attrs['type']);
+    }
+    return $info;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -65,7 +65,7 @@ For more, see https://docs.angularjs.org/guide/directive');
     $ctx['htmlPath'] = $basedir->string('ang', $ctx['angularModuleName'], $ctx['baseFileName'] . '.html');
 
     //// Construct files ////
-    $output->writeln("<info>Initialize Angular directive \"" . $ctx['dirNameHyp'] . "\" (aka \"" . $ctx['dirNameCamel'] . "\")</info>");
+    $output->writeln("<info>Initialize Angular directive</info> " . $ctx['dirNameHyp'] . " <info>(aka </info>" . $ctx['dirNameCamel'] . "<info>)</info>");
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -12,9 +12,10 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
-class AddAngularDirectiveCommand extends \Symfony\Component\Console\Command\Command {
+class AddAngularDirectiveCommand extends AbstractCommand {
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:angular-directive')
       ->setDescription('Add a new Angular directive (Civi v4.6+)')

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -43,7 +43,7 @@ class AddAngularModuleCommand extends AbstractCommand {
     $ctx['angularModuleCss'] = $basedir->string('ang', $ctx['angularModuleName'] . '.css');
 
     //// Construct files ////
-    $output->writeln("<info>Initialize Angular module \"" . $ctx['angularModuleName'] . "\"</info>");
+    $output->writeln("<info>Initialize Angular module</info> " . $ctx['angularModuleName']);
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -12,9 +12,10 @@ use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
-class AddAngularModuleCommand extends \Symfony\Component\Console\Command\Command {
+class AddAngularModuleCommand extends AbstractCommand {
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:angular-module')
       ->setDescription('Add a new Angular module (Civi v4.6+)')

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -12,9 +12,10 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
-class AddAngularPageCommand extends \Symfony\Component\Console\Command\Command {
+class AddAngularPageCommand extends AbstractCommand {
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:angular-page')
       ->setDescription('Add a new Angular page (Civi v4.6+)')

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -64,7 +64,7 @@ For more, see https://docs.angularjs.org/guide');
     $ctx['hlpPath'] = $basedir->string('templates', $ctx['hlpName'] . '.hlp');
 
     //// Construct files ////
-    $output->writeln("<info>Initialize Angular page \"" . $ctx['ctrlName'] . "\" (civicrm/a/#/" . $ctx['ctrlRelPath'] . ")</info>");
+    $output->writeln("<info>Initialize Angular page</info> " . $ctx['ctrlName'] . " <info>(</info>civicrm/a/#/" . $ctx['ctrlRelPath'] . "<info>)</info>");
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -108,7 +108,7 @@ action names.
     $dirs->save($ctx, $output);
 
     if (!file_exists($ctx['apiFile'])) {
-      $output->writeln(sprintf('<info>Write %s</info>', $ctx['apiFile']));
+      $output->writeln(sprintf('<info>Write</info> %s', $ctx['apiFile']));
       file_put_contents($ctx['apiFile'], Services::templating()
         ->render('api.php.php', $ctx));
     }
@@ -151,7 +151,7 @@ action names.
     ]);
     $test_dirs->save($ctx, $output);
     if (!file_exists($ctx['apiTestFile'])) {
-      $output->writeln(sprintf('<info>Write %s</info>', $ctx['apiTestFile']));
+      $output->writeln(sprintf('<info>Write</info> %s', $ctx['apiTestFile']));
       file_put_contents($ctx['apiTestFile'], Services::templating()
         ->render('test-api.php.php', $ctx));
     }

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -12,8 +12,9 @@ use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
 
-class AddCaseTypeCommand extends \Symfony\Component\Console\Command\Command {
+class AddCaseTypeCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:case-type')
       ->setDescription('Add a CiviCase case-type')

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -4,7 +4,6 @@ namespace CRM\CivixBundle\Command;
 use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
@@ -13,6 +12,7 @@ use CRM\CivixBundle\Utils\Path;
 use Exception;
 
 class AddCaseTypeCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/AddCodeceptionConfigCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCodeceptionConfigCommand.php
@@ -14,9 +14,10 @@ use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
  *
  * @package CRM\CivixBundle\Command
  */
-class AddCodeceptionConfigCommand extends \Symfony\Component\Console\Command\Command {
+class AddCodeceptionConfigCommand extends AbstractCommand {
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:codeception-config')
       ->setDescription('Add a new End-to-end Configuration for codeception to a CiviCRM Module-Extension')

--- a/src/CRM/CivixBundle/Command/AddCodeceptionConfigCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCodeceptionConfigCommand.php
@@ -1,13 +1,11 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Filesystem\Exception\IOExceptionInterface;
 
 /**
  * Class AddCodeceptionConfigCommand

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -11,8 +11,9 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\CustomDataXML;
 use CRM\CivixBundle\Utils\Path;
 
-class AddCustomDataCommand extends \Symfony\Component\Console\Command\Command {
+class AddCustomDataCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:custom-xml')
       ->setDescription('Export custom data and profiles to an XML file')

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -12,6 +12,7 @@ use CRM\CivixBundle\Builder\CustomDataXML;
 use CRM\CivixBundle\Utils\Path;
 
 class AddCustomDataCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -9,10 +9,11 @@ use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
 
-class AddEntityBoilerplateCommand extends \Symfony\Component\Console\Command\Command {
+class AddEntityBoilerplateCommand extends AbstractCommand {
   const API_VERSION = 3;
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:entity-boilerplate')
       ->setDescription('Generates boilerplate code for entities based on xml schema definition files (*EXPERIMENTAL AND INCOMPLETE*)')

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -103,7 +103,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       $dao->run();
       ob_end_clean();
       $daoFileName = $basedir->string("{$table['base']}{$table['fileName']}");
-      $output->writeln("<info>Write $daoFileName</info>");
+      $output->writeln("<info>Write</info> $daoFileName");
     }
 
     $schema = new \CRM_Core_CodeGen_Schema($config);
@@ -120,7 +120,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       // We're poking into an internal class+function (`$schema->$generator()`) that changed in v5.23.
       // Beginning in 5.23: $schema->$function() returns an array with file content.
       // Before 5.23: $schema->$function($fileName) creates $fileName and returns void.
-      $output->writeln("<info>Write {$filePath}</info>");
+      $output->writeln("<info>Write</info> $filePath");
       if (version_compare(\CRM_Utils_System::version(), '5.23.alpha1', '>=')) {
         $data = $schema->$generator();
         if (!file_put_contents($filePath, reset($data))) {

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -17,10 +17,11 @@ use CRM\CivixBundle\Utils\Naming;
 
 use Exception;
 
-class AddEntityCommand extends \Symfony\Component\Console\Command\Command {
+class AddEntityCommand extends AbstractCommand {
   const API_VERSION = 3;
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:entity')
       ->setDescription('Add a new API/BAO/GenCode entity to a CiviCRM Module-Extension (*EXPERIMENTAL*)')

--- a/src/CRM/CivixBundle/Command/AddFormCommand.php
+++ b/src/CRM/CivixBundle/Command/AddFormCommand.php
@@ -1,8 +1,10 @@
 <?php
 namespace CRM\CivixBundle\Command;
+
 use Symfony\Component\Console\Input\InputInterface;
 
 class AddFormCommand extends AbstractAddPageCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/AddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddPageCommand.php
@@ -1,8 +1,10 @@
 <?php
 namespace CRM\CivixBundle\Command;
+
 use Symfony\Component\Console\Input\InputInterface;
 
 class AddPageCommand extends AbstractAddPageCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -15,8 +15,9 @@ use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
-class AddReportCommand extends \Symfony\Component\Console\Command\Command {
+class AddReportCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:report')
       ->setDescription('Add a report to a module-extension')

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -16,6 +16,7 @@ use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
 class AddReportCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -49,7 +49,7 @@ class AddSearchCommand extends AbstractCommand {
     $ctx['searchTplFile'] = $basedir->string('templates', $ctx['searchTplRelFile']);
 
     //// Construct files ////
-    $output->writeln("<info>Initialize search " . $ctx['searchClassName'] . "</info>");
+    $output->writeln("<info>Initialize search</info> " . $ctx['searchClassName']);
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -15,10 +15,11 @@ use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
-class AddSearchCommand extends \Symfony\Component\Console\Command\Command {
+class AddSearchCommand extends AbstractCommand {
   const GENERIC_SEARCH_TEMPLATE = 'CRM/Contact/Form/Search/Custom.tpl';
 
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:search')
       ->setDescription('Add a custom search to a module-extension')

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -12,8 +12,9 @@ use CRM\CivixBundle\Utils\Path;
 use CRM\CivixBundle\Builder\PHPUnitGenerateInitFiles;
 use Exception;
 
-class AddTestCommand extends \Symfony\Component\Console\Command\Command {
+class AddTestCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:test')
       ->setDescription('Add a new PHPUnit test to a CiviCRM Module-Extension')

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -117,7 +117,7 @@ as separate groups:
     $dirs->save($ctx, $output);
 
     if (!file_exists($testPath)) {
-      $output->writeln(sprintf('<info>Write %s</info>', $testPath));
+      $output->writeln(sprintf('<info>Write</info> %s', $testPath));
       file_put_contents($testPath, Services::templating()
         ->render($templateName, $ctx));
     }

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -13,6 +13,7 @@ use CRM\CivixBundle\Builder\PHPUnitGenerateInitFiles;
 use Exception;
 
 class AddTestCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this
@@ -90,7 +91,7 @@ as separate groups:
   /**
    * @param string $fullClassName
    * @param string $templateName
-   * @param Path $basedir
+   * @param \CRM\CivixBundle\Utils\Path $basedir
    * @param array $ctx
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @throws \Exception

--- a/src/CRM/CivixBundle/Command/AddThemeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddThemeCommand.php
@@ -69,7 +69,7 @@ $ civix generate:theme foobar
     $ctx['themeBootstrapCss'] = $ctx['themePrefixDir']->string('css', 'bootstrap.css');
 
     //// Construct files ////
-    $output->writeln("<info>Initialize theme \"" . $ctx['themeName'] . "\"</info>");
+    $output->writeln("<info>Initialize theme</info> " . $ctx['themeName']);
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddThemeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddThemeCommand.php
@@ -5,7 +5,6 @@ use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Collection;
 use CRM\CivixBundle\Builder\Dirs;
@@ -13,7 +12,6 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Utils\Path;
-use Exception;
 
 class AddThemeCommand extends Command {
 

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -44,7 +44,7 @@ class AddUpgraderCommand extends AbstractCommand {
 
     $phpFile = $basedir->string($ctx['namespace'], 'Upgrader.php');
     if (!file_exists($phpFile)) {
-      $output->writeln(sprintf('<info>Write %s</info>', $phpFile));
+      $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
       file_put_contents($phpFile, Services::templating()
         ->render('upgrader.php.php', $ctx));
     }
@@ -53,7 +53,7 @@ class AddUpgraderCommand extends AbstractCommand {
     }
 
     $phpFile = $basedir->string($ctx['namespace'], 'Upgrader', 'Base.php');
-    $output->writeln(sprintf('<info>Write %s</info>', $phpFile));
+    $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
     file_put_contents($phpFile, Services::templating()
       ->render('upgrader-base.php.php', $ctx));
 

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -11,8 +11,9 @@ use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
 
-class AddUpgraderCommand extends \Symfony\Component\Console\Command\Command {
+class AddUpgraderCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('generate:upgrader')
       ->setDescription('Add an example upgrader class to a CiviCRM Module-Extension');

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -9,9 +9,9 @@ use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;
-use Exception;
 
 class AddUpgraderCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -8,8 +8,9 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
 
-class BuildCommand extends \Symfony\Component\Console\Command\Command {
+class BuildCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('build:zip')
       ->setDescription('Build a zip file for a CiviCRM Extension');

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -6,9 +6,9 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Utils\Path;
-use Exception;
 
 class BuildCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -7,6 +7,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class ConfigGetCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -6,8 +6,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ConfigGetCommand extends \Symfony\Component\Console\Command\Command {
+class ConfigGetCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('config:get')
       ->setDescription('Get configuration values')

--- a/src/CRM/CivixBundle/Command/ConfigSetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigSetCommand.php
@@ -6,11 +6,10 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Collection;
-use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Ini;
-use CRM\CivixBundle\Utils\Path;
 
 class ConfigSetCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/ConfigSetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigSetCommand.php
@@ -10,8 +10,9 @@ use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Ini;
 use CRM\CivixBundle\Utils\Path;
 
-class ConfigSetCommand extends \Symfony\Component\Console\Command\Command {
+class ConfigSetCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('config:set')
       ->setDescription('Set configuration value')

--- a/src/CRM/CivixBundle/Command/InfoGetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoGetCommand.php
@@ -1,19 +1,12 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Command\HelpCommand;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Builder\Module;
-use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Utils\Path;
-use Exception;
 
 class InfoGetCommand extends Command {
 
@@ -59,7 +52,8 @@ Common fields:\n * " . implode("\n * ", $fields) . "\n");
     if (is_null($xpath)) {
       // missing xpath value so provide help
       $help = $this->getApplication()->get('help');
-      $help->setCommand($this); // tell help to provide specific help for this function
+      // tell help to provide specific help for this function
+      $help->setCommand($this);
       return $help->run($input, $output);
     }
     foreach ($info->get()->xpath($xpath) as $node) {

--- a/src/CRM/CivixBundle/Command/InfoSetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoSetCommand.php
@@ -1,18 +1,12 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Builder\Module;
-use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Utils\Path;
-use Exception;
 
 class InfoSetCommand extends Command {
 

--- a/src/CRM/CivixBundle/Command/PingCommand.php
+++ b/src/CRM/CivixBundle/Command/PingCommand.php
@@ -5,8 +5,9 @@ use CRM\CivixBundle\Services;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class PingCommand extends \Symfony\Component\Console\Command\Command {
+class PingCommand extends AbstractCommand {
   protected function configure() {
+    parent::configure();
     $this
       ->setName('civicrm:ping')
       ->setDescription('Test whether the CiviCRM client is properly configured');

--- a/src/CRM/CivixBundle/Command/PingCommand.php
+++ b/src/CRM/CivixBundle/Command/PingCommand.php
@@ -6,6 +6,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class PingCommand extends AbstractCommand {
+
   protected function configure() {
     parent::configure();
     $this

--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -135,7 +135,8 @@ class TestRunCommand extends Command {
    */
   protected static function createPhpShellCommand($script) {
     $php = escapeshellcmd(self::getPhp());
-    $args = func_get_args(); // get $script and any others
+    // get $script and any others
+    $args = func_get_args();
     $escArgs = array_map('escapeshellarg', $args);
     $cmd = $php . ' ' . implode(' ', $escArgs);
     return $cmd;
@@ -173,6 +174,7 @@ class TestRunCommand extends Command {
    * Find (or auto-create) a PHP file with information for bootstrapping the test environment
    *
    * @param string $key the extension for which tests will be run
+   * @param bool $clear
    * @return string temp file path
    */
   protected function getBootstrapFile($key, $clear = FALSE) {

--- a/src/CRM/CivixBundle/Utils/Functions.php
+++ b/src/CRM/CivixBundle/Utils/Functions.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+class Functions {
+
+  /**
+   * Create a "curried function" in which some arguments are pre-applied.
+   *
+   * Ex:
+   *   $sha256 = Functions::curry('hash', 'sha256');
+   *   echo $sha256('hello world');
+   *   // Equivalent to `hash('sha256', 'hello world')`
+   *
+   * @param callable $callable
+   * @param mixed ...$args1
+   * @return \Closure
+   */
+  public static function curry($callable, ...$args1) {
+    return function (...$args2) use ($callable, $args1) {
+      $allArgs = array_merge($args1, $args2);
+      return $callable(...$allArgs);
+    };
+  }
+
+}


### PR DESCRIPTION
This branch contains a hodgepodge of cleanups and refactorings. These are all tangential changes from work on integrating `mixin`. Generally changes are:

* Cleanup code style
* Use a common base-class (with some common behaviors/helpers) for most commands
* Cleanup output style / color coding