### PR TITLE
Mixins - Use `<compatibility>` to enable/disable backporting

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,24 @@ $ php -dphar.readonly=0 /usr/local/bin/box build
 
 ### Development: Testing
 
-There isn't a proper test-suite, but the script `tests/make-example.sh` will
-run all the code-generators (with a given build/version of CiviCRM).  It's
-not pretty, though -- it assumes you're using buildkit and Drupal
-single-site.
+Automated testing for `civix` requires a live CiviCRM deployment. The deployment must be amenable to CLI scripting (eg `civix`, `cv`).
 
+Tests are divided into three areas:
+
+* PHPUnit: End-to-end tests (`tests/e2e/**Test.php`)
+* PHPUnit: Unit tests (`src/CRM/CivixBundle/**Test.php`)
+* Bash: Example script (`tests/make-example.sh`) which runs all code-generators
+
+PHPUnit is now preferred for testing (because it can support better assertions, better debugging, and better coding).
+To run PHPUnit, one must define a folder (`CIVIX_WORKSPACE`) where it will place new/sample extensions. Example:
+
+```bash
+export CIVIX_WORKSPACE=$HOME/bknix/build/dmaster/web/sites/all/modules/civicrm/ext/civixtest
+phpunit8
+```
+
+The bash script (`make-example.sh`) has been around longer and covers more functionality, but the assertions are limited,
+and effective usage may require more effort. Example:
 
 ```bash
 ## Usage: tests/make-example.sh <BUILDKIT_ROOT> <BUILDKIT_BUILD>

--- a/box.json
+++ b/box.json
@@ -8,6 +8,10 @@
     ],
     "finder": [
         {
+            "name": "mixin-backports.php",
+            "in": "."
+        },
+        {
             "name": "*.php",
             "exclude": [
               "phpunit",

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,12 @@
         }
     ],
     "extra": {
+        "compile": [
+            {
+                "title": "Download mixins (<comment>mixin-backports.php</comment>)",
+                "run": "@php-method \\CRM\\CivixBundle\\ComposerCompile::downloadMixins"
+            }
+        ],
         "downloads": {
           "bootstrap": {
               "version": "v0.3.14",
@@ -53,23 +59,6 @@
               "version": "5.45",
               "url": "https://raw.githubusercontent.com/civicrm/civicrm-core/{$version}/tools/mixin/src/Mixlib.php",
               "path": "extern/src/Mixlib.php",
-              "type": "file"
-          },
-          "polyfill": {
-              "version": "5.45",
-              "url": "https://raw.githubusercontent.com/civicrm/civicrm-core/{$version}/mixin/polyfill.php",
-              "path": "extern/mixin/polyfill.php",
-              "type": "file"
-          },
-          "ang-php@1": {"version": "5.45"},
-          "case-xml@1": {"version": "5.45"},
-          "menu-xml@1": {"version": "5.45"},
-          "mgd-php@1": {"version": "5.45"},
-          "setting-php@1": {"version": "5.45"},
-          "theme-php@1": {"version": "5.45"},
-          "*": {
-              "path": "extern/mixin/{$id}/mixin.php",
-              "url": "https://raw.githubusercontent.com/civicrm/civicrm-core/{$version}/mixin/{$id}/mixin.php",
               "type": "file"
           }
         }

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "homepage": "https://github.com/totten/civix",
     "license": "AGPL-3.0",
     "require": {
-        "php": ">=7.1.3",
+        "php": ">=7.2.0",
+        "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
         "symfony/console": "^4|^5",
         "symfony/filesystem": "^4|^5",
@@ -25,8 +26,12 @@
         "bin/civix"
     ],
     "config": {
+        "allow-plugins": {
+          "civicrm/composer-compile-plugin": true,
+          "civicrm/composer-downloads-plugin": true
+        },
         "platform": {
-          "php": "7.1.3"
+          "php": "7.2.0"
         },
         "bin-dir": "bin"
     },

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,8 @@
         "symfony/templating": "^4|^5",
         "symfony/var-dumper": "^4|^5",
         "symfony/var-exporter": "^4.4|^5",
-        "totten/license-data": "dev-master"
+        "totten/license-data": "dev-master",
+        "totten/process-helper": "^1.0.1"
     },
     "autoload": {
         "psr-0": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b32ec3c357e14e10a44f162544ee6fa",
+    "content-hash": "14d309f3d68bea8e3bd89dfe8aea27db",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -1216,6 +1216,46 @@
                 "source": "https://github.com/totten/Lurker/tree/1.3.0"
             },
             "time": "2020-09-01T10:01:01+00:00"
+        },
+        {
+            "name": "totten/process-helper",
+            "version": "v1.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/totten/process-helper.git",
+                "reference": "4cd78744c60ca8fff3a1a1e453e53a8e099d9c4e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/totten/process-helper/zipball/4cd78744c60ca8fff3a1a1e453e53a8e099d9c4e",
+                "reference": "4cd78744c60ca8fff3a1a1e453e53a8e099d9c4e",
+                "shasum": ""
+            },
+            "require": {
+                "symfony/process": "^2.0 || ^3.0 || ^4.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ProcessHelper\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "Some quick sugar for working with Symfony Process",
+            "support": {
+                "issues": "https://github.com/totten/process-helper/issues",
+                "source": "https://github.com/totten/process-helper/tree/v1.0.1"
+            },
+            "time": "2019-08-09T07:44:46+00:00"
         }
     ],
     "packages-dev": [],

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,57 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "65c084d16330e9b12d5e2402212e90ee",
+    "content-hash": "0b32ec3c357e14e10a44f162544ee6fa",
     "packages": [
+        {
+            "name": "civicrm/composer-compile-plugin",
+            "version": "v0.18",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/composer-compile-plugin.git",
+                "reference": "158be6061320c2f481e1aa8f821be5c7e0eea220"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/composer-compile-plugin/zipball/158be6061320c2f481e1aa8f821be5c7e0eea220",
+                "reference": "158be6061320c2f481e1aa8f821be5c7e0eea220",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": ">=7.2",
+                "totten/lurkerlite": "^1.3"
+            },
+            "require-dev": {
+                "composer/composer": "~1.0",
+                "totten/process-helper": "^1.0.1"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Civi\\CompilePlugin\\CompilePlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Civi\\CompilePlugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Otten",
+                    "email": "info@civicrm.org"
+                }
+            ],
+            "description": "Define a 'compile' event for all packages in the dependency-graph",
+            "support": {
+                "issues": "https://github.com/civicrm/composer-compile-plugin/issues",
+                "source": "https://github.com/civicrm/composer-compile-plugin/tree/v0.18"
+            },
+            "time": "2022-04-01T08:01:29+00:00"
+        },
         {
             "name": "civicrm/composer-downloads-plugin",
             "version": "v3.0.1",
@@ -1104,6 +1153,69 @@
                 "source": "https://github.com/totten/license-data/tree/master"
             },
             "time": "2015-08-18T16:41:33+00:00"
+        },
+        {
+            "name": "totten/lurkerlite",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/totten/Lurker.git",
+                "reference": "a20c47142b486415b9117c76aa4c2117ff95b49a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/totten/Lurker/zipball/a20c47142b486415b9117c76aa4c2117ff95b49a",
+                "reference": "a20c47142b486415b9117c76aa4c2117ff95b49a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "replace": {
+                "henrikbjorn/lurker": "*"
+            },
+            "suggest": {
+                "ext-inotify": ">=0.1.6"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Lurker": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Konstantin Kudryashov",
+                    "email": "ever.zet@gmail.com"
+                },
+                {
+                    "name": "Yaroslav Kiliba",
+                    "email": "om.dattaya@gmail.com"
+                },
+                {
+                    "name": "Henrik Bjrnskov",
+                    "email": "henrik@bjrnskov.dk"
+                }
+            ],
+            "description": "Resource Watcher - Lightweight edition of henrikbjorn/lurker with no dependencies",
+            "keywords": [
+                "filesystem",
+                "resource",
+                "watching"
+            ],
+            "support": {
+                "source": "https://github.com/totten/Lurker/tree/1.3.0"
+            },
+            "time": "2020-09-01T10:01:01+00:00"
         }
     ],
     "packages-dev": [],
@@ -1115,11 +1227,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.1.3"
+        "php": ">=7.2.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.3"
+        "php": "7.2.0"
     },
     "plugin-api-version": "2.1.0"
 }

--- a/mixin-backports.php
+++ b/mixin-backports.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ * Mirror a select list of backports from `civicrm-core:mixin/`.
+ */
+return [
+  'polyfill' => [
+    'sha256' => '5377fc936628875cec195737ccc22d5b8c72ed562d2aef460f9dc07dbe773613',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/polyfill.php',
+    'local' => 'extern/mixin/polyfill.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'ang-php@1' => [
+    'version' => '1.0.0',
+    'sha256' => '7dc91fab620fc6ba74a5a00347a2d8f39846c97c8cf20cf4291a1002d3d9c245',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/ang-php@1/mixin.php',
+    'local' => 'extern/mixin/ang-php@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'case-xml@1' => [
+    'version' => '1.0.0',
+    'sha256' => '23a4f7d128b286c79acf20598a9017a0fac213115a64504d8f84c2096ce1f490',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/case-xml@1/mixin.php',
+    'local' => 'extern/mixin/case-xml@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'menu-xml@1' => [
+    'version' => '1.0.0',
+    'sha256' => '4f5be44d6764816b22d0a5cdc2e047cfd9ec4acf48e548f82bb20c05db933d0e',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/menu-xml@1/mixin.php',
+    'local' => 'extern/mixin/menu-xml@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'mgd-php@1' => [
+    'version' => '1.0.0',
+    'sha256' => '458fef1ae4b649bae7826bfc9f3b7d55c6a3f577d2eae4cbc1c520c48d6d4d7d',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/mgd-php@1/mixin.php',
+    'local' => 'extern/mixin/mgd-php@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'setting-php@1' => [
+    'version' => '1.0.0',
+    'sha256' => '5ce236c1a1a63637ce5f0f4fe5bf7f21eaa06c750ca16c0fbf4dd792da0d23c9',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/setting-php@1/mixin.php',
+    'local' => 'extern/mixin/setting-php@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+  'theme-php@1' => [
+    'version' => '1.0.0',
+    'sha256' => '2d4bd2442fde152c8f31805ac265c2249d5cf771185f1ac870fd1fcbb18db3ed',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/theme-php@1/mixin.php',
+    'local' => 'extern/mixin/theme-php@1/mixin.php',
+    'provided-by' => '5.45.beta1',
+  ],
+];

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,8 +10,11 @@
          cacheResult="false"
 >
   <testsuites>
-    <testsuite name="Civix Test Suite">
+    <testsuite name="unit">
       <directory>./src/</directory>
+    </testsuite>
+    <testsuite name="e2e">
+      <directory>./tests/e2e/</directory>
     </testsuite>
   </testsuites>
 

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -39,7 +39,7 @@ class Info extends XML {
     $xml->addChild('releaseDate', date('Y-m-d'));
     $xml->addChild('version', '1.0');
     $xml->addChild('develStage', 'alpha');
-    $xml->addChild('compatibility')->addChild('ver', '5.0');
+    $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin'] ?? '5.0');
     $xml->addChild('comments', 'This is a new, undeveloped module');
 
     // APIv4 will look for classes+files matching 'Civi/Api4', and
@@ -83,6 +83,8 @@ class Info extends XML {
     $ctx['angularModuleName'] = !empty($angularModule) ? $angularModule : $ctx['mainFile'];
     $items = $this->get()->xpath('civix/format');
     $ctx['civixFormat'] = (string) array_shift($items);
+    $ctx['compatibilityVerMin'] = $this->getCompatibilityVer('MIN');
+    $ctx['compatibilityVerMax'] = $this->getCompatibilityVer('MAX');
   }
 
   /**

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -138,4 +138,31 @@ class Info extends XML {
     }
   }
 
+  /**
+   * Determine the target version of CiviCRM.
+   *
+   * @param string $mode
+   *   The `info.xml` file may list multiple `<ver>` tags, and we will only return one.
+   *   Either return the lowest-compatible `<ver>` ('MIN') or the highest-compatible `<ver>` ('MAX').
+   * @return string|null
+   */
+  public function getCompatibilityVer(string $mode = 'MIN'): ?string {
+    $vers = [];
+    foreach ($this->get()->xpath('compatibility/ver') as $ver) {
+      $vers[] = (string) $ver;
+    }
+    usort($vers, 'version_compare');
+
+    switch ($mode) {
+      case 'MIN':
+        return $vers ? reset($vers) : NULL;
+
+      case 'MAX':
+        return $vers ? end($vers) : NULL;
+
+      default:
+        throw new \RuntimeException("getCompatilityVer($mode): Unrecognized mode");
+    }
+  }
+
 }

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -158,11 +158,9 @@ class Mixins implements Builder {
       $file = $this->outputDir . '/' . $extra . $fileExt;
       $backportInfo = $this->getBackportInfo($extra);
       if ($this->isProvidedByCore($extra)) {
-        $output->writeln("<error>Extra backport: \"$extra\" is already included with civicrm-core ({$backportInfo['provided-by']} >= {$this->info->getCompatibilityVer('MIN')}).</error>");
         $this->removeBackportFile($output, $file);
       }
       elseif ($backportInfo && !in_array($extra, $declarations)) {
-        $output->writeln("<error>Extra backport: \"$extra\" is inactive. It can be removed</error>");
         $this->removeBackportFile($output, $file);
       }
       else {

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -148,13 +148,6 @@ class Mixins implements Builder {
     $missingBackports = array_diff($expectedBackports, $existingBackports);
     $extraBackports = array_diff($existingBackports, $expectedBackports);
 
-    // print_r([
-    //   'expected' => $expectedBackports,
-    //   'existing' => $existingBackports,
-    //   'missing' => $missingBackports,
-    //   'extra' => $extraBackports,
-    // ]);
-
     foreach ($missingBackports as $mixinName) {
       $mixinSpec = Services::mixlib()->get($mixinName);
       $this->createBackportFile($output, $mixinSpec);

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -73,9 +73,10 @@ class UpgradeCommand extends AbstractCommand {
 
     $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
     $upgrader->cleanEmptyHooks();
+    $upgrader->reconcileMixins();
 
     /**
-     * @var Info $info
+     * @var \CRM\CivixBundle\Builder\Info $info
      */
     [$ctx, $info] = $this->loadCtxInfo();
     $basedir = new Path(\CRM\CivixBundle\Application::findExtDir());

--- a/src/CRM/CivixBundle/ComposerCompile.php
+++ b/src/CRM/CivixBundle/ComposerCompile.php
@@ -1,0 +1,51 @@
+<?php
+namespace CRM\CivixBundle;
+
+/**
+ * Helper methods called via `composer compile`.
+ *
+ * Note that the application is still being setup, so it may be ill-advised to use higher-level services.
+ */
+class ComposerCompile {
+
+  /**
+   * Download the mixin files
+   *
+   * Note: We want to read the list from `mixin-backports.php` because we can track extra metadata.
+   *
+   * @param array $task
+   */
+  public static function downloadMixins(array $task): void {
+    $civix = dirname(__DIR__, 3);
+    $mixinListFile = "$civix/mixin-backports.php";
+    $mixinListTimestamp = filemtime($mixinListFile);
+    $mixins = require $mixinListFile;
+    foreach ($mixins as $id => $mixin) {
+      $checksum = file_exists($mixin['local']) ? hash('sha256', file_get_contents($mixin['local'])) : '';
+
+      if (!file_exists($mixin['local']) || $checksum !== $mixin['sha256']) {
+        printf(" - Download %s\n", $mixin['local']);
+        $content = file_get_contents($mixin['remote']);
+        $contentChecksum = hash('sha256', $content);
+        if ($contentChecksum !== $mixin['sha256']) {
+          throw new \RuntimeException("Download from {$mixin['remote']} has wrong checksum. (expect={$mixin['sha256']}, actual=$contentChecksum)");
+        }
+
+        static::putFile($mixin['local'], $content);
+      }
+    }
+  }
+
+  protected static function putFile(string $path, string $content): void {
+    $outDir = dirname($path);
+    if (!is_dir($outDir)) {
+      if (!mkdir($outDir, 0777, TRUE)) {
+        throw new \RuntimeException("Failed to make dir: $outDir");
+      }
+    }
+    if (FALSE === file_put_contents($path, $content)) {
+      throw new \RuntimeException("Failed to write file: $path");
+    }
+  }
+
+}

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -1,6 +1,8 @@
 <?php
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
+$_compatibility = isset($compatibilityVerMin) ? $compatibilityVerMin : '5.0';
+$_invokePolyfill = version_compare($_compatibility, '5.45.beta1', '<') ? sprintf("  _%s_civix_mixin_polyfill();\n", $mainFile) : '';
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
@@ -82,6 +84,7 @@ class <?php echo $_namespace ?>_ExtensionUtil {
 
 use <?php echo $_namespace ?>_ExtensionUtil as E;
 
+<?php if (version_compare($_compatibility, '5.45.beta1', '<')) { ?>
 function _<?php echo $mainFile ?>_civix_mixin_polyfill() {
   if (!class_exists('CRM_Extension_MixInfo')) {
     $polyfill = __DIR__ . '/mixin/polyfill.php';
@@ -89,7 +92,7 @@ function _<?php echo $mainFile ?>_civix_mixin_polyfill() {
   }
 }
 
-
+<?php } ?>
 /**
  * (Delegated) Implements hook_civicrm_config().
  *
@@ -116,8 +119,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);
-
-  _<?php echo $mainFile ?>_civix_mixin_polyfill();
+<?php echo $_invokePolyfill; ?>
 }
 
 /**
@@ -130,7 +132,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_install() {
   if ($upgrader = _<?php echo $mainFile ?>_civix_upgrader()) {
     $upgrader->onInstall();
   }
-  _<?php echo $mainFile ?>_civix_mixin_polyfill();
+<?php echo $_invokePolyfill; ?>
 }
 
 /**
@@ -171,7 +173,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_enable() {
       $upgrader->onEnable();
     }
   }
-  _<?php echo $mainFile ?>_civix_mixin_polyfill();
+<?php echo $_invokePolyfill; ?>
 }
 
 /**

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -314,6 +314,15 @@ class Upgrader {
     });
   }
 
+  /**
+   * Ensure that the `mixin/` folder is in-sync with the current 'info.xml'.
+   */
+  public function reconcileMixins(): void {
+    $this->updateMixins(function (\CRM\CivixBundle\Builder\Mixins $mixins) {
+      // noop
+    });
+  }
+
   public function addMixins(array $mixinConstraints): void {
     $msg = count($mixinConstraints) > 1 ? 'Enable mixins' : 'Enable mixin';
     $this->io->writeln("<info>$msg</info> " . implode(', ', $mixinConstraints));

--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -34,6 +34,7 @@ class NamingTest extends \PHPUnit\Framework\TestCase {
    */
   public function testCreateShortName($name, $expectValid, $expectShort, $expectCamel) {
     if (!$expectValid) {
+      $this->assertTrue(TRUE);
       return;
     }
     $this->assertEquals($expectShort, Naming::createShortName($name));
@@ -44,6 +45,7 @@ class NamingTest extends \PHPUnit\Framework\TestCase {
    */
   public function testCreateCamelName($name, $expectValid, $expectShort, $expectCamel) {
     if (!$expectValid) {
+      $this->assertTrue(TRUE);
       return;
     }
     $this->assertEquals($expectCamel, Naming::createCamelName($name));

--- a/src/CRM/CivixBundle/Utils/Path.php
+++ b/src/CRM/CivixBundle/Utils/Path.php
@@ -8,6 +8,10 @@ class Path {
     $this->basedir = $basedir;
   }
 
+  public function __toString(): string {
+    return $this->basedir;
+  }
+
   /**
    * Determine the full path to a file underneath this path
    *

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -16,4 +16,4 @@ if (!isset($loader)) {
 }
 
 #### Extra - Register classes in "tests" directory
-$loader->add('CRM', __DIR__);
+$loader->addPsr4('E2E\\', __DIR__ . '/e2e');

--- a/tests/e2e/AddPageTest.php
+++ b/tests/e2e/AddPageTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace E2E;
+
+class AddPageTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civix_addpage';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+
+    $this->assertFileExists('info.xml');
+    $this->assertFileExists('civix_addpage.php');
+    $this->assertFileExists('civix_addpage.civix.php');
+  }
+
+  public function testAddPage() {
+    $this->assertFileNotExists('CRM/CivixAddpage/Page/MyPage.php');
+    $this->assertFileNotExists('templates/CRM/CivixAddpage/Page/MyPage.tpl');
+    $this->assertFileNotExists('xml/Menu/civix_addpage.xml');
+
+    $this->civixGeneratePage('MyPage', 'civicrm/thirty');
+
+    $this->assertFileExists('CRM/CivixAddpage/Page/MyPage.php');
+    $this->assertFileExists('templates/CRM/CivixAddpage/Page/MyPage.tpl');
+    $this->assertFileExists('xml/Menu/civix_addpage.xml');
+  }
+
+}

--- a/tests/e2e/AddPageTest.php
+++ b/tests/e2e/AddPageTest.php
@@ -14,21 +14,27 @@ class AddPageTest extends \PHPUnit\Framework\TestCase {
     $this->civixGenerateModule(static::getKey());
     chdir(static::getKey());
 
-    $this->assertFileExists('info.xml');
-    $this->assertFileExists('civix_addpage.php');
-    $this->assertFileExists('civix_addpage.civix.php');
+    $this->assertFileGlobs([
+      'info.xml' => 1,
+      'civix_addpage.php' => 1,
+      'civix_addpage.civix.php' => 1,
+    ]);
   }
 
-  public function testAddPage() {
-    $this->assertFileNotExists('CRM/CivixAddpage/Page/MyPage.php');
-    $this->assertFileNotExists('templates/CRM/CivixAddpage/Page/MyPage.tpl');
-    $this->assertFileNotExists('xml/Menu/civix_addpage.xml');
+  public function testAddPage(): void {
+    $this->assertFileGlobs([
+      'CRM/CivixAddpage/Page/MyPage.php' => 0,
+      'templates/CRM/CivixAddpage/Page/MyPage.tpl' => 0,
+      'xml/Menu/civix_addpage.xml' => 0,
+    ]);
 
     $this->civixGeneratePage('MyPage', 'civicrm/thirty');
 
-    $this->assertFileExists('CRM/CivixAddpage/Page/MyPage.php');
-    $this->assertFileExists('templates/CRM/CivixAddpage/Page/MyPage.tpl');
-    $this->assertFileExists('xml/Menu/civix_addpage.xml');
+    $this->assertFileGlobs([
+      'CRM/CivixAddpage/Page/MyPage.php' => 1,
+      'templates/CRM/CivixAddpage/Page/MyPage.tpl' => 1,
+      'xml/Menu/civix_addpage.xml' => 1,
+    ]);
   }
 
 }

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace E2E;
+
+use CRM\CivixBundle\Application;
+use CRM\CivixBundle\Upgrader;
+use CRM\CivixBundle\Utils\Path;
+use ProcessHelper\ProcessHelper as PH;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\StreamOutput;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * Add this to a test-class to define an E2E test with a new civix-style extension/project.
+ *
+ * Requirements:
+ * - The consuming class MUST define a static property `$key` with the name of the extension.
+ * - The runner MUST set an env-var CIVIX_WORKSPACE. This is a folder where extensions can be generated.
+ *
+ * Services:
+ * - The consuming class WILL (by default) inherit `setUpBeforeClass()` and `tearDownAfterClass()`.
+ * - The consuming class MAY use helpers like `getWorkspacePath()` nd `getExtPath()`
+ * - The consuming class MAY use helpers like `civixGenerateModule()`, `civixGeneratePage()`, `civix($cmd)`, etc.
+ */
+trait CivixProjectTestTrait {
+
+  /**
+   * @var string
+   */
+  private static $origDir;
+
+  public static function getKey(): string {
+    if (!property_exists(static::class, 'key')) {
+      throw new \RuntimeException(sprintf("Class %s does not have property \$key"));
+    }
+    return static::$key;
+  }
+
+  public static function setUpBeforeClass(): void {
+    static::assertValidSetup();
+    static::$origDir = getcwd();
+  }
+
+  public static function tearDownAfterClass(): void {
+    chdir(static::$origDir);
+    self::$origDir = NULL;
+  }
+
+  public static function assertValidSetup() {
+    if (!property_exists(static::class, 'key')) {
+      throw new \RuntimeException(sprintf("Class %s does not have property \$longName"));
+    }
+
+    if (empty(getenv('CIVIX_WORKSPACE'))) {
+      throw new \RuntimeException('Undefined variable: CIVIX_WORKSPACE');
+    }
+
+    static::getWorkspacePath()->mkdir();
+  }
+
+  public static function getWorkspacePath(...$subpath): Path {
+    $path = new Path(getenv('CIVIX_WORKSPACE'));
+    return empty($subpath) ? $path : $path->path(...$subpath);
+  }
+
+  public static function getExtPath(...$subpath): Path {
+    array_unshift($subpath, static::getKey());
+    return static::getWorkspacePath(...$subpath);
+  }
+
+  public static function civix(string $command): CommandTester {
+    $application = new Application();
+    $command = $application->find($command);
+    return new CommandTester($command);
+  }
+
+  public function civixGenerateModule(string $key): CommandTester {
+    $tester = static::civix('generate:module');
+    $tester->execute([
+      'key' => $key,
+      '--enable' => 'false',
+    ]);
+    if ($tester->getStatusCode() !== 0) {
+      throw new \RuntimeException(sprintf("Failed to generate module (%s)", $key));
+    }
+    return $tester;
+  }
+
+  public function civixGeneratePage(string $className, string $webPath): CommandTester {
+    $tester = static::civix('generate:page');
+    $tester->execute([
+      '<ClassName>' => $className,
+      '<web/path>' => $webPath,
+    ]);
+    if ($tester->getStatusCode() !== 0) {
+      throw new \RuntimeException(sprintf("Failed to generate module (%s)", static::getKey()));
+    }
+    return $tester;
+  }
+
+  /**
+   * Update the "info.xml" by calling "civix info:set"
+   *
+   * @param string $xpath
+   * @param string $value
+   */
+  public function civixInfoSet(string $xpath, string $value): CommandTester {
+    $tester = static::civix('info:set');
+    $tester->execute([
+      '--xpath' => $xpath,
+      '--to' => $value,
+    ]);
+    if ($tester->getStatusCode() !== 0) {
+      throw new \RuntimeException(sprintf("Failed to set \"%s\" to \"%s\"", $xpath, $value));
+    }
+    return $tester;
+  }
+
+  public function civixUpgradeHelper(): Upgrader {
+    $input = new ArrayInput([]);
+    $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
+    return new Upgrader($input, $output, static::getExtPath());
+  }
+
+  /**
+   * If a directory exists, remove it.
+   *
+   * @param string $dir
+   */
+  protected static function cleanDir($dir): void {
+    PH::runOk(['if [ -d @DIR ]; then rm -rf @DIR ; fi', 'DIR' => $dir]);
+  }
+
+  protected function assertFileGlobs(array $globs): void {
+    $globs = (array) $globs;
+    $errors = [];
+    foreach ($globs as $glob => $expectMatches) {
+      $matches = (array) glob($glob);
+      if ($expectMatches === TRUE && empty($matches)) {
+        $errors[$glob] = "Expected matches for \"$glob\", but none were found.";
+      }
+      if ($expectMatches === FALSE && !empty($matches)) {
+        $errors[$glob] = "Unexpected matches for \"$glob\": " . implode(' ', $matches);
+      }
+      if (is_int($expectMatches)) {
+        $countMatches = count($matches);
+        if ($countMatches != $expectMatches) {
+          $errors[$glob] = "Expected to find {$expectMatches} matches for \"$glob\". Found  {$countMatches} matches (" . implode(' ', $matches) . ")";
+        }
+      }
+    }
+    $this->assertEquals([], $errors);
+  }
+
+}

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -46,7 +46,7 @@ trait CivixProjectTestTrait {
     self::$origDir = NULL;
   }
 
-  public static function assertValidSetup() {
+  public static function assertValidSetup(): void {
     if (!property_exists(static::class, 'key')) {
       throw new \RuntimeException(sprintf("Class %s does not have property \$longName"));
     }

--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -58,6 +58,9 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
       'mixin/polyfill.php' => 1,
       'mixin/menu-xml@1.*.*.mixin.php' => 1,
     ]);
+    $content = file_get_contents('civix_mixinrec.civix.php');
+    $this->assertRegExp('|function _civix_mixinrec_civix_mixin_polyfill\(\) \{|', $content);
+    $this->assertRegExp('|_civix_mixinrec_civix_mixin_polyfill\(\);|', $content);
   }
 
   public function testAddPageFor545() {
@@ -77,6 +80,10 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
       'mixin/setting-php@1.*.*.mixin.php' => 0,
       'mixin/menu-xml@1.*.*.mixin.php' => 0,
     ]);
+
+    $content = file_get_contents('civix_mixinrec.civix.php');
+    $this->assertNotRegExp('|function _civix_mixinrec_civix_mixin_polyfill\(\) \{|', $content);
+    $this->assertNotRegExp('|_civix_mixinrec_civix_mixin_polyfill\(\);|', $content);
   }
 
 }

--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace E2E;
+
+class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civix_mixinrec';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+
+    $this->assertFileExists('info.xml');
+  }
+
+  public function testDefaultMixins() {
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+      'mixin/case-xml@1.*.*.mixin.php' => 0,
+      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+      'mixin/mgd-php@1.*.*.mixin.php' => 0,
+    ]);
+  }
+
+  public function testChangeCompatibility() {
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+    ]);
+
+    $this->civixInfoSet('compatibility/ver', '5.45');
+    $upgrade = $this->civix('upgrade');
+    $this->assertEquals(0, $upgrade->execute([]));
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 0,
+      'mixin/setting-php@1.*.*.mixin.php' => 0,
+    ]);
+  }
+
+  public function testAddPageFor530() {
+    $this->civixInfoSet('compatibility/ver', '5.30');
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    ]);
+
+    $this->civixGeneratePage('Thirty', 'civicrm/thirty');
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/menu-xml@1.*.*.mixin.php' => 1,
+    ]);
+  }
+
+  public function testAddPageFor545() {
+    $this->civixInfoSet('compatibility/ver', '5.45');
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    ]);
+
+    $this->civixGeneratePage('FortyFive', 'civicrm/forty-five');
+
+    // Not only do we omit 'menu-xml' backport... but we also clean-up the extras...
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 0,
+      'mixin/setting-php@1.*.*.mixin.php' => 0,
+      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    ]);
+  }
+
+}

--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -17,7 +17,7 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
     $this->assertFileExists('info.xml');
   }
 
-  public function testDefaultMixins() {
+  public function testDefaultMixins(): void {
     $this->assertFileGlobs([
       'mixin/polyfill.php' => 1,
       'mixin/setting-php@1.*.*.mixin.php' => 1,
@@ -27,7 +27,7 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
     ]);
   }
 
-  public function testChangeCompatibility() {
+  public function testChangeCompatibility(): void {
     $this->assertFileGlobs([
       'mixin/polyfill.php' => 1,
       'mixin/setting-php@1.*.*.mixin.php' => 1,
@@ -43,7 +43,7 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
     ]);
   }
 
-  public function testAddPageFor530() {
+  public function testAddPageFor530(): void {
     $this->civixInfoSet('compatibility/ver', '5.30');
 
     $this->assertFileGlobs([
@@ -63,7 +63,7 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
     $this->assertRegExp('|_civix_mixinrec_civix_mixin_polyfill\(\);|', $content);
   }
 
-  public function testAddPageFor545() {
+  public function testAddPageFor545(): void {
     $this->civixInfoSet('compatibility/ver', '5.45');
 
     $this->assertFileGlobs([


### PR DESCRIPTION
Overview
----------

Broadly, this is an optimization which will omit `mixin/*` files that are already in `civicrm-core`.

Before
-------

`civix` unconditionally copies any mixins that it relies into the `mixin` folder (for each extension).

But, depending on the extension's planned deployment/usage, it may not need the files.

When updating a core-ext, this feels particularly gratuitous. The same mixins are already in core... we don't need 5 more copies in the same repo...

After
-----

`mixin`s are copied conditionally. Example: `civix generate:page` requires `menu-xml@1.0.0`. This mixin was merged into `civicrm-core@5.45`. The `menu-xml` file _might_ be copied into an extension, depending:

* If the extension targets `<compatibility><ver>5.45</ver></compatibility>`, then it _does not_ need to include its own copy of `menu-xml`.
* If the extension targets `<compatibility><ver>5.30</ver></compatibility>`, then it _does need_ to include its own copy of `menu-xml`.

This notably helps core-exts. Core-exts always declare `<compatibility>` for the selfsame version.

Technical Details
-----------------

* We need extra metadata describing each mixin (ie "when was menu-xml@1.0.0 added to core?"). To accommodate more metadata, I moved the list of backports from `civix:composer.json` to `civix:mixin-backports.php`. Responsibility for executing the download shifts from `composer-downloads-plugin` to `composer-compile-plugin`.
* The functional changes are mostly driven through `CRM\CivixBundle\Builder\Mixins::save()`.
* It's a bit tiresome to test by hand, so I added an E2E test-suite. The README.md has some description of how to run this.

