### PR TITLE
Simplify hook_civicrm_config, remove extension from include_path

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -105,20 +105,13 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
   }
   $configured = TRUE;
 
-  $template = CRM_Core_Smarty::singleton();
+  $tplDir = __DIR__ . DIRECTORY_SEPARATOR . 'templates';
 
-  $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
-  $extDir = $extRoot . 'templates';
-
-  if (is_array($template->template_dir)) {
-    array_unshift($template->template_dir, $extDir);
-  }
-  else {
-    $template->template_dir = [$extDir, $template->template_dir];
+  if (is_dir($tplDir)) {
+    $smarty = CRM_Core_Smarty::singleton();
+    $smarty->template_dir = array_merge([$tplDir], (array) $smarty->template_dir);
   }
 
-  $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
-  set_include_path($include_path);
 <?php echo $_invokePolyfill; ?>
 }
 


### PR DESCRIPTION
Since #265 the `include_path` addition has not been needed except for odd edge-cases where the extension has stuff that's not covered by the autoloader. I'm honestly not sure what those things might be, but best-practice is to use the autoloader and not mess with `include_path`.