### PR TITLE
Upgrade to use CRM_Extension_Upgrader_Base and info.xml `<upgrader>` tag

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -11,6 +11,11 @@ use SimpleXMLElement;
 class Info extends XML {
 
   public function init(&$ctx) {
+    $ctx += [
+      // FIXME: Auto-detect current installed civi version
+      'compatibilityVerMin' => 5.45,
+    ];
+
     $xml = new SimpleXMLElement('<extension></extension>');
     $xml->addAttribute('key', $ctx['fullName']);
     $xml->addAttribute('type', $ctx['type']);
@@ -40,7 +45,7 @@ class Info extends XML {
     $xml->addChild('releaseDate', date('Y-m-d'));
     $xml->addChild('version', '1.0');
     $xml->addChild('develStage', 'alpha');
-    $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin'] ?? '5.0');
+    $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin']);
     $xml->addChild('comments', 'This is a new, undeveloped module');
 
     // APIv4 will look for classes+files matching 'Civi/Api4', and

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -87,6 +87,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $io->title('General upgrade');
 
     $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+    $upgrader->cleanUpgraderBase();
     $upgrader->cleanEmptyHooks();
     $upgrader->reconcileMixins();
 

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -3,6 +3,7 @@ echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 $_compatibility = isset($compatibilityVerMin) ? $compatibilityVerMin : '5.0';
 $_invokePolyfill = version_compare($_compatibility, '5.45.beta1', '<') ? sprintf("  _%s_civix_mixin_polyfill();\n", $mainFile) : '';
+$_useCoreUpgrader = version_compare($_compatibility, '5.38', '>=');
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
@@ -122,6 +123,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
 <?php echo $_invokePolyfill; ?>
 }
 
+<?php if (!$_useCoreUpgrader) { ?>
 /**
  * Implements hook_civicrm_install().
  *
@@ -221,6 +223,7 @@ function _<?php echo $mainFile ?>_civix_upgrader() {
   }
 }
 
+<?php } ?>
 /**
  * Inserts a navigation menu item at a given place in the hierarchy.
  *

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -9,7 +9,7 @@ use <?php echo $_namespace ?>_ExtensionUtil as E;
 /**
  * Collection of upgrade steps.
  */
-class <?php echo $_namespace ?>_Upgrader extends <?php echo $_namespace ?>_Upgrader_Base {
+class <?php echo $_namespace ?>_Upgrader extends <?php echo $baseUpgrader ?> {
 
   // By convention, functions that look like "function upgrade_NNNN()" are
   // upgrade tasks. They are executed in order (like Drupal's hook_update_N).

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -368,6 +368,46 @@ class Upgrader {
     });
   }
 
+  /**
+   * Since 5.38 core supports an <upgrader> tag in liu of hooks, and a common base class.
+   *
+   * Remove hook delegations from module.php and add <upgrader> to info.xml
+   * Switch upgrader base class to use the one in core and remove the boilerplate version
+   */
+  public function cleanUpgraderBase(): void {
+    $compatVer = $this->infoXml->getCompatibilityVer();
+    $useCore = version_compare($compatVer, '5.38', '>=');
+    if ($useCore) {
+      $prefix = $this->infoXml->getFile();
+      $this->removeHookDelegation([
+        "_{$prefix}_civix_civicrm_install",
+        "_{$prefix}_civix_civicrm_postInstall",
+        "_{$prefix}_civix_civicrm_uninstall",
+        "_{$prefix}_civix_civicrm_enable",
+        "_{$prefix}_civix_civicrm_disable",
+        "_{$prefix}_civix_civicrm_upgrade",
+      ]);
+      $nameSpace = $this->infoXml->getNamespace();
+      $upgraderFile = $this->baseDir->string($nameSpace . DIRECTORY_SEPARATOR . 'Upgrader.php');
+      $upgraderBaseFile = $this->baseDir->string($nameSpace . DIRECTORY_SEPARATOR . 'Upgrader' . DIRECTORY_SEPARATOR . 'Base.php');
+      if (file_exists($upgraderFile)) {
+        $crmPrefix = preg_replace(':/:', '_', $nameSpace);
+        // Add <upgrader> tag
+        if (!$this->infoXml->get()->xpath('upgrader')) {
+          $this->infoXml->get()->addChild('upgrader', $crmPrefix . '_Upgrader');
+          $this->infoXml->save($this->_ctx, $this->output);
+        }
+        // Switch base class
+        file_put_contents($upgraderFile,
+          str_replace("{$crmPrefix}_Upgrader_Base", 'CRM_Extension_Upgrader_Base', file_get_contents($upgraderFile))
+        );
+      }
+      if (file_exists($upgraderBaseFile)) {
+        unlink($upgraderBaseFile);
+      }
+    }
+  }
+
   // -------------------------------------------------
   // These are some helper utilities.
 

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -264,7 +264,7 @@ class Upgrader {
             $this->io->writeln(sprintf("<info>Removing line </info>%s:%d<info></info>\n", $mainPhp, 1 + $lineNum));
             $line = NULL;
           }
-          elseif (preg_match("|$nameQuoted|", $line, $m)) {
+          elseif (preg_match("|$nameQuoted|", (string) $line, $m)) {
             $this->io->writeln(sprintf(
               "<info>Found reference to obsolete function </info>%s()<info> at </info>%s:%d<info>.</info>\n",
               $name, $mainPhp, 1 + $lineNum
@@ -315,12 +315,13 @@ class Upgrader {
       $comment = "/\*\*\n( \*.*\n)* \*/";
       $funcName = $infoXml->getFile() . "_civicrm_[a-zA-Z0-9_]+";
       $funcArgs = "\([^\)]*\)";
+      $typeHint = ":[ ]*[|?a-z]+";
       $startBody = "\{[^\}]*\}"; /* For empty functions, this grabs everything. For non-empty functions, this may just grab the opening segment. */
-      $content = preg_replace_callback(";({$comment})?\n\s*function ({$funcName})({$funcArgs})\s*({$startBody})\n*;m", function ($m) {
+      $content = preg_replace_callback(";($comment)?\n\s*function ($funcName)($funcArgs)[ ]*($typeHint)?\s*($startBody)\n*;m", function ($m) {
         $func = $m[3];
 
         // Is our start-body basically empty (notwithstanding silly things - like `{}`, `//Comment`, and `return;`)?
-        $mStartBody = explode("\n", $m[5]);
+        $mStartBody = explode("\n", $m[6]);
         $mStartBody = preg_replace(';^\s*;', '', $mStartBody);
         $mStartBody = preg_grep(';^\/\/;', $mStartBody, PREG_GREP_INVERT);
         $mStartBody = preg_grep('/^$/', $mStartBody, PREG_GREP_INVERT);


### PR DESCRIPTION
Since 5.38 core supports an `<upgrader>` tag in liu of hooks, and a common base class.
For extensions where core version is >= 5.38, this will generate upgrader classes that use the common base, and the tag instead of delegated hooks.
It will also perform this cleanup on existing modules during each `civix upgrade`.