### PR TITLE
Only add templates dir if it exists

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -109,7 +109,9 @@ function _<?php echo $mainFile ?>_civix_civicrm_config($config = NULL) {
 
   $extRoot = __DIR__ . DIRECTORY_SEPARATOR;
   $extDir = $extRoot . 'templates';
-  CRM_Core_Smarty::singleton()->addTemplateDir($extDir);
+  if (file_exists($extDir)) {
+    CRM_Core_Smarty::singleton()->addTemplateDir($extDir);
+  }
 
   $include_path = $extRoot . PATH_SEPARATOR . get_include_path();
   set_include_path($include_path);


### PR DESCRIPTION
On trying to upgrade some extensions `addTemplateDir` actions I was struck by how many of the extensions are adding template directories that don't exist. I feel like this must be at least marginally worse for performance & it feels a bit confusing

@totten 