### PR TITLE
Fix self-reference being identified as circular foreign key

### DIFF
--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -94,7 +94,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
 
     $config->tables = $tables;
     $_namespace = ' ' . preg_replace(':/:', '_', $ctx['namespace']);
-    $this->orderTables($tables);
+    $this->orderTables($tables, $output);
     $this->resolveForeignKeys($tables);
     $config->tables = $tables;
 
@@ -151,7 +151,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
 
   }
 
-  private function orderTables(&$tables) {
+  private function orderTables(&$tables, $output) {
 
     $ordered = [];
     $abort = count($tables);
@@ -170,9 +170,10 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
           unset($tables[$k]);
         }
         if (isset($table['foreignKey'])) {
-          // If any FK references a table still in our list, skip this table for now
+          // If any FK references a table still in our list (but is not a self-reference),
+          // skip this table for now
           foreach ($table['foreignKey'] as $fKey) {
-            if (in_array($fKey['table'], array_keys($tables))) {
+            if (in_array($fKey['table'], array_keys($tables)) && $fKey['table'] != $table['name']) {
               continue 2;
             }
           }

--- a/tests/e2e/AddEntityTest.php
+++ b/tests/e2e/AddEntityTest.php
@@ -52,6 +52,8 @@ class AddEntityTest extends \PHPUnit\Framework\TestCase {
     $this->addExampleFK($this->getExtPath('xml/schema/CRM/CivixAddentity/Bread.xml'), 'flour', 'civicrm_flour');
     $this->addExampleFK($this->getExtPath('xml/schema/CRM/CivixAddentity/Sandwich.xml'), 'bread', 'civicrm_bread');
     $this->addExampleFK($this->getExtPath('xml/schema/CRM/CivixAddentity/Meal.xml'), 'sandwich', 'civicrm_sandwich');
+    // add FK referencing its own table
+    $this->addExampleFK($this->getExtPath('xml/schema/CRM/CivixAddentity/Meal.xml'), 'next_meal', 'civicrm_meal');
     $this->civixGenerateEntityBoilerplate();
 
     $this->assertFileGlobs([


### PR DESCRIPTION
This fixes an issue where foreign keys referencing their own table trigger the check for circular dependencies. This can be avoided by ignoring affected foreign keys when ordering tables.

This also fixes a null reference in the error handler.

Note that I've only done limited testing (read: running `tests/e2e/AddEntityTest.php`) as I ran into an issue with `box` and ran out of time to work on this. 😅 