### PR TITLE
MixinCommand - Fix '--enable-all' on PHAR builds

### DIFF
--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -54,7 +54,7 @@ class Mixins implements Builder {
     $this->outputDir = $outputDir;
     $this->newConstraints = (array) $newConstraints;
     $this->removals = [];
-    $this->allBackports = require Application::findCivixDir() . '/mixin-backports.php';
+    $this->allBackports = Services::mixinBackports();
   }
 
   public function loadInit(&$ctx) {

--- a/src/CRM/CivixBundle/Services.php
+++ b/src/CRM/CivixBundle/Services.php
@@ -117,6 +117,16 @@ class Services {
   }
 
   /**
+   * @return array
+   */
+  public static function mixinBackports(): array {
+    if (!isset(self::$cache[__FUNCTION__])) {
+      self::$cache[__FUNCTION__] = require Application::findCivixDir() . '/mixin-backports.php';
+    }
+    return self::$cache[__FUNCTION__];
+  }
+
+  /**
    * @return \CRM\CivixBundle\UpgradeList
    */
   public static function upgradeList(): UpgradeList {

--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -43,6 +43,35 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
     ]);
   }
 
+  public function testEnableAllDisableAll(): void {
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+    ]);
+
+    $enableAll = $this->civix('mixin');
+    $this->assertEquals(0, $enableAll->execute(['--enable-all' => TRUE]));
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 1,
+      'mixin/case-xml@1.*.*.mixin.php' => 1,
+      'mixin/menu-xml@1.*.*.mixin.php' => 1,
+      'mixin/mgd-php@1.*.*.mixin.php' => 1,
+    ]);
+
+    $disableAll = $this->civix('mixin');
+    $this->assertEquals(0, $disableAll->execute(['--disable-all' => TRUE]));
+
+    $this->assertFileGlobs([
+      'mixin/polyfill.php' => 1,
+      'mixin/setting-php@1.*.*.mixin.php' => 0,
+      'mixin/case-xml@1.*.*.mixin.php' => 0,
+      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+      'mixin/mgd-php@1.*.*.mixin.php' => 0,
+    ]);
+  }
+
   public function testAddPageFor530(): void {
     $this->civixInfoSet('compatibility/ver', '5.30');
 


### PR DESCRIPTION
Consider this command:

```
civix mixin --enable-all
```

On  git-based deployments, it worked. But on phar-based deloyments, it didn't.

The problem is that `--enable-all` needs a list of backports, which was retrieved via `Mixlib::getList()` and `glob()` (*which doesn't work in PHAR folders*). Getting the same list from `mixin-backports.php` circumvents the `glob()` limit.