### PR TITLE
Update cv library. Respect CIVICRM_BOOT or CIVICRM_SETTINGS.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     "license": "AGPL-3.0",
     "require": {
         "php": ">=7.3.0",
+        "civicrm/cv-lib": "~0.3.44",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
         "symfony/console": "^4|^5",
@@ -19,7 +20,6 @@
     "autoload": {
         "psr-0": {
             "Mixlib": "extern/src/",
-            "Civi\\Cv": "extern/src/",
             "CRM\\CivixBundle": "src/"
          }
     },
@@ -50,12 +50,6 @@
             }
         ],
         "downloads": {
-          "bootstrap": {
-              "version": "v0.3.43",
-              "url": "https://raw.githubusercontent.com/civicrm/cv/{$version}/src/Bootstrap.php",
-              "path": "extern/src/Civi/Cv/Bootstrap.php",
-              "type": "file"
-          },
           "mixlib": {
               "version": "5.45",
               "url": "https://raw.githubusercontent.com/civicrm/civicrm-core/{$version}/tools/mixin/src/Mixlib.php",

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/totten/civix",
     "license": "AGPL-3.0",
     "require": {
-        "php": ">=7.2.0",
+        "php": ">=7.3.0",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
         "symfony/console": "^4|^5",
@@ -32,7 +32,7 @@
           "civicrm/composer-downloads-plugin": true
         },
         "platform": {
-          "php": "7.2.0"
+          "php": "7.3.0"
         },
         "bin-dir": "bin"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6d25be2fb982e1b021998a7e2fba372b",
+    "content-hash": "51b24f21ca09ac6dbc30b84efe25fc77",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -110,6 +110,49 @@
             "time": "2020-11-02T05:26:23+00:00"
         },
         {
+            "name": "civicrm/cv-lib",
+            "version": "v0.3.44",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/civicrm/cv-lib.git",
+                "reference": "34cd212d371d541c53f180e7382880dcaeb01d37"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/civicrm/cv-lib/zipball/34cd212d371d541c53f180e7382880dcaeb01d37",
+                "reference": "34cd212d371d541c53f180e7382880dcaeb01d37",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "php": ">=7.3.0",
+                "psr/log": "~1.1 || ~2.0 || ~3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Civi\\Cv\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "description": "Bootstrap library for CiviCRM CLI tools",
+            "support": {
+                "source": "https://github.com/civicrm/cv-lib/tree/v0.3.44"
+            },
+            "time": "2023-07-12T04:38:41+00:00"
+        },
+        {
             "name": "psr/container",
             "version": "1.0.0",
             "source": {
@@ -161,6 +204,56 @@
                 "source": "https://github.com/php-fig/container/tree/master"
             },
             "time": "2017-02-14T16:28:37+00:00"
+        },
+        {
+            "name": "psr/log",
+            "version": "1.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/d49695b909c3b7628b6289db5479a1c204601f11",
+                "reference": "d49695b909c3b7628b6289db5479a1c204601f11",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/log/tree/1.1.4"
+            },
+            "time": "2021-05-03T11:20:27+00:00"
         },
         {
             "name": "symfony/console",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b4081b2cdf5a2260ffbb52a8cd2b007d",
+    "content-hash": "6d25be2fb982e1b021998a7e2fba372b",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -1267,11 +1267,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.2.0"
+        "php": ">=7.3.0"
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.0"
+        "php": "7.3.0"
     },
     "plugin-api-version": "2.3.0"
 }

--- a/src/CRM/CivixBundle/Services.php
+++ b/src/CRM/CivixBundle/Services.php
@@ -18,10 +18,19 @@ class Services {
   public static function boot($options = []) {
     if (!isset(self::$cache['boot'])) {
       $cwd = getcwd();
-      $options = array_merge(['prefetch' => FALSE], $options);
-      Bootstrap::singleton()->boot($options);
-      \CRM_Core_Config::singleton();
-      \CRM_Utils_System::loadBootStrap([], FALSE);
+      // TODO: It might be better for civix commands to use cv's BootTrait.
+      if (!empty(getenv('CIVICRM_BOOT'))) {
+        \Civi\Cv\CmsBootstrap::singleton()
+          ->addOptions($options)
+          ->bootCms()
+          ->bootCivi();
+      }
+      else {
+        $options = array_merge(['prefetch' => FALSE], $options);
+        Bootstrap::singleton()->boot($options);
+        \CRM_Core_Config::singleton();
+        \CRM_Utils_System::loadBootStrap([], FALSE);
+      }
       chdir($cwd);
       self::$cache['boot'] = 1;
     }


### PR DESCRIPTION
This update aims to resolve an issue identified in the discussion of https://github.com/civicrm/cv/pull/166 - i.e. `civix` doesn't support some of bootstrap (initialization) options that `cv` does, which limits compatibility with some environments.

Before
---------

* When `civix` needs to acces CiviCRM, it uses `cv`'s `Bootstrap.php`.
* `Bootstrap.php` is included by way of a special/single-file download step.
* `Bootstrap.php` only supports the traditional (Civi-first / CIVICRM_SETTINGS) protocol. It doesn't support the newer (CMS-first / CIVICRM_BOOT) protocol.

After
-------

* When `civix` needs to acces CiviCRM, it uses `cv`'s `Bootstrap.php` _or_ `CmsBootstrap.php`.
* All `cv` helper classes are included as a composer dependency (`civicrm/cv-lib`).
* `civix`'s boot behavior should now match `cv`'s behavior, as described in https://github.com/civicrm/cv#bootstrap