### PR TITLE
mixin-backports - Update smarty-v2 (1.0.0 => 1.0.1)

### DIFF
--- a/mixin-backports.php
+++ b/mixin-backports.php
@@ -78,9 +78,9 @@ return [
     'minimum' => '5.27', /* Compat may go back further; haven't tested */
   ],
   'smarty-v2@1' => [
-    'version' => '1.0.0',
-    'sha256' => '0264d19df83e53d317aa7a192ab4bad324c93c21d3d423174e7d2bf14785bd2e',
-    'remote' => 'https://github.com/civicrm/civicrm-core/raw/d40b449db6f769dba244388938cffacf3a636b5d/mixin/smarty-v2%401/mixin.php',
+    'version' => '1.0.1',
+    'sha256' => '6b1e05facc17d414d8e99faf5bdd9fe694ff92cc3d7f9a05e2fe6fc63e3d1948',
+    'remote' => 'https://github.com/civicrm/civicrm-core/raw/7168793c03ef57c06bbfe45f5ff873ebb3657806/mixin/smarty-v2%401/mixin.php',
     'local' => 'extern/mixin/smarty-v2@1/mixin.php',
     'provided-by' => '5.59',
     'minimum' => '5.27', /* Compat may go back to 5.25; only really tested 5.33 */


### PR DESCRIPTION
Should fix warning mentioned in #294.

v1.0.1 was tested previously as part of https://github.com/civicrm/civicrm-core/pull/25667