### PR TITLE
upgrades/23.02.1 - Suggest enabling the "Civi" namespace

### DIFF
--- a/upgrades/23.02.1.up.php
+++ b/upgrades/23.02.1.up.php
@@ -1,0 +1,32 @@
+<?php
+
+/**
+ * Circa v19.11.0, it became a default to add the psr4 rule for "Civi" folders.
+ * However, as older extensions adopt newer technologies (like `Civi\Api4`), it helps
+ * to add a similar to them.
+ */
+return function (\CRM\CivixBundle\Upgrader $upgrader) {
+
+  $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
+    /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+    $io = $upgrader->io;
+
+    $loaders = $info->getClassloaders();
+    $prefixes = array_column($loaders, 'prefix');
+    if (!in_array('Civi\\', $prefixes)) {
+      $io->section('"Civi" Class-loader');
+      $io->note([
+        'Technologies like APIv4 may require you to use the "Civi" namespace, which is not enabled on this extension.',
+        'You can automatically add the "Civi" namespace now to get prepared, or you can skip this.',
+        '(If you change your mind later, then simply edit "info.xml" to add or remove "<classloader>" rules.)',
+      ]);
+
+      if ($io->confirm('Add the "Civi" namespace?')) {
+        $loaders[] = ['type' => 'psr4', 'prefix' => 'Civi\\', 'path' => '.'];
+        $info->setClassLoaders($loaders);
+      }
+    }
+
+  });
+
+};


### PR DESCRIPTION
Overview
-------------

On Mattermost, it came up that folks often get tripped-up when their existing extension doesn't have the `Civi` namespace turned on.

This PR adds an upgrade-step to turn it on:

![Screenshot from 2023-02-24 14-27-04](https://user-images.githubusercontent.com/1336047/221305402-a988a049-7ef3-4182-83b5-d2f8ae2e5cef.png)


Comments
--------------

For many authors with existing extensions, it's probably better to enable this proactively. It's a bit obscure, and it's already enabled by default on new extensions. If you omit this and need it, then it can take an hour of debugging to figure out why classes don't load.

Still, this is not strongly required.  Many existing extensions work fine without it.  There's a small performance argument for keeping it disabled if you don't need it.

So this update presents the option.  Even if the developer say no, it should at least promote some consciousness about classloading (*and thereby reduce future debug times*).