### PR TITLE
Add extension dirs to class loader in bootstrap.php template

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -9,10 +9,12 @@ eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();
-$loader->add('CRM_', __DIR__);
-$loader->add('Civi\\', __DIR__);
-$loader->add('api_', __DIR__);
-$loader->add('api\\', __DIR__);
+$loader = new \Composer\Autoload\ClassLoader();
+$loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
+$loader->add('api_', [__DIR__ . '/../..', __DIR__]);
+$loader->addPsr4('api\\', [__DIR__ . '/../../api', __DIR__ . '/api']);
+
 $loader->register();
 
 /**

--- a/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/phpunit-boot-cv.php.php
@@ -9,7 +9,6 @@ eval(cv('php:boot --level=classloader', 'phpcode'));
 // phpcs:enable
 // Allow autoloading of PHPUnit helper classes in this extension.
 $loader = new \Composer\Autoload\ClassLoader();
-$loader = new \Composer\Autoload\ClassLoader();
 $loader->add('CRM_', [__DIR__ . '/../..', __DIR__]);
 $loader->addPsr4('Civi\\', [__DIR__ . '/../../Civi', __DIR__ . '/Civi']);
 $loader->add('api_', [__DIR__ . '/../..', __DIR__]);


### PR DESCRIPTION
To run unit tests that do not require a CiviCRM environment the extension's classes need to be loadable by the class loader.

It might be considered to do this for every extension in case the extension under test is in the `ext` directory so that it is possible to access classes of other extensions.