### PR TITLE
civix upgrade - Add option to replay previous upgrade steps

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -74,11 +74,8 @@ explicity.');
 
     $ctx['entityNameCamel'] = ucfirst($input->getArgument('<EntityName>'));
     $ctx['tableName'] = $input->getOption('table-name') ? $input->getOption('table-name') : Naming::createTableName($input->getArgument('<EntityName>'));
-    if (function_exists('civicrm_api_get_function_name')) {
-      $ctx['apiFunctionPrefix'] = strtolower(civicrm_api_get_function_name($ctx['entityNameCamel'], '', self::API_VERSION));
-    }
-    elseif (function_exists('_civicrm_api_get_entity_name_from_camel')) {
-      $ctx['apiFunctionPrefix'] = 'civicrm_api' . self::API_VERSION . '_' . _civicrm_api_get_entity_name_from_camel($ctx['entityNameCamel']) . '_' . $ctx['actionNameCamel'];
+    if (function_exists('_civicrm_api_get_entity_name_from_camel')) {
+      $ctx['apiFunctionPrefix'] = 'civicrm_api' . self::API_VERSION . '_' . _civicrm_api_get_entity_name_from_camel($ctx['entityNameCamel']) . '_';
     }
     else {
       throw new Exception("Failed to determine proper API function name. Perhaps the API internals have changed?");

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -56,11 +56,7 @@ class UpgradeCommand extends AbstractCommand {
       $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
       $func = require $upgradeFile;
       $func($upgrader);
-
-      $upgrader->updateInfo(function (Info $info) use ($upgradeVersion, $io) {
-        $io->writeln("<info>Set civix format to </info>$upgradeVersion<info> in </info>info.xml");
-        $info->get()->civix->format = $upgradeVersion;
-      });
+      $upgrader->updateFormatVersion($upgradeVersion);
       $lastVersion = $upgradeVersion;
     }
   }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -92,6 +92,16 @@ class Upgrader {
   }
 
   /**
+   * @param string $newVersion
+   */
+  public function updateFormatVersion(string $newVersion) {
+    $this->updateInfo(function (Info $info) use ($newVersion) {
+      $this->io->writeln("<info>Set civix format to </info>$newVersion<info> in </info>info.xml");
+      $info->get()->civix->format = $newVersion;
+    });
+  }
+
+  /**
    * Apply a filter to the "Mixins" list.
    *
    * @param callable $function

--- a/tests/e2e/IdempotentUpgradeTest.php
+++ b/tests/e2e/IdempotentUpgradeTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace E2E;
+
+/**
+ * What happens if you take a new extension and run an upgrade on it?
+ * The result should match.
+ */
+class IdempotentUpgradeTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civix_upgradereset';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+  }
+
+  /**
+   * Do the upgrade a full replay (`civix upgrade --start=0`).
+   */
+  public function testBasicUpgrade(): void {
+    // Make an example
+    $this->civixGeneratePage('MyPage', 'civicrm/thirty');
+    $this->civixGenerateEntity('MyEntity');
+    $this->civixGenerateEntityBoilerplate();
+    $start = $this->getExtSnapshot();
+
+    // Do the upgrade
+    $result = $this->civixUpgrade()->getDisplay(TRUE);
+    $expectLines = [
+      'Incremental upgrades',
+      'General upgrade',
+    ];
+    $this->assertStringSequence($expectLines, $result);
+    $this->assertNotRegExp(';Upgrade v([\d\.]+) => v([\d\.]+);', $result);
+
+    // Compare before+after
+    $end = $this->getExtSnapshot();
+    $this->assertEquals($start, $end);
+  }
+
+  /**
+   * Do the upgrade a full replay (`civix upgrade --start=0`).
+   */
+  public function testResetVersion0(): void {
+    // Make an example
+    $this->civixGeneratePage('MyPage', 'civicrm/thirty');
+    $this->civixGenerateEntity('MyEntity');
+    $this->civixGenerateEntityBoilerplate();
+    $start = $this->getExtSnapshot();
+
+    // Do the upgrade
+    $result = $this->civixUpgrade(['--start' => '0'])->getDisplay(TRUE);
+    $expectLines = [
+      'Incremental upgrades',
+      'Upgrade v13.10.0 => v16.10.0',
+      'Upgrade v22.05.0 => v22.05.2',
+      'General upgrade',
+    ];
+    $this->assertStringSequence($expectLines, $result);
+
+    // Compare before+after
+    $end = $this->getExtSnapshot();
+    $this->assertEquals($start, $end);
+  }
+
+  /**
+   * Do the upgrade a full replay (`civix upgrade --start=22.01.0`).
+   */
+  public function testResetVersion2201(): void {
+    // Make an example
+    $this->civixGeneratePage('MyPage', 'civicrm/thirty');
+    $this->civixGenerateEntity('MyEntity');
+    $this->civixGenerateEntityBoilerplate();
+    $start = $this->getExtSnapshot();
+
+    // Do the upgrade
+    $result = $this->civixUpgrade(['--start' => '22.01.0'])->getDisplay(TRUE);
+    $expectLines = [
+      'Incremental upgrades',
+      'Upgrade v22.05.0 => v22.05.2',
+      'General upgrade',
+    ];
+    $this->assertStringSequence($expectLines, $result);
+    $this->assertStringNotContainsString('Upgrade v13.10.0 => v16.10.0', $result);
+
+    // Compare before+after
+    $end = $this->getExtSnapshot();
+    $this->assertEquals($start, $end);
+  }
+
+  /**
+   * Assert that each item of $expectSubstrings appears in $actualText.
+   * Strings must appear in the given order. Other text is ignored.
+   *
+   * @param string[] $expectSubstrings
+   *   List of strings that should appear, in order of appearance.
+   *   Ex: ['200', '400']
+   * @param string $actualText
+   *   Ex: "100\n200\n300\n400\n500\n"
+   */
+  protected function assertStringSequence(array $expectSubstrings, string $actualText) {
+    $lastPos = 0;
+    foreach ($expectSubstrings as $n => $expectLine) {
+      $pos = strpos($actualText, $expectLine, $lastPos);
+      $this->assertTrue($pos !== FALSE && $pos >= $lastPos, "Expect to find item #{$n} (\"$expectLine\")");
+      $lastPos = $pos;
+    }
+    $this->assertTrue($lastPos > 0, 'Should have found multiple lines.');
+  }
+
+}


### PR DESCRIPTION
Add an option to  `civix upgrade`  which allows you to replay the upgrade checks, eg

```
civix upgrade                ##  Default: Run upgrade based on the saved version from info.xml
civix upgrade --start=0      ##  Run all upgrade steps from the beginning of time.
civix upgrade --start=22.01  ##  Run upgrade steps from 22.01 to current.
```

This generally shouldn't be necessary, but there could be edge-cases where it's useful. (*Speculating...*) For example, if you merge branches from different developers with different civix versions, then you may want to replay an upgrade on the final branch.

Inspired by comments from  @artfulrobot in #252.