### PR TITLE
upgrades/16.10.0.up.php - Don't add hook_postInstall if `<upgrader>` registered via XML

### DIFF
--- a/upgrades/16.10.0.up.php
+++ b/upgrades/16.10.0.up.php
@@ -8,6 +8,11 @@
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
   $io = $upgrader->io;
 
+  if (!empty($upgrader->infoXml->get()->upgrader)) {
+    $io->note("Found <upgrader> tag. Skip hook_postInstall.");
+    return;
+  }
+
   // Give a notice if the new `CRM/*/Upgrader/Base` has a substantive change.
   // Note: The change is actually done in the generic regen. This is just a notice.
   $phpBaseClass = \CRM\CivixBundle\Utils\Naming::createClassName($upgrader->infoXml->getNamespace(), 'Upgrader', 'Base');


### PR DESCRIPTION
Extensions going from (say) v15.* to v22.05 should add `hook_postInstall` (as in `16.10.0.up.php`)... unless they have been manually edited to use `<upgrader>`.

CC @colemanw 
See: https://github.com/totten/civix/issues/221#issuecomment-1157599835