### PR TITLE
Update config function

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -94,9 +94,9 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template =& CRM_Core_Smarty::singleton();
+  $template = CRM_Core_Smarty::singleton();
 
-  $extRoot = dirname(__FILE__) . DIRECTORY_SEPARATOR;
+  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
 
   if (is_array($template->template_dir)) {


### PR DESCRIPTION
I'm getting notices about this line
```
  $template = & CRM_Core_Smarty::singleton();
```

PHP Notice:  Only variables should be assigned by reference in /srv/civi-sites/wmff/civicrm/ext/greenwich/greenwich.civix.php on line 94

__DIR__ is just a teensy bit shorter / more readable