### PR TITLE
Adds composer.json package information to the extension

### DIFF
--- a/src/CRM/CivixBundle/Builder/Module.php
+++ b/src/CRM/CivixBundle/Builder/Module.php
@@ -39,6 +39,15 @@ class Module implements Builder {
     $ctx['entityTypes'] = $this->generateEntityTypes("{$ctx['basedir']}/xml/schema/CRM/*/*.entityType.php");
 
     $moduleCivix->save($ctx, $output);
+
+    // Add composer package info
+    $composerPackage = new Template(
+      'composer.json.php',
+      $basedir->string('composer.json'),
+      'ignore',
+      $this->templateEngine
+    );
+    $composerPackage->save($ctx, $output);
   }
 
   private function generateEntityTypes($glob){

--- a/src/CRM/CivixBundle/Resources/views/Code/composer.json.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/composer.json.php
@@ -1,0 +1,12 @@
+{
+  "name": "civicrm/<?php echo $mainFile; ?>",
+  "type": "civicrm-ext",
+  "description": "FIXME",
+  "license": "<?php echo $license ?>",
+  "authors": [
+    {
+      "name": "FIXME",
+      "email": "FIXME"
+    }
+  ]
+}


### PR DESCRIPTION
@totten This minor PR adds the functionality to add a default (from template) `composer.json` file to the extension's root folder