### PR TITLE
Mixins - When toggling mixins, auto-raise the the `<compatibility>` flag.

### DIFF
--- a/tests/e2e/MixinMgmtTest.php
+++ b/tests/e2e/MixinMgmtTest.php
@@ -28,65 +28,117 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
   }
 
   public function testChangeCompatibility(): void {
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 1,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
     ]);
 
     $this->civixInfoSet('compatibility/ver', '5.45');
     $upgrade = $this->civix('upgrade');
     $this->assertEquals(0, $upgrade->execute([]));
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 0,
-      'mixin/setting-php@1.*.*.mixin.php' => 0,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 0]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on',
     ]);
   }
 
-  public function testEnableAllDisableAll(): void {
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 1,
+  /**
+   * In this example, we enable some of the original mixins - but omit some of the newer ones.
+   * We go back-and-forth, with enabling and disabling. At each step, we observe the status
+   * of the polyfill and the mixins.
+   */
+  public function testEnableSomeDisableAll(): void {
+    $this->assertEquals('5.27', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'off',
+      'scan-classes@1' => 'off',
     ]);
 
     $enableAll = $this->civix('mixin');
-    $this->assertEquals(0, $enableAll->execute(['--enable-all' => TRUE]));
+    $this->assertEquals(0, $enableAll->execute(['--enable' => 'menu-xml@1.0.0,mgd-php@1.0.0']));
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 1,
-      'mixin/case-xml@1.*.*.mixin.php' => 1,
-      'mixin/menu-xml@1.*.*.mixin.php' => 1,
-      'mixin/mgd-php@1.*.*.mixin.php' => 1,
+    $this->assertEquals('5.27', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'on+backport',
+      'mgd-php@1' => 'on+backport',
+      'scan-classes@1' => 'off',
     ]);
 
     $disableAll = $this->civix('mixin');
     $this->assertEquals(0, $disableAll->execute(['--disable-all' => TRUE]));
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 0,
-      'mixin/case-xml@1.*.*.mixin.php' => 0,
-      'mixin/menu-xml@1.*.*.mixin.php' => 0,
-      'mixin/mgd-php@1.*.*.mixin.php' => 0,
+    $this->assertEquals('5.27', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'off',
+      'menu-xml@1' => 'off',
+      'mgd-php@1' => 'off',
+      'scan-classes@1' => 'off',
+    ]);
+  }
+
+  /**
+   * In this example, we enable all currently known mixins. This may incidentally the `<compatibility>`
+   * and the set of backports.
+   */
+  public function testEnableAllDisableAll(): void {
+    $this->assertEquals('5.27', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'off',
+      'scan-classes@1' => 'off',
+    ]);
+
+    $enableAll = $this->civix('mixin');
+    $this->assertEquals(0, $enableAll->execute(['--enable-all' => TRUE]));
+    // Enabling _all_ mixins brings in 'scan-classes@1', which causes the <ver> to go higher (5.51).
+
+    $this->assertEquals('5.51', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 0]);
+    $this->assertMixinStatuses([
+      // These are active but don't need backports (for 5.51).
+      'setting-php@1' => 'on',
+      'menu-xml@1' => 'on',
+      'scan-classes@1' => 'on',
+      'mgd-php@1' => 'on',
+    ]);
+
+    $disableAll = $this->civix('mixin');
+    $this->assertEquals(0, $disableAll->execute(['--disable-all' => TRUE]));
+
+    $this->assertEquals('5.51', trim($this->civixInfoGet('compatibility/ver')->getDisplay()));
+    $this->assertFileGlobs(['mixin/polyfill.php' => 0]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'off',
+      'menu-xml@1' => 'off',
+      'scan-classes@1' => 'off',
+      'mgd-php@1' => 'off',
     ]);
   }
 
   public function testAddPageFor530(): void {
     $this->civixInfoSet('compatibility/ver', '5.30');
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 1,
-      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'off',
     ]);
 
     $this->civixGeneratePage('Thirty', 'civicrm/thirty');
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/menu-xml@1.*.*.mixin.php' => 1,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'on+backport',
     ]);
+
     $content = file_get_contents('civix_mixinrec.civix.php');
     $this->assertRegExp('|function _civix_mixinrec_civix_mixin_polyfill\(\) \{|', $content);
     $this->assertRegExp('|_civix_mixinrec_civix_mixin_polyfill\(\);|', $content);
@@ -95,19 +147,19 @@ class MixinMgmtTest extends \PHPUnit\Framework\TestCase {
   public function testAddPageFor545(): void {
     $this->civixInfoSet('compatibility/ver', '5.45');
 
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 1,
-      'mixin/setting-php@1.*.*.mixin.php' => 1,
-      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 1]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on+backport',
+      'menu-xml@1' => 'off',
     ]);
 
     $this->civixGeneratePage('FortyFive', 'civicrm/forty-five');
 
     // Not only do we omit 'menu-xml' backport... but we also clean-up the extras...
-    $this->assertFileGlobs([
-      'mixin/polyfill.php' => 0,
-      'mixin/setting-php@1.*.*.mixin.php' => 0,
-      'mixin/menu-xml@1.*.*.mixin.php' => 0,
+    $this->assertFileGlobs(['mixin/polyfill.php' => 0]);
+    $this->assertMixinStatuses([
+      'setting-php@1' => 'on',
+      'menu-xml@1' => 'on',
     ]);
 
     $content = file_get_contents('civix_mixinrec.civix.php');


### PR DESCRIPTION
If you activate a mixin that declares `minimum => 5.45`, then your `info.xml` should require at least `5.45.`

The update should manipulate `<compatibility>` automatically across a range of commands/use-cases. It will show messages about when+why it changes `<compatibility>`.

(*It might be nicer to prompt for confirmation, but -- in this case -- it takes more work than it's worth. And anyone who uses `git` will still have an extra opportunity to consider the change.*)

For nerding purposes, here are a few examples/edge-cases of how `<compatibility>` is updated:

* `civix mixin --enable=menu-xml@1.0.0`
    * __Description__: The mixin requires `minimum=>5.27`. Enabling it will cause the `<compatibility>` constraint to go up to `<ver>5.27</ver>`. (If you already require 5.27+, then the requirement won't change.)
    * __Note__: Given that all the original mixins have `minimum=>5.27`, civix will now exert a strong bias toward setting `<compatibility>` to at least `<ver>5.27</ver>`.
    * __Note__: The number 5.27 is slightly arbitrary -- it's the oldest version that I tested when adding mixin support. If someone tests further back, then we can change this.
* `civix mixin --enable=scan-classes@1.0.0`
    * __Description__: This mixin requires `minimum=>5.51`. Enabling it will cause the `<compatibility>` constraint to go up to `<ver>5.51</ver>`.
    * __Note__: The mixin is also `provided-by=>5.51`, so there's no point in backporting.
* `civix mixin --enable=entity-types-php@1.0.0` (with the pending PR #272)
    * __Description__: This mixin requires `minimum=>5.45`. Enabling it will cause the `<compatibility>` constraint to go up to `<ver>5.45</ver>`. 
    * __Note__: For 5.45, the backport-file will be included. However, if you manually bump to  `<ver>5.57</ver>`, then the backport-file will be skipped.
