### PR TITLE
Add some (easy) return type hints

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -29,7 +29,7 @@ class <?php echo $_namespace ?>_ExtensionUtil {
    *   Translated text.
    * @see ts
    */
-  public static function ts($text, $params = []) {
+  public static function ts($text, $params = []): string {
     if (!array_key_exists('domain', $params)) {
       $params['domain'] = [self::LONG_NAME, NULL];
     }
@@ -46,7 +46,7 @@ class <?php echo $_namespace ?>_ExtensionUtil {
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo'.
    *   Ex: 'http://example.org/sites/default/ext/org.example.foo/css/foo.css'.
    */
-  public static function url($file = NULL) {
+  public static function url($file = NULL): string {
     if ($file === NULL) {
       return rtrim(CRM_Core_Resources::singleton()->getUrl(self::LONG_NAME), '/');
     }

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -22,7 +22,7 @@ function <?php echo $mainFile ?>_civicrm_config(&$config) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
-function <?php echo $mainFile ?>_civicrm_install() {
+function <?php echo $mainFile ?>_civicrm_install(): void {
   _<?php echo $mainFile ?>_civix_civicrm_install();
 }
 
@@ -31,7 +31,7 @@ function <?php echo $mainFile ?>_civicrm_install() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
  */
-function <?php echo $mainFile ?>_civicrm_postInstall() {
+function <?php echo $mainFile ?>_civicrm_postInstall(): void {
   _<?php echo $mainFile ?>_civix_civicrm_postInstall();
 }
 
@@ -40,7 +40,7 @@ function <?php echo $mainFile ?>_civicrm_postInstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
  */
-function <?php echo $mainFile ?>_civicrm_uninstall() {
+function <?php echo $mainFile ?>_civicrm_uninstall(): void {
   _<?php echo $mainFile ?>_civix_civicrm_uninstall();
 }
 
@@ -49,7 +49,7 @@ function <?php echo $mainFile ?>_civicrm_uninstall() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
-function <?php echo $mainFile ?>_civicrm_enable() {
+function <?php echo $mainFile ?>_civicrm_enable(): void {
   _<?php echo $mainFile ?>_civix_civicrm_enable();
 }
 
@@ -58,7 +58,7 @@ function <?php echo $mainFile ?>_civicrm_enable() {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
  */
-function <?php echo $mainFile ?>_civicrm_disable() {
+function <?php echo $mainFile ?>_civicrm_disable(): void {
   _<?php echo $mainFile ?>_civix_civicrm_disable();
 }
 
@@ -78,7 +78,7 @@ function <?php echo $mainFile ?>_civicrm_upgrade($op, CRM_Queue_Queue $queue = N
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_entityTypes
  */
-function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes) {
+function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes): void {
   _<?php echo $mainFile ?>_civix_civicrm_entityTypes($entityTypes);
 }
 
@@ -89,7 +89,7 @@ function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
  */
-//function <?php echo $mainFile ?>_civicrm_preProcess($formName, &$form) {
+//function <?php echo $mainFile ?>_civicrm_preProcess($formName, &$form): void {
 //
 //}
 
@@ -98,7 +98,7 @@ function <?php echo $mainFile ?>_civicrm_entityTypes(&$entityTypes) {
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
  */
-//function <?php echo $mainFile ?>_civicrm_navigationMenu(&$menu) {
+//function <?php echo $mainFile ?>_civicrm_navigationMenu(&$menu): void {
 //  _<?php echo $mainFile ?>_civix_insert_navigation_menu($menu, 'Mailings', [
 //    'label' => E::ts('New subliminal message'),
 //    'name' => 'mailing_subliminal_message',


### PR DESCRIPTION
php is getting tighter & tigher on type hints & I think it's pretty likely that by the
time we are doing php9 they we will be doing re-work to add them - so
we should make sure we are adding them on code as we go now. This just adds
a handful of easy ones (ones where it is really easy to see what the hints
should be)