### PR TITLE
composer.json - Update "cv" requirement. Support "Standalone".

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,7 +51,7 @@
         ],
         "downloads": {
           "bootstrap": {
-              "version": "v0.3.14",
+              "version": "v0.3.43",
               "url": "https://raw.githubusercontent.com/civicrm/cv/{$version}/src/Bootstrap.php",
               "path": "extern/src/Civi/Cv/Bootstrap.php",
               "type": "file"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "14d309f3d68bea8e3bd89dfe8aea27db",
+    "content-hash": "b4081b2cdf5a2260ffbb52a8cd2b007d",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -1273,5 +1273,5 @@
     "platform-overrides": {
         "php": "7.2.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.3.0"
 }


### PR DESCRIPTION
This enables `civix` to run on civicrm-standalone. It brings in a newer bootstrap library from `cv.get`.