### PR TITLE
"generate:module" - Add option to specify compatibility of new modules. Use dynamic default.

### DIFF
--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -28,6 +28,7 @@ class InitCommand extends AbstractCommand {
       ->setDescription('Create a new CiviCRM Module-Extension (Regenerate module.civix.php if \"key\" not specified)')
       ->addArgument('key', InputArgument::OPTIONAL, "Extension identifier (Ex: \"foo_bar\" or \"org.example.foo-bar\")")
       ->addOption('enable', NULL, InputOption::VALUE_REQUIRED, 'Whether to auto-enable the new module (yes/no/ask)', 'ask')
+      ->addOption('compatibility', NULL, InputOption::VALUE_REQUIRED, 'Version of CiviCRM that we target (eg "5.30" or "current")', 'current')
       ->addOption('mixins', NULL, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'Automatically enable the listed mixins')
       ->addOption('license', NULL, InputOption::VALUE_OPTIONAL, 'License for the extension (' . implode(', ', $this->getLicenses()) . ')', $this->getDefaultLicense())
       ->addOption('author', NULL, InputOption::VALUE_REQUIRED, 'Name of the author', $this->getDefaultAuthor())
@@ -56,6 +57,8 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
+    Services::boot(['output' => $output]);
+
     $ctx = [];
     $ctx['type'] = 'module';
     if (!$input->getArgument('key')) {
@@ -95,6 +98,14 @@ class InitCommand extends AbstractCommand {
     else {
       $output->writeln('<error>Unrecognized license (' . $ctx['license'] . ')</error>');
       return;
+    }
+
+    if ($input->getOption('compatibility') === 'current') {
+      [$verMajor, $verMinor] = explode('.', \CRM_Utils_System::version());
+      $ctx['compatibilityVerMin'] = "$verMajor.$verMinor";
+    }
+    else {
+      $ctx['compatibilityVerMin'] = $input->getOption('compatibility');
     }
 
     if ($ctx['fullName'] !== $ctx['mainFile']) {

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -75,9 +75,9 @@ trait CivixProjectTestTrait {
     return new CommandTester($command);
   }
 
-  public function civixGenerateModule(string $key): CommandTester {
+  public function civixGenerateModule(string $key, array $options = []): CommandTester {
     $tester = static::civix('generate:module');
-    $tester->execute([
+    $tester->execute($options + [
       'key' => $key,
       '--enable' => 'false',
     ]);

--- a/tests/e2e/IdempotentUpgradeTest.php
+++ b/tests/e2e/IdempotentUpgradeTest.php
@@ -15,7 +15,7 @@ class IdempotentUpgradeTest extends \PHPUnit\Framework\TestCase {
   public function setUp(): void {
     chdir(static::getWorkspacePath());
     static::cleanDir(static::getKey());
-    $this->civixGenerateModule(static::getKey());
+    $this->civixGenerateModule(static::getKey(), ['--compatibility' => '5.0']);
     chdir(static::getKey());
   }
 

--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -11,7 +11,7 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
   public function setUp(): void {
     chdir(static::getWorkspacePath());
     static::cleanDir(static::getKey());
-    $this->civixGenerateModule(static::getKey());
+    $this->civixGenerateModule(static::getKey(), ['--compatibility' => '5.0']);
     chdir(static::getKey());
 
     $this->assertFileExists('info.xml');


### PR DESCRIPTION
This does three related this:

1. Allow an option like `civix generate:module --compatibility=5.0`
2. Use a default value (`--compatibility=current`) which inherits the current version from the locally installed CiviCRM instance. (Presumably, that's the version you will actually test against...)
3. Update some of the E2E tests to explicitly control for the initial `--compatibility`. These tests examine how the code changes with different compatibility targets.