### PR TITLE
Upgrade - Fix cleanup logic for a few funny edge-cases

### DIFF
--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -306,7 +306,7 @@ class Upgrader {
       $funcName = $infoXml->getFile() . "_civicrm_[a-zA-Z0-9_]+";
       $funcArgs = "\([^\)]*\)";
       $startBody = "\{[^\}]*\}"; /* For empty functions, this grabs everything. For non-empty functions, this may just grab the opening segment. */
-      $content = preg_replace_callback(";({$comment})?\s*function ({$funcName})({$funcArgs})\s*({$startBody})\n*;m", function ($m) {
+      $content = preg_replace_callback(";({$comment})?\n\s*function ({$funcName})({$funcArgs})\s*({$startBody})\n*;m", function ($m) {
         $func = $m[3];
 
         // Is our start-body basically empty (notwithstanding silly things - like `{}`, `//Comment`, and `return;`)?

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -379,18 +379,35 @@ class Upgrader {
    * @param array $lines
    * @param int $focusLine
    */
-  protected function showLine(array $lines, int $focusLine): void {
+  public function showLine(array $lines, int $focusLine): void {
     $low = max(0, $focusLine - 2);
     $high = min(count($lines), $focusLine + 2);
-    $this->showCode($lines, $low, $high, $focusLine);
+    $this->showCode($lines, $low, $high, $focusLine, $focusLine);
   }
 
-  protected function showCode(array $lines, ?int $low = NULL, ?int $high = NULL, ?int $focusLine = NULL): void {
-    $low = $low ?: 0;
-    $high = $high ?: (count($lines) - 1);
+  /**
+   * Show a chunk of code.
+   *
+   * @param array $lines
+   * @param int|null $low
+   *   The first line to show
+   * @param int|null $high
+   *   The last line to show
+   * @param int|null $focusStart
+   *   The first line to highlight (within the overall code)
+   * @param int|null $focusEnd
+   *   The last line to highlight (within the overall code).
+   */
+  public function showCode(array $lines, ?int $low = NULL, ?int $high = NULL, ?int $focusStart = NULL, ?int $focusEnd = NULL): void {
+    if ($low === NULL || $low < 0) {
+      $low = 0;
+    }
+    if ($high === NULL || $high >= count($lines)) {
+      $high = count($lines) - 1;
+    }
     for ($i = $low; $i <= $high; $i++) {
       $fmt = sprintf('% 5d', 1 + $i);
-      if ($i === $focusLine) {
+      if ($focusStart !== NULL && $focusEnd !== NULL && $i >= $focusStart && $i <= $focusEnd) {
         $this->io->write("<error>*{$fmt}: ");
         $this->io->write($lines[$i], SymfonyStyle::OUTPUT_RAW);
         $this->io->write("</error>");

--- a/src/CRM/CivixBundle/Utils/EvilEx.php
+++ b/src/CRM/CivixBundle/Utils/EvilEx.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+/**
+ * Evil Expressions: What happens when you don't import nikic/php-parser.
+ */
+class EvilEx {
+
+  /**
+   * Find a function-body, and run it through a filter.
+   *
+   * Limitation: This only matches top-level functions, where the `function x()` begins in the leftmost,
+   * and where the closing `}` is als in the leftmost, and where the body is indented.
+   *
+   * @param string $body
+   *   Full-text file.
+   * @param string $function
+   *   Name of the function to filter.
+   * @param callable $filter
+   *   Filter the function-body; return new body.
+   *   function(string $body): string
+   * @return string
+   *   Updated body.
+   */
+  public static function rewriteFunction(string $body, string $function, callable $filter): string {
+    $pattern = "/(\nfunction " . $function . "\([^{]+\)\s*{\n)((\n|  [^\n]*\n)*)(}\n)/m";
+    return preg_replace_callback($pattern,
+      function ($m) use ($filter) {
+        $body = $m[2];
+        $newBody = $filter($body);
+        return $m[1] . $newBody . $m[4];
+      },
+      $body
+    );
+  }
+
+  /**
+   * Searches for a chunk of code - and replaces it.
+   *
+   * When matching the chunk of code, it specifically ignores whitespace and blank lines.
+   *
+   * @param string $body
+   * @param array $matchChunk
+   *   A series of lines which should be found somewhere inside $body (modulo whitespace).
+   * @param callable $filterChunk
+   *   Filter the matching lines; return new lines.
+   *   function(array $matchLines): array
+   * @return string
+   *   Updated body.
+   */
+  public static function rewriteMultilineChunk(string $body, array $matchChunk, callable $filterChunk) {
+    $expectLines = EvilEx::digestLines($matchChunk);
+    $actualLines = EvilEx::digestLines(explode("\n", $body));
+    foreach (array_keys($actualLines) as $startOffset) {
+      $endOffset = NULL;
+      $expectLineNum = 0;
+      for ($actualLineNum = $startOffset; $actualLineNum < count($actualLines); $actualLineNum++) {
+        if (empty($actualLines[$actualLineNum]['dig'])) {
+          continue;
+        }
+        if ($expectLines[$expectLineNum]['dig'] !== $actualLines[$actualLineNum]['dig']) {
+          continue 2;
+        }
+        $expectLineNum++;
+        if ($expectLineNum >= count($expectLines)) {
+          $endOffset = $actualLineNum;
+          break 2;
+        }
+      }
+    }
+
+    if ($endOffset === NULL) {
+      return $body;
+    }
+
+    $rawActualLines = array_column($actualLines, 'raw');
+    $matchLines = array_slice($rawActualLines, $startOffset, $endOffset - $startOffset + 1, TRUE);
+    $newLines = $filterChunk($matchLines);
+    array_splice($rawActualLines, $startOffset, $endOffset - $startOffset + 1, $newLines);
+    return implode("\n", $rawActualLines);
+  }
+
+  public static function digestLine(string $line): string {
+    return mb_strtolower(preg_replace('/\s+/', '', $line));
+  }
+
+  public static function digestLines($lines): array {
+    $result = [];
+    foreach ($lines as $line) {
+      $result[] = ['raw' => $line, 'dig' => static::digestLine($line)];
+    }
+    return $result;
+  }
+
+}

--- a/tests/e2e/CleanEmptyTest.in.txt
+++ b/tests/e2e/CleanEmptyTest.in.txt
@@ -1,0 +1,67 @@
+<?php
+// [[ EX - Removable 1 ]]
+
+function civixcleanempty_civicrm_removeOne() {
+}
+
+// [[ EX - Keepable 1 ]]
+
+function civixcleanempty_civicrm_keepOne() {
+  stuff();
+}
+
+// [[ EX - Removable 2 ]]
+
+/**
+ *
+ */
+function civixcleanempty_civicrm_removeTwo() {
+
+}
+
+// [[ EX - Keepable 2 ]]
+
+/**
+ * @param $x
+ */
+function civixcleanempty_civicrm_keepTwo($x) {
+  stuff($x);
+}
+
+// [[ EX - Removable 3 ]]
+
+/**
+ *
+ */
+function civixcleanempty_civicrm_remove_three($x) {
+  // Do nothing
+}
+
+// [[ EX - Keepable 3 ]]
+
+function civixcleanempty_civicrm_keepThree() {
+  stuff(); // Comment
+}
+
+// [[ EX - Removable 4 ]]
+
+function civixcleanempty_civicrm_removeFour() {}
+
+// [[ EX - Keepable 4 ]]
+
+function civixcleanempty_civicrm_keepFour() {
+  foreach ($a as $b) {} x();
+}
+
+// [[ EX - Removable 5 ]]
+
+function civixcleanempty_civicrm_removeFive() { }
+
+// [[ EX - Keepable 5 ]]
+
+function civixcleanempty_civicrm_keepFive() {
+  if (FOO) {
+    x();
+  }
+  y();
+}

--- a/tests/e2e/CleanEmptyTest.in.txt
+++ b/tests/e2e/CleanEmptyTest.in.txt
@@ -1,4 +1,10 @@
 <?php
+// [[ EX - Keep pure comment ]]
+
+// function civixcleanempty_civicrm_keepPureComment() {
+// foo
+// }
+
 // [[ EX - Removable 1 ]]
 
 function civixcleanempty_civicrm_removeOne() {

--- a/tests/e2e/CleanEmptyTest.in.txt
+++ b/tests/e2e/CleanEmptyTest.in.txt
@@ -65,3 +65,22 @@ function civixcleanempty_civicrm_keepFive() {
   }
   y();
 }
+
+// [[ EX - Removable 6 ]]
+
+function civixcleanempty_civicrm_removeSix() {
+  return;
+}
+
+// [[ EX - Keepable 6 ]]
+
+function civixcleanempty_civicrm_keepSix() {
+  return;
+  $x++;
+}
+
+// [[ EX - Keepable 6a ]]
+
+function civixcleanempty_civicrm_keepSixA() {
+  return 1;
+}

--- a/tests/e2e/CleanEmptyTest.out.txt
+++ b/tests/e2e/CleanEmptyTest.out.txt
@@ -1,4 +1,10 @@
 <?php
+// [[ EX - Keep pure comment ]]
+
+// function civixcleanempty_civicrm_keepPureComment() {
+// foo
+// }
+
 // [[ EX - Removable 1 ]]
 
 // [[ EX - Keepable 1 ]]

--- a/tests/e2e/CleanEmptyTest.out.txt
+++ b/tests/e2e/CleanEmptyTest.out.txt
@@ -1,0 +1,50 @@
+<?php
+// [[ EX - Removable 1 ]]
+
+// [[ EX - Keepable 1 ]]
+
+function civixcleanempty_civicrm_keepOne() {
+  stuff();
+}
+
+// [[ EX - Removable 2 ]]
+
+
+
+// [[ EX - Keepable 2 ]]
+
+/**
+ * @param $x
+ */
+function civixcleanempty_civicrm_keepTwo($x) {
+  stuff($x);
+}
+
+// [[ EX - Removable 3 ]]
+
+
+
+// [[ EX - Keepable 3 ]]
+
+function civixcleanempty_civicrm_keepThree() {
+  stuff(); // Comment
+}
+
+// [[ EX - Removable 4 ]]
+
+// [[ EX - Keepable 4 ]]
+
+function civixcleanempty_civicrm_keepFour() {
+  foreach ($a as $b) {} x();
+}
+
+// [[ EX - Removable 5 ]]
+
+// [[ EX - Keepable 5 ]]
+
+function civixcleanempty_civicrm_keepFive() {
+  if (FOO) {
+    x();
+  }
+  y();
+}

--- a/tests/e2e/CleanEmptyTest.out.txt
+++ b/tests/e2e/CleanEmptyTest.out.txt
@@ -48,3 +48,18 @@ function civixcleanempty_civicrm_keepFive() {
   }
   y();
 }
+
+// [[ EX - Removable 6 ]]
+
+// [[ EX - Keepable 6 ]]
+
+function civixcleanempty_civicrm_keepSix() {
+  return;
+  $x++;
+}
+
+// [[ EX - Keepable 6a ]]
+
+function civixcleanempty_civicrm_keepSixA() {
+  return 1;
+}

--- a/tests/e2e/CleanEmptyTest.php
+++ b/tests/e2e/CleanEmptyTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace E2E;
+
+class CleanEmptyTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civixcleanempty';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+
+    $this->assertFileExists('info.xml');
+  }
+
+  public function testCleanup(): void {
+    $mainPhp = static::getKey() . '.php';
+    copy(__DIR__ . '/CleanEmptyTest.in.txt', $mainPhp);
+    $this->assertEquals(0, $this->civix('upgrade')->execute([]));
+    $this->assertFileEquals(__DIR__ . '/CleanEmptyTest.out.txt', $mainPhp);
+  }
+
+}

--- a/upgrades/22.05.2.up.php
+++ b/upgrades/22.05.2.up.php
@@ -1,0 +1,71 @@
+<?php
+
+use CRM\CivixBundle\Builder\Mixins;
+use CRM\CivixBundle\Utils\EvilEx;
+
+return function (\CRM\CivixBundle\Upgrader $upgrader) {
+  $mixins = new Mixins($upgrader->infoXml, $upgrader->baseDir->string('mixin'));
+  $declared = $mixins->getDeclaredMixinConstraints();
+  $hasSettingMixin = (bool) preg_grep('/^setting-php@/', $declared);
+  $action = NULL;
+
+  $upgrader->updateModulePhp(function (\CRM\CivixBundle\Builder\Info $info, string $content) use ($upgrader, $hasSettingMixin, &$action) {
+    $prefix = $upgrader->infoXml->getFile();
+    $hookFunc = "{$prefix}_civicrm_alterSettingsFolders";
+    $hookBody = [
+      'static $configured = FALSE;',
+      'if ($configured) return;',
+      '$configured = TRUE;',
+      '$extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;',
+      '$extDir = $extRoot . \'settings\';',
+      'if(!in_array($extDir, $metaDataFolders)){',
+      '  $metaDataFolders[] = $extDir;',
+      '}',
+    ];
+
+    $newContent = EvilEx::rewriteMultilineChunk($content, $hookBody, function(array $matchLines) use ($hookFunc, $content, $upgrader, $hasSettingMixin, &$action) {
+      /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+      $io = $upgrader->io;
+      $matchLineKeys = array_keys($matchLines);
+      $allLines = explode("\n", $content);
+      $focusStart = min($matchLineKeys);
+      $focusEnd = max($matchLineKeys);
+
+      $io->note("The following chunk resembles an older template for \"{$hookFunc}()\".");
+      $upgrader->showCode($allLines, $focusStart - 4, $focusEnd + 4, $focusStart, $focusEnd);
+
+      if ($hasSettingMixin) {
+        $io->note([
+          "Similar functionality is now provided by the \"setting-php\" mixin, which is already enabled.",
+        ]);
+      }
+      else {
+        $io->note([
+          "Similar functionality is now available in the \"setting-php\" mixin, which is currently disabled.",
+        ]);
+      }
+
+      $actions = [
+        'm' => 'Use the mixin ("setting-php") and remove this boilerplate.',
+        'b' => 'Use the boilerplate and disable the mixin ("setting-php").',
+        'n' => 'Do nothing. Keep as-is. (You may manually change it later.)',
+      ];
+      $action = $io->choice("What should we do?", $actions, 'm');
+      return ($action == 'm') ? [] : $matchLines;
+    });
+
+    if ($action === 'm' && !$hasSettingMixin) {
+      $upgrader->updateMixins(function (Mixins $mixins) {
+        $mixins->addMixin('setting-php@1.0.0');
+      });
+    }
+    elseif ($action === 'b' && $hasSettingMixin) {
+      $upgrader->updateMixins(function (Mixins $mixins) {
+        $mixins->removeMixin('setting-php');
+      });
+    }
+
+    return $newContent;
+  });
+
+};


### PR DESCRIPTION
I grepped `universe` for examples of bespoke hook-implementations. There weren't a huge number, but there were a couple things like:

* Multiple extensions had comments into the boilerplate for `hook_angularModules`.  (Probably an older template?) The comments prevented it from recognizing the functions as empty.
    ```php
    function foo_civicrm_angularModules(...) {
      // Yadda yadda
    }
    ```
* Multiple extensions had a `return` in the boilerplate for `hook_managed`.  (Probably an older template?) These were being left behind and liable to duplicate the `mgd-php` behavior.
    ```php
    function foo_civicrm_managed(...) {
      return _foo_civix_civicrm_managed(...);
    }
    ```
* Multiple extensions had an identical chunk in `hook_alterSettingsFolders`.  (Probably an older template?)  These were being left behind and liable to duplicate the `setting-php` behavior.
    ```php
    function foo_civicrm_alterSettingsFolders(&$metaDataFolders) {
      static $configured = FALSE;
      if ($configured) return;
      $configured = TRUE;

      $extRoot = dirname( __FILE__ ) . DIRECTORY_SEPARATOR;
      $extDir = $extRoot . 'settings';
      if(!in_array($extDir, $metaDataFolders)){
        $metaDataFolders[] = $extDir;
      }
    }
    ```