### PR TITLE
Reinstante lifecycle hooks (partially). Always uses 5.38-style `<upgrader>`.

### DIFF
--- a/scripts/load-snapshot.sh
+++ b/scripts/load-snapshot.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+
+## Load an snapshot, i.e.
+## - Clean the test site.
+## - Extract the snapshot into the test site.
+## - Install the extension
+
+################################################
+function usage() {
+  echo "$0 [-r] [-x] [-g] [-e] [-u] [-s <source>] "
+  echo
+  echo "Data:"
+  echo "-s     (Source)   Specify which snapshot file to load"
+  echo
+  echo "Actions:"
+  echo "-r     (Reset)    Reset Civi DB"
+  echo "-x     (Extract)  Extract the zip file to a temporary folder"
+  echo "-g     (Git)      Add temporary folder to a temporary git repo"
+  echo "-e     (Enable)   Enable the extension in CiviCRM"
+  echo "-u     (Upgrade)   Run civix upgrades"
+  echo
+  echo "Example:"
+  echo "  $0 -rxge -s tests/snapshots/org.example.civixsnapshot-v19.11.0-kitchensink/"
+  echo
+  echo "NOTE: Actions are executed in requested order. So these two are slightly different:"
+  echo "  $0 -rxgeu    (restore => extract => git => enable => upgrade)"
+  echo "  $0 -rxgue    (restore => extract => git => upgrade => enable)"
+}
+
+################################################
+EXMODULE=${EXMODULE:-org.example.civixsnapshot}
+#SNAPSHOT="$1"
+#shift
+SNAPSHOT=
+TASKS=
+while getopts "hs:rxgeu" opt; do
+  case $opt in
+    h) usage ; exit ; ;;
+    s) SNAPSHOT="$OPTARG" ; ;;
+    r) TASKS="$TASKS restore" ; ;;
+    x) TASKS="$TASKS extract" ; ;;
+    g) TASKS="$TASKS git" ; ;;
+    e) TASKS="$TASKS enable" ; ;;
+    u) TASKS="$TASKS upgrade" ; ;;
+  esac
+done
+
+echo "SNAPSHOT=[$SNAPSHOT] TASKS=[$TASKS]"
+if [  -z "$TASKS" -o -z "$SNAPSHOT" ]; then
+  usage 2>&1
+  exit 1
+fi
+
+################################################
+## Didn't set a workspace? Educated guess...
+if [ -z "$CIVIX_WORKSPACE" -a -d "$CIVIBUILD_HOME/dmaster/web/sites/all/modules/civicrm" ]; then
+  export CIVIX_WORKSPACE="$CIVIBUILD_HOME/dmaster/web/sites/all/modules/civicrm/ext/civixtest"
+  echo "Inferred CIVIX_WORKSPACE=$CIVIX_WORKSPACE"
+fi
+if [ -z "$CIVIX_WORKSPACE" ]; then
+  echo "Missing env var: CIVIX_WORKSPACE"
+  exit 1
+fi
+
+################################################
+## Main
+
+if [ -n "$SNAPSHOT" -a -e "$SNAPSHOT/original.zip" ]; then
+  SNAPSHOT="$SNAPSHOT/original.zip"
+fi
+
+if [ -z "$SNAPSHOT" -o ! -e "$SNAPSHOT" ]; then
+  echo "Usage: $0 <snapshot-file>"
+  exit 1
+fi
+
+set -ex
+
+## Convert to absolute path
+ZIP=$(readlink -f "$SNAPSHOT")
+if [ ! -f "$ZIP" ]; then
+  echo "Error resolving $SNAPSHOT to file"
+  exit 1
+fi
+
+## Go extract it
+pushd "$CIVIX_WORKSPACE"
+  for TASK in $TASKS ; do
+    case "$TASK" in
+      restore) civibuild restore ; ;;
+      extract) [ -d "$EXMODULE" ] && rm -rf "$EXMODULE" ; unzip "$ZIP" ; ;;
+      git)
+        pushd "$EXMODULE"
+          git init
+          git add .
+          git commit -m skeleton
+        popd
+        ;;
+      enable) cv en "$EXMODULE" ; ;;
+      upgrade) echo "FIXME: Need CIVIX var" ; ;;
+      # upgrade) pushd "$EXMODULE" && $CIVIX upgrade && popd ; ;;
+      *) echo "Unrecognized task: $TASK" ; exit 1; ;;
+    esac
+  done
+popd
+
+echo "Output: $CIVIX_WORKSPACE/$EXMODULE"

--- a/scripts/make-snapshots.sh
+++ b/scripts/make-snapshots.sh
@@ -55,7 +55,7 @@ function build_snapshot() {
   [ -f "$zipfile" ] && rm -f "$zipfile"
   [ ! -d "$snapdir" ] && mkdir -p "$snapdir"
 
-  $CIVIX $VERBOSITY generate:module "$EXMODULE" --enable=no --no-interaction
+  $CIVIX $VERBOSITY generate:module "$EXMODULE" --enable=no --no-interaction --compatibility=5.0
 
   pushd "$EXMODULE"
   case "$name" in

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -87,7 +87,6 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $io->title('General upgrade');
 
     $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
-    $upgrader->cleanUpgraderBase();
     $upgrader->cleanEmptyHooks();
     $upgrader->reconcileMixins();
 

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -88,6 +88,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
 
     $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
     $upgrader->cleanEmptyHooks();
+    $upgrader->cleanEmptyLines();
     $upgrader->reconcileMixins();
 
     /**

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -3,13 +3,6 @@ echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 $_compatibility = isset($compatibilityVerMin) ? $compatibilityVerMin : '5.0';
 $_invokePolyfill = version_compare($_compatibility, '5.45.beta1', '<') ? sprintf("  _%s_civix_mixin_polyfill();\n", $mainFile) : '';
-$_delegateToUpgrader = function (string $op, string $params = '') use ($_compatibility, $mainFile) {
-  if (!version_compare($_compatibility, '5.38', '>=')) {
-    printf("  if (\$upgrader = _%s_civix_upgrader() && is_callable([\$upgrader, %s])) {\n", $mainFile, var_export($op, 1));
-    printf("    \$upgrader->%s(%s);\n", $op, $params);
-    printf("  }\n");
-  }
-}
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file
@@ -135,29 +128,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _<?php echo $mainFile ?>_civix_civicrm_install() {
-  _<?php echo $mainFile ?>_civix_civicrm_config();
-<?php $_delegateToUpgrader('onInstall'); ?>
 <?php echo $_invokePolyfill; ?>
-}
-
-/**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function _<?php echo $mainFile ?>_civix_civicrm_postInstall() {
-  _<?php echo $mainFile ?>_civix_civicrm_config();
-<?php $_delegateToUpgrader('onPostInstall'); ?>
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function _<?php echo $mainFile ?>_civix_civicrm_uninstall(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_config();
-<?php $_delegateToUpgrader('onUninstall'); ?>
 }
 
 /**
@@ -166,48 +137,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_uninstall(): void {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _<?php echo $mainFile ?>_civix_civicrm_enable(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_config();
-<?php $_delegateToUpgrader('onEnable'); ?>
 <?php echo $_invokePolyfill; ?>
-}
-
-/**
- * (Delegated) Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- * @return mixed
- */
-function _<?php echo $mainFile ?>_civix_civicrm_disable(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_config();
-<?php $_delegateToUpgrader('onDisable'); ?>
-}
-
-/**
- * (Delegated) Implements hook_civicrm_upgrade().
- *
- * @param $op string, the type of operation being performed; 'check' or 'enqueue'
- * @param $queue CRM_Queue_Queue, (for 'enqueue') the modifiable list of pending up upgrade tasks
- *
- * @return mixed
- *   based on op. for 'check', returns array(boolean) (TRUE if upgrades are pending)
- *   for 'enqueue', returns void
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function _<?php echo $mainFile ?>_civix_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-<?php $_delegateToUpgrader('onUpgrade', '$op, $queue'); ?>
-}
-
-/**
- * @return <?php echo $_namespace ?>_Upgrader
- */
-function _<?php echo $mainFile ?>_civix_upgrader() {
-  if (!file_exists(__DIR__ . '/<?php echo $namespace ?>/Upgrader.php')) {
-    return NULL;
-  }
-  else {
-    return <?php echo $_namespace ?>_Upgrader_Base::instance();
-  }
 }
 
 /**

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -2,7 +2,9 @@
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 $_compatibility = isset($compatibilityVerMin) ? $compatibilityVerMin : '5.0';
-$_invokePolyfill = version_compare($_compatibility, '5.45.beta1', '<') ? sprintf("  _%s_civix_mixin_polyfill();\n", $mainFile) : '';
+$_invokePolyfill = version_compare($_compatibility, '5.45.beta1', '<')
+  ? sprintf("  _%s_civix_mixin_polyfill();\n", $mainFile)
+  : "  // Based on <compatibility>, this does not currently require mixin/polyfill.php.\n";
 ?>
 
 // AUTO-GENERATED FILE -- Civix may overwrite any changes made to this file

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -130,6 +130,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_config(&$config = NULL) {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_install
  */
 function _<?php echo $mainFile ?>_civix_civicrm_install() {
+  _<?php echo $mainFile ?>_civix_civicrm_config();
 <?php echo $_invokePolyfill; ?>
 }
 
@@ -139,6 +140,7 @@ function _<?php echo $mainFile ?>_civix_civicrm_install() {
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function _<?php echo $mainFile ?>_civix_civicrm_enable(): void {
+  _<?php echo $mainFile ?>_civix_civicrm_config();
 <?php echo $_invokePolyfill; ?>
 }
 

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -27,48 +27,12 @@ function <?php echo $mainFile ?>_civicrm_install(): void {
 }
 
 /**
- * Implements hook_civicrm_postInstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_postInstall
- */
-function <?php echo $mainFile ?>_civicrm_postInstall(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_postInstall();
-}
-
-/**
- * Implements hook_civicrm_uninstall().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_uninstall
- */
-function <?php echo $mainFile ?>_civicrm_uninstall(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_uninstall();
-}
-
-/**
  * Implements hook_civicrm_enable().
  *
  * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_enable
  */
 function <?php echo $mainFile ?>_civicrm_enable(): void {
   _<?php echo $mainFile ?>_civix_civicrm_enable();
-}
-
-/**
- * Implements hook_civicrm_disable().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_disable
- */
-function <?php echo $mainFile ?>_civicrm_disable(): void {
-  _<?php echo $mainFile ?>_civix_civicrm_disable();
-}
-
-/**
- * Implements hook_civicrm_upgrade().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_upgrade
- */
-function <?php echo $mainFile ?>_civicrm_upgrade($op, CRM_Queue_Queue $queue = NULL) {
-  return _<?php echo $mainFile ?>_civix_civicrm_upgrade($op, $queue);
 }
 
 /**

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -349,6 +349,13 @@ class Upgrader {
     });
   }
 
+  public function cleanEmptyLines(): void {
+    $this->updateModulePhp(function($infoXml, $content) {
+      // It might be better to cleanup more stuff, but this is enough to get IdempotentUpgradeTest to pass.
+      return rtrim($content, "\n") . "\n";
+    });
+  }
+
   /**
    * Ensure that the `mixin/` folder is in-sync with the current 'info.xml'.
    */

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -380,10 +380,10 @@ class Upgrader {
     if ($useCore) {
       $prefix = $this->infoXml->getFile();
       $this->removeHookDelegation([
-        "_{$prefix}_civix_civicrm_install",
+        // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_install",
         "_{$prefix}_civix_civicrm_postInstall",
         "_{$prefix}_civix_civicrm_uninstall",
-        "_{$prefix}_civix_civicrm_enable",
+        // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_enable",
         "_{$prefix}_civix_civicrm_disable",
         "_{$prefix}_civix_civicrm_upgrade",
       ]);

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -368,46 +368,6 @@ class Upgrader {
     });
   }
 
-  /**
-   * Since 5.38 core supports an <upgrader> tag in liu of hooks, and a common base class.
-   *
-   * Remove hook delegations from module.php and add <upgrader> to info.xml
-   * Switch upgrader base class to use the one in core and remove the boilerplate version
-   */
-  public function cleanUpgraderBase(): void {
-    $compatVer = $this->infoXml->getCompatibilityVer();
-    $useCore = version_compare($compatVer, '5.38', '>=');
-    if ($useCore) {
-      $prefix = $this->infoXml->getFile();
-      $this->removeHookDelegation([
-        // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_install",
-        "_{$prefix}_civix_civicrm_postInstall",
-        "_{$prefix}_civix_civicrm_uninstall",
-        // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_enable",
-        "_{$prefix}_civix_civicrm_disable",
-        "_{$prefix}_civix_civicrm_upgrade",
-      ]);
-      $nameSpace = $this->infoXml->getNamespace();
-      $upgraderFile = $this->baseDir->string($nameSpace . DIRECTORY_SEPARATOR . 'Upgrader.php');
-      $upgraderBaseFile = $this->baseDir->string($nameSpace . DIRECTORY_SEPARATOR . 'Upgrader' . DIRECTORY_SEPARATOR . 'Base.php');
-      if (file_exists($upgraderFile)) {
-        $crmPrefix = preg_replace(':/:', '_', $nameSpace);
-        // Add <upgrader> tag
-        if (!$this->infoXml->get()->xpath('upgrader')) {
-          $this->infoXml->get()->addChild('upgrader', $crmPrefix . '_Upgrader');
-          $this->infoXml->save($this->_ctx, $this->output);
-        }
-        // Switch base class
-        file_put_contents($upgraderFile,
-          str_replace("{$crmPrefix}_Upgrader_Base", 'CRM_Extension_Upgrader_Base', file_get_contents($upgraderFile))
-        );
-      }
-      if (file_exists($upgraderBaseFile)) {
-        unlink($upgraderBaseFile);
-      }
-    }
-  }
-
   // -------------------------------------------------
   // These are some helper utilities.
 

--- a/upgrades/22.12.1.up.php
+++ b/upgrades/22.12.1.up.php
@@ -1,0 +1,69 @@
+<?php
+
+use CRM\CivixBundle\Utils\Naming;
+
+/**
+ * v5.38 supports an <upgrader> tag and a common base class. Updates:
+ * - Remove hook delegations from module.php.
+ * - Add <upgrader> to info.xml
+ * - Use core's base class
+ * - Remove old base class
+ */
+return function (\CRM\CivixBundle\Upgrader $upgrader) {
+  $io = $upgrader->io;
+  $io->section('Lifecycle Hooks: Install, Upgrade, etc');
+
+  $MIN_COMPAT = '5.38';
+  $nameSpace = $upgrader->infoXml->getNamespace();
+  $upgraderClass = Naming::createClassName($nameSpace, 'Upgrader');
+  $upgraderFile = Naming::createClassFile($nameSpace, 'Upgrader');
+  $upgraderBaseClass = Naming::createClassName($nameSpace, 'Upgrader', 'Base');
+  $upgraderBaseFile = Naming::createClassFile($nameSpace, 'Upgrader', 'Base');
+  // $upgraderFile = $upgrader->baseDir->string(Naming::createClassFile($nameSpace, 'Upgrader'));
+  // $upgraderBaseFile = $upgrader->baseDir->string(Naming::createClassFile($nameSpace, 'Upgrader', 'Base'));
+  $hasUpgrader = file_exists($upgraderFile);
+
+  $notes = [];
+  $notes[] = 'Old templates included ~10 boilerplate functions to handle lifecycle events (hook_install, hook_upgrade, hook_uninstall, etc).';
+  $notes[] = $hasUpgrader
+    ? "With CiviCRM $MIN_COMPAT+, these can be simplified or removed. Instead, we will use the \"info.xml\" directive for \"<upgrader>\"."
+    : 'Much of this boilerplate can be simplified or removed.';
+  $io->note($notes);
+
+  if ($hasUpgrader && version_compare($upgrader->infoXml->getCompatibilityVer(), $MIN_COMPAT, '<')) {
+    $io->warning("The minimum required version of CiviCRM will increase to $MIN_COMPAT.");
+  }
+
+  if (!$io->confirm('Continue with upgrade?')) {
+    throw new \RuntimeException('User stopped upgrade');
+  }
+
+  $prefix = $upgrader->infoXml->getFile();
+  $upgrader->removeHookDelegation([
+    // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_install",
+    "_{$prefix}_civix_civicrm_postInstall",
+    "_{$prefix}_civix_civicrm_uninstall",
+    // Needed by mixin-polyfill: "_{$prefix}_civix_civicrm_enable",
+    "_{$prefix}_civix_civicrm_disable",
+    "_{$prefix}_civix_civicrm_upgrade",
+  ]);
+
+  if ($hasUpgrader) {
+    $upgrader->updateInfo(function(\CRM\CivixBundle\Builder\Info $info) use ($MIN_COMPAT, $upgraderClass) {
+      $info->raiseCompatibilityMinimum($MIN_COMPAT);
+      // Add <upgrader> tag
+      if (!$info->get()->xpath('upgrader')) {
+        $info->get()->addChild('upgrader', $upgraderClass);
+      }
+    });
+    // Switch base class
+    $upgrader->updateTextFiles([$upgraderFile], function(string $file, string $content) use ($upgraderBaseClass) {
+      return str_replace($upgraderBaseClass, 'CRM_Extension_Upgrader_Base', $content);
+    });
+  }
+
+  if (file_exists($upgraderBaseFile)) {
+    unlink($upgraderBaseFile);
+  }
+
+};


### PR DESCRIPTION
This is a follow-up/re-roll to the recent #270. Its main purpose is to fix the regression where new extensions have mis-linked stubs. The approach is to go all-in on 5.38-style `<upgrader>` classes -- but to preserve the edifice needed for mixin-polyfill.

## Example

If you have an extension that targets `5.0` and defines `CRM_*_Upgrader`, then `civix upgrade` will produce this:

<img width="856" alt="Screen Shot 2022-11-28 at 6 14 13 PM" src="https://user-images.githubusercontent.com/1336047/204422624-297753ab-62dc-4d53-9489-ed514eaf32e6.png">

The message gets simpler in other circumstances -- e.g.

* If you don't have `CRM_*_Upgrader`, then some of the bullets go away.
* If you don't have `CRM_*_Upgrader`, or if you already require 5.38+, then the warning goes away.

## Technical Details

* `CRM_*_Upgrader`
    * (**Invariant condition for v22.12**) `CRM_*_Upgrader` requires CiviCRM v5.38.
    * If you have an extension which already uses `CRM_*_Upgrader`, then `civix upgrade` will update `info.xml` (ie `<upgrader>` and possibly `<compatibility>`).
    * If you have a new extension and call `civix generate:upgrader`, then it will update `info.xml` (ie `<upgrader>` and possibly `<compatibility>`).
* `hook_postInstall`, `hook_disable`, `hook_uninstall`
    * (**Invariant condition for v22.12**) civix does *not* use these hooks.
    * (`mymodule.civix.php`) Removed these hook implementations (across-the-board/unconditionally)
    * (`mymodule.php`) Removed stubs for new renditions of `mymodule.php`. For existing renditions of `mymodule.php`, perform a soft-removal (*ie drop the old delegation code; if the function becomes empty, then drop that*).
* `hook_install` and `hook_enable`
    * (**Invariant condition for v22.12**) civix does use these these hooks.
    * (`mymodule.civix.php`) Preserve these hook implementations. However, the content becomes shorter/simpler -- they no longer call `CRM_*_Upgrader`.
    * (`mymodule.php`) Preserve these stubs.
    * (**Note**) As always, clever developers who know what they're doing can delete stubs from `mymodule.php`.
    * (**Note**) We could revisit after (say...) March 2023 and consider raising the minimum to 5.45 -- which should make these unnecessary.

## Edge Case: hook_install and "include paths"

~~There is one edge-case that may be broken by this regime. (This probably broke in #270, but I reinforced the breakage in this branch.) The old versions of `hook_install` (etal) delegated down to to `_civix_civicrm_config()` to ensure that the include-paths were setup. Historically, this was important for class-loading - but it shouldn't matter now that v22.10+ defines `<psr0>`.. It could theoretically be an issue for Smarty's include-path -- but I've searched `universe` and only found two places where an upgrader references `smarty` or `tpl`. This PR checks for similar references and prompts the developer to investigate:~~

<img width="861" alt="Screen Shot 2022-11-28 at 6 47 43 PM" src="https://user-images.githubusercontent.com/1336047/204426382-47fff3ef-412f-47aa-b000-4a6bf27aea30.png">

(*REVISED*) Rereading this, it strikes me that the include-path issue also affects APIv3. It is much more plausible for that cuase trouble. Need to look at that.

(*There's also potential impact for class-overrides, but it's extremely edgy, and my interest in investigating that angle is... ehm... *)