### PR TITLE
All code-generator commands should validate the current format/version

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -167,4 +167,23 @@ class Info extends XML {
     }
   }
 
+  /**
+   * Determine the civix-format version of this extension.
+   *
+   * If the value isn't explicitly available, inspect some related fields to make an
+   * educated  guess.
+   *
+   * @return string
+   */
+  public function detectFormat(): string {
+    $items = $this->get()->xpath('civix/format');
+    $explicit = (string) array_shift($items);
+    if ($explicit) {
+      return $explicit;
+    }
+
+    $mixins = $this->get()->xpath('mixins');
+    return empty($mixins) ? '13.10.0' : '22.05.0';
+  }
+
 }

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -3,12 +3,10 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Services;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Dirs;
-use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Menu;
 use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Utils\Path;

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -28,6 +28,8 @@ abstract class AbstractAddPageCommand extends AbstractCommand {
       throw new Exception("Class name should be valid (alphanumeric beginning with uppercase)");
     }
 
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Info;
+use CRM\CivixBundle\Services;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -37,6 +38,15 @@ abstract class AbstractCommand extends Command {
       throw new \RuntimeException('Wrong extension type: ' . $attrs['type']);
     }
     return $info;
+  }
+
+  protected function assertCurrentFormat() {
+    $info = $this->getModuleInfo($ctx);
+    $actualVersion = $info->detectFormat();
+    $expectedVersion = Services::upgradeList()->getHeadVersion();
+    if (version_compare($actualVersion, $expectedVersion, '<')) {
+      throw new \Exception("This extension requires an upgrade for the file-format (current=$actualVersion; expected=$expectedVersion). Please run 'civix upgrade' before generating code.");
+    }
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -33,6 +33,8 @@ For more, see https://docs.angularjs.org/guide/directive');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -23,6 +23,8 @@ class AddAngularModuleCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -38,6 +38,8 @@ For more, see https://docs.angularjs.org/guide');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -57,6 +57,8 @@ action names.
       return;
     }
 
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -30,6 +30,8 @@ class AddCaseTypeCommand extends AbstractCommand {
       return;
     }
 
+    $this->assertCurrentFormat();
+
     if (!preg_match('/^[A-Z][A-Za-z0-9_ \.\-]*$/', $input->getArgument('<Label>'))) {
       throw new Exception("Label should be valid");
     }

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -33,6 +33,8 @@ class AddCustomDataCommand extends AbstractCommand {
       return;
     }
 
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -45,6 +45,8 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       return 1;
     }
 
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -48,6 +48,8 @@ explicity.');
       return;
     }
 
+    $this->assertCurrentFormat();
+
     $apiVersions = explode(',', $input->getOption('api-version'));
     if (!empty(array_diff($apiVersions, ['3', '4']))) {
       throw new Exception("In --api-versions, found unrecognized versions. Expected: '3' and/or '4'");

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -29,6 +29,8 @@ class AddReportCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data and put it in $ctx ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -28,6 +28,8 @@ class AddSearchCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -54,6 +54,8 @@ as separate groups:
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/AddThemeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddThemeCommand.php
@@ -34,6 +34,8 @@ $ civix generate:theme foobar
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     //// Figure out template data ////
     $ctx = [];
     $ctx['type'] = 'module';

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -20,6 +20,8 @@ class AddUpgraderCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     // TODO validate that hook_civicrm_upgrade has been implemented
 
     $ctx = [];

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -17,6 +17,8 @@ class BuildCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/MixinCommand.php
+++ b/src/CRM/CivixBundle/Command/MixinCommand.php
@@ -39,6 +39,8 @@ class MixinCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -35,9 +35,7 @@ class UpgradeCommand extends AbstractCommand {
     $startVersion = $ctx['civixFormat'] ?? NULL;
 
     if (!$startVersion) {
-      // We'll have to make an educated guess...
-      $mixins = $info->get()->xpath('mixins');
-      $startVersion = empty($mixins) ? '13.10.0' : '22.05.0';
+      $startVersion = $info->detectFormat();
       $io->writeln("info.xml does not declare the civix format. Inferred <info>v{$startVersion}</info>.");
     }
     else {


### PR DESCRIPTION
There have been multiple reports (Github, MM, etc; ex) where an extension gets into a non-runnable state due to a workflow/communication issue. (Ex: #244, #250, #252) There is a common thread to these:  the `civix upgrade` steps need to run. A typical example flow might be:

1. Install latest version of `civix`
2. Checkout a pre-existing extension (*esp one which pre-dates `civix` v22.05*)
3. Run any code-generating command (`generate:page`, `generate:api`, `generate:entity-boilerplate`, etc).
    * As a side-effect, this regenerates `*.civix.php` from the latest template. Critically, it it does not update any inter-related files (like `info.xml` or the main `*.php` file).
4. Open some Civi screen and observe an error (eg *undefined function `_mymodule_civix_civicrm_alterSettingsFolders()`*).
    * The function should be obsolete (per [the new format](https://civicrm.org/blog/totten/civix-v2205-how-remove-million-lines-extra-code)), but there are still old references because it has not fully adopted the new format. 

Running the `civix upgrade` command first would prevent the problem. The workflow should be:

1. Install latest version of `civix`
2. Checkout a pre-existing extension (*esp one which pre-dates `civix` v22.05*)
3. Run `civix upgrade`
4. Run any code-generating command (`generate:page`, `generate:api`, `generate:entity-boilerplate`, etc).
5. Drink a beer

With this patch, every code-generating command will do a validation before it runs. Ex:

```
## Checkout some pre-existing code (pre-dating v22.05).
$ git checkout 2.9
HEAD is now at cde5359 Merge pull request #492 from mattwire/2.9

## Run any code-generator
$ civix generate:page Foobar civicrm/foobar

In AbstractCommand.php line 48:

  This extension requires an upgrade for the file-format (current=13.10.0; expected=22.05.2). Please run 'civix upgrade' before generating code.
```

This way, you won't get an invalid `*.civix.php` -- instead, you'll get a prompt to do a full upgrade.