### PR TITLE
Standards fixes in civix

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
@@ -2,6 +2,7 @@
 echo "<?php\n";
 ?>
 
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;

--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api3-test.php.php
@@ -20,7 +20,7 @@ class <?php echo $testApi3ClassName ?> extends \PHPUnit\Framework\TestCase imple
    *
    * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
    */
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->apply();

--- a/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
@@ -2,7 +2,9 @@
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+// phpcs:disable
 use <?php echo $_namespace ?>_ExtensionUtil as E;
+// phpcs:enable
 
 class <?php echo $baoClassName ?> extends <?php echo $daoClassName ?> {
 
@@ -11,7 +13,8 @@ class <?php echo $baoClassName ?> extends <?php echo $daoClassName ?> {
    *
    * @param array $params key-value pairs
    * @return <?php echo $daoClassName ?>|NULL
-   *
+   */
+  /*
   public static function create($params) {
     $className = '<?php echo $daoClassName ?>';
     $entityName = '<?php echo $entityNameCamel ?>';
@@ -24,6 +27,7 @@ class <?php echo $baoClassName ?> extends <?php echo $daoClassName ?> {
     CRM_Utils_Hook::post($hook, $entityName, $instance->id, $instance);
 
     return $instance;
-  } */
+  }
+  */
 
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
@@ -2,6 +2,7 @@
 echo "<?php\n";
 ?>
 
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;

--- a/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-api.php.php
@@ -21,7 +21,7 @@ class <?php echo $testClassName ?> extends \PHPUnit\Framework\TestCase implement
    *
    * See: https://docs.civicrm.org/dev/en/latest/testing/phpunit/#civitest
    */
-  public function setUpHeadless() {
+  public function setUpHeadless(): CiviEnvBuilder {
     return \Civi\Test::headless()
       ->installMe(__DIR__)
       ->apply();

--- a/src/CRM/CivixBundle/Resources/views/Code/test-headless.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/test-headless.php.php
@@ -8,10 +8,10 @@ $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
 use <?php echo $_namespace ?>_ExtensionUtil as E;
+use Civi\Test\CiviEnvBuilder;
 use Civi\Test\HeadlessInterface;
 use Civi\Test\HookInterface;
 use Civi\Test\TransactionalInterface;
-use Civi\Test\CiviEnvBuilder;
 
 /**
  * FIXME - Add test description.

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader-base.php.php
@@ -97,7 +97,7 @@ class <?php echo $_namespace ?>_Upgrader_Base {
    *   the CustomData XML file path (relative to this extension's dir)
    * @return bool
    */
-  public function executeCustomDataFile($relativePath) {
+  public function executeCustomDataFile($relativePath): bool {
     $xml_file = $this->extensionDir . '/' . $relativePath;
     return $this->executeCustomDataFileByAbsPath($xml_file);
   }

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -2,7 +2,9 @@
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
+// phpcs:disable
 use <?php echo $_namespace ?>_ExtensionUtil as E;
+// phpcs:enable
 
 /**
  * Collection of upgrade steps.
@@ -15,8 +17,10 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
   /**
    * Example: Run an external SQL script when the module is installed.
    *
-  public function install() {
-    $this->executeSqlFile('sql/myinstall.sql');
+   * Note that if a file is present sql\auto_install that will run regardless of this hook.
+   */
+  public function install(): void {
+    //$this->executeSqlFile('sql/my_install.sql');
   }
 
   /**
@@ -27,7 +31,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    * created during the installation (e.g., a setting or a managed entity), do
    * so here to avoid order of operation problems.
    */
-  // public function postInstall() {
+  // public function postInstall(): void {
   //  $customFieldId = civicrm_api3('CustomField', 'getvalue', array(
   //    'return' => array("id"),
   //    'name' => "customFieldCreatedViaManagedHook",
@@ -39,22 +43,24 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
 
   /**
    * Example: Run an external SQL script when the module is uninstalled.
+   *
+   * Note that if a file is present sql\auto_uninstall that will run regardless of this hook.
    */
-  // public function uninstall() {
-  //  $this->executeSqlFile('sql/myuninstall.sql');
-  // }
+  public function uninstall(): void {
+    //$this->executeSqlFile('sql/my_uninstall.sql');
+  }
 
   /**
    * Example: Run a simple query when a module is enabled.
    */
-  // public function enable() {
+  // public function enable(): void {
   //  CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 1 WHERE bar = "whiz"');
   // }
 
   /**
    * Example: Run a simple query when a module is disabled.
    */
-  // public function disable() {
+  // public function disable(): void {
   //   CRM_Core_DAO::executeQuery('UPDATE foo SET is_active = 0 WHERE bar = "whiz"');
   // }
 
@@ -62,7 +68,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    * Example: Run a couple simple queries.
    *
    * @return TRUE on success
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   // public function upgrade_4200(): bool {
   //   $this->ctx->log->info('Applying update 4200');
@@ -76,7 +82,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    * Example: Run an external SQL script.
    *
    * @return TRUE on success
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   // public function upgrade_4201(): bool {
   //   $this->ctx->log->info('Applying update 4201');
@@ -90,7 +96,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    * Example: Run a slow upgrade process by breaking it up into smaller chunk.
    *
    * @return TRUE on success
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   // public function upgrade_4202(): bool {
   //   $this->ctx->log->info('Planning update 4202'); // PEAR Log interface
@@ -109,7 +115,7 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    * millions) of records by breaking it up into smaller chunks.
    *
    * @return TRUE on success
-   * @throws Exception
+   * @throws CRM_Core_Exception
    */
   // public function upgrade_4203(): bool {
   //   $this->ctx->log->info('Planning update 4203'); // PEAR Log interface

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -19,9 +19,9 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    *
    * Note that if a file is present sql\auto_install that will run regardless of this hook.
    */
-  public function install(): void {
-    //$this->executeSqlFile('sql/my_install.sql');
-  }
+  // public function install(): void {
+  //   $this->executeSqlFile('sql/my_install.sql');
+  // }
 
   /**
    * Example: Work with entities usually not available during the install step.
@@ -46,9 +46,9 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
    *
    * Note that if a file is present sql\auto_uninstall that will run regardless of this hook.
    */
-  public function uninstall(): void {
-    //$this->executeSqlFile('sql/my_uninstall.sql');
-  }
+  // public function uninstall(): void {
+  //   $this->executeSqlFile('sql/my_uninstall.sql');
+  // }
 
   /**
    * Example: Run a simple query when a module is enabled.
@@ -77,7 +77,6 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
   //   return TRUE;
   // }
 
-
   /**
    * Example: Run an external SQL script.
    *
@@ -90,7 +89,6 @@ class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgra
   //   $this->executeSqlFile('sql/upgrade_4201.sql');
   //   return TRUE;
   // }
-
 
   /**
    * Example: Run a slow upgrade process by breaking it up into smaller chunk.


### PR DESCRIPTION
I recently submitted a civix-generated extension & found man boilerplate lines didn't pass style - this fixes.

It also removes a 'not-a-word' 'myinstall' & switches to 'my_install' - we shouldn't make people have to add made-up words to their IDE spelling checkers...

https://github.com/civicrm/civicrm-core/pull/24585