### PR TITLE
InitCommand - Enable mgd-php by default

### DIFF
--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -19,7 +19,7 @@ use CRM\CivixBundle\Utils\Path;
 
 class InitCommand extends AbstractCommand {
 
-  protected $defaultMixins = ['setting-php@1'];
+  protected $defaultMixins = ['setting-php@1', 'mgd-php@1'];
 
   protected function configure() {
     Services::templating();


### PR DESCRIPTION
This is probably worthwhile because we're getting more processes that use mgd-php, and (for now) it's fairly simple.