### PR TITLE
Add PSR-0 classloading for "CRM"

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -187,4 +187,45 @@ class Info extends XML {
     return empty($mixins) ? '13.10.0' : '22.05.0';
   }
 
+  public function getClassloaders(): array {
+    $loaders = [];
+
+    foreach (['psr0', 'psr4'] as $type) {
+      $items = $this->get()->xpath("classloader/$type");
+      foreach ($items as $item) {
+        $attrs = $item->attributes();
+        $loaders[] = [
+          'type' => $type,
+          'prefix' => (string) $attrs['prefix'],
+          'path' => (string) $attrs['path'],
+        ];
+      }
+    }
+    return $loaders;
+  }
+
+  /**
+   * @param array $loaders
+   *   Ex: [['type' => 'psr4', 'prefix' => 'Civi\Foobar\', 'path' => 'src']]
+   */
+  public function setClassLoaders(array $loaders): void {
+    foreach ($this->xml->xpath('classloader/*') as $child) {
+      unset($child[0]);
+    }
+
+    $classloader = $this->findCreateElement($this->xml, 'classloader');
+    foreach ($loaders as $loader) {
+      $rule = $classloader->addChild($loader['type']);
+      $rule->addAttribute('prefix', $loader['prefix']);
+      $rule->addAttribute('path', $loader['path']);
+    }
+  }
+
+  private function findCreateElement(SimpleXMLElement $base, string $tag): SimpleXMLElement {
+    foreach ($base->xpath($tag) as $existingClassloader) {
+      return $existingClassloader;
+    }
+    return $base->addChild($tag);
+  }
+
 }

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -47,9 +47,14 @@ class Info extends XML {
     // classes for this ext should be 'Civi\MyExt', so this is the
     // simplest default.
     $classloader = $xml->addChild('classloader');
-    $classloaderRule = $classloader->addChild('psr4');
-    $classloaderRule->addAttribute('prefix', 'Civi\\');
-    $classloaderRule->addAttribute('path', 'Civi');
+
+    $crmClassloaderRule = $classloader->addChild('psr0');
+    $crmClassloaderRule->addAttribute('prefix', 'CRM_');
+    $crmClassloaderRule->addAttribute('path', '');
+
+    $civiClassloaderRule = $classloader->addChild('psr4');
+    $civiClassloaderRule->addAttribute('prefix', 'Civi\\');
+    $civiClassloaderRule->addAttribute('path', 'Civi');
 
     // store extra metadata to facilitate code manipulation
     $civix = $xml->addChild('civix');

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -50,7 +50,7 @@ class Info extends XML {
 
     $crmClassloaderRule = $classloader->addChild('psr0');
     $crmClassloaderRule->addAttribute('prefix', 'CRM_');
-    $crmClassloaderRule->addAttribute('path', '');
+    $crmClassloaderRule->addAttribute('path', '.');
 
     $civiClassloaderRule = $classloader->addChild('psr4');
     $civiClassloaderRule->addAttribute('prefix', 'Civi\\');

--- a/upgrades/22.10.0.up.php
+++ b/upgrades/22.10.0.up.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * I haven't traced why, but it seems that core is getting more eager to scan
+ * BAOs/DAOs early on -- in a way that provokes class-loading errors if your
+ * extension defines entities and lacks `<psr0>` for `CRM_`
+ *
+ * Just add the '<psr0>` bit to everything.
+ */
+return function (\CRM\CivixBundle\Upgrader $upgrader) {
+
+  $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
+    /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+    $io = $upgrader->io;
+
+    $loaders = $info->getClassloaders();
+    $prefixes = array_column($loaders, 'prefix');
+    if (file_exists($upgrader->baseDir->string('CRM')) && !in_array('CRM_', $prefixes)) {
+      $io->section('"CRM" Class-loader');
+      $io->note([
+        'Older templates enabled class-loading via "hook_config" and "include_path".',
+        'Newer templates enable class-loading via "info.xml" ("<classloader>"). This fixes some edge-case issues and allows more configuration.',
+        'It is generally safe for these loaders to coexist. The upgrade will add "<classloader>" for the "CRM" folder.',
+      ]);
+      $io->warning([
+        'If you use the rare (and ill-advised/unsupported) practice of class-overrides, then you may need extra diligence with any changes to class-loading.',
+      ]);
+
+      if (!$io->confirm('Continue with upgrade?')) {
+        throw new \RuntimeException('User stopped upgrade');
+      }
+      $loaders[] = ['type' => 'psr0', 'prefix' => 'CRM_', 'path' => '.'];
+      $info->setClassLoaders($loaders);
+    }
+
+  });
+
+};


### PR DESCRIPTION
This updates the `info.xml` in new extensions (`civix generate:module`) and existing extensions (`civix upgrade`) to declare:

```xml
<classloader>
  <psr0 prefix="CRM_" path=""/>
</classloader>
```

Todo: Check test results