### PR TITLE
Apply update polyfill. Add test coverage for generating multiple extensions. (#257)

### DIFF
--- a/mixin-backports.php
+++ b/mixin-backports.php
@@ -5,8 +5,9 @@
  */
 return [
   'polyfill' => [
-    'sha256' => '5377fc936628875cec195737ccc22d5b8c72ed562d2aef460f9dc07dbe773613',
-    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/5.45.3/mixin/polyfill.php',
+    'sha256' => '4a60b871ca6ef75172459667e130d0692998d10b6ee59cfc3be541e50d0da3f7',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/f55a0e7978c92e76c18cd613ece11489052b5b33/mixin/polyfill.php',
+    // ^^ This link can be updated when there is tag for 5.58.
     'local' => 'extern/mixin/polyfill.php',
     'provided-by' => '5.45.beta1',
     'minimum' => '5.27', /* Compat may go back further; haven't tested */

--- a/tests/e2e/MultiExtensionTest.php
+++ b/tests/e2e/MultiExtensionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace E2E;
+
+use ProcessHelper\ProcessHelper as PH;
+
+/**
+ * For this test, we create and enable two extensions.
+ * They should coexist.
+ */
+class MultiExtensionTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $keys = ['apple', 'banana'];
+
+  public static $key = '**INVALID**';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    PH::runOk('civibuild restore');
+
+    foreach (static::$keys as $key) {
+      static::cleanDir($key);
+      $this->civixGenerateModule($key);
+    }
+
+    foreach ($this->visitExts() as $name) {
+      $this->assertFileGlobs([
+        'info.xml' => 1,
+        "$name.php" => 1,
+        "$name.civix.php" => 1,
+      ]);
+    }
+  }
+
+  protected function tearDown(): void {
+    chdir(static::getWorkspacePath());
+    PH::runOk('civibuild restore');
+  }
+
+  public function testAddPage(): void {
+    foreach ($this->visitExts() as $name) {
+      $camel = ucfirst($name);
+      $this->assertFileGlobs(["CRM/$camel/Page/My$camel.php" => 0]);
+      $this->civixGeneratePage("My$camel", "civicrm/example/$name");
+      $this->assertFileGlobs(["CRM/$camel/Page/My$camel.php" => 1]);
+
+      PH::runOK('cv en ' . escapeshellarg($name));
+    }
+
+    foreach ($this->visitExts() as $name) {
+      $camel = ucfirst($name);
+      $getPage = PH::runOK("cv api4 Route.get +w path=civicrm/example/$name +s page_callback");
+      $this->assertTrue((bool) preg_match("/CRM_{$camel}_Page_My{$camel}/", $getPage->getOutput()), "Route 'civicrm/example/$name' should be registered");
+    }
+  }
+
+  protected function visitExts(): \Generator {
+    foreach (static::$keys as $key) {
+      static::$key = $key;
+      chdir(static::getWorkspacePath());
+      chdir($key);
+      yield $key;
+    }
+    chdir(static::getWorkspacePath());
+  }
+
+}


### PR DESCRIPTION
The test creates two extensions. I've run it on 5.44 (which requires the polyfill). The test fails with the old revision of the polyfill -- and passes with @jaapjansma's updated revision. Woot.