### PR TITLE
Ensure that PHPUnit xml is set to convert deprecations to exceptions …

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,6 +4,7 @@
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
+         convertDeprecationsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
          bootstrap="tests/bootstrap.php"

--- a/src/CRM/CivixBundle/Builder/PhpUnitXML.php
+++ b/src/CRM/CivixBundle/Builder/PhpUnitXML.php
@@ -17,6 +17,7 @@ class PhpUnitXML extends XML {
     $xml->addAttribute('convertErrorsToExceptions', 'true');
     $xml->addAttribute('convertNoticesToExceptions', 'true');
     $xml->addAttribute('convertWarningsToExceptions', 'true');
+    $xml->addAttribute('convertDeprecationsToExceptions', 'true');
     $xml->addAttribute('processIsolation', 'false');
     $xml->addAttribute('stopOnFailure', 'false');
     $xml->addAttribute('cacheResult', 'false');


### PR DESCRIPTION
…as per previous behaviour

ping @totten @eileenmcnaughton this is as per https://github.com/civicrm/civicrm-core/pull/23985