### PR TITLE
php-scoper - Fix prefixing

### DIFF
--- a/box.json
+++ b/box.json
@@ -14,6 +14,7 @@
         {
             "name": "*.php",
             "exclude": [
+              "composer-compile-plugin",
               "phpunit",
               "Tests", "Test", "tests", "test"
             ],

--- a/build.sh
+++ b/build.sh
@@ -9,9 +9,10 @@ function absdirname() {
 }
 
 PRJDIR=$(absdirname "$0")
+OUTFILE="$PRJDIR/bin/civix.phar"
 set -ex
 
-BOX_VERSION=3.16.0
+BOX_VERSION=4.3.8
 BOX_URL="https://github.com/box-project/box/releases/download/${BOX_VERSION}/box.phar"
 BOX_DIR="$PRJDIR/extern/box-$BOX_VERSION"
 BOX_BIN="$BOX_DIR/box"
@@ -38,5 +39,7 @@ pushd "$PRJDIR" >> /dev/null
   ## `composer/xdebug-handler`.  (Both have a need to manipulate PHP INI.) The flag `BOX_ALLOW_XDEBUG` is defined by their
   ## upstream.  Setting the flag doesn't actually configure xdebug -- rather, it disables PHP INI automanipulations, so that you
   ## are _allowed_ to set PHP INI options (`xdebug.*`, `phar.*`, etc) on your own.
+
+  php scripts/check-phar.php "$OUTFILE"
 
 popd >> /dev/null

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -21,6 +21,7 @@ return [
   'exclude-classes' => [
     '/^(CRM_|HTML_|DB_|Log_)/',
     'civicrm_api3',
+    'Mixlib',
     'DB',
     'Log',
     'JFactory',
@@ -42,6 +43,6 @@ return [
     glob('src/CRM/CivixBundle/Resources/views/*/*.php'),
     glob('extern/*/*/*.php'),
     glob('extern/*/*.php'),
-  )
+  ),
 
 ];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -2,21 +2,46 @@
 
 return [
   'prefix' => 'CivixPhar',
-  'patchers' => [
-      function (string $filePath, string $prefix, string $content) {
-          // In some cases, `civix` references classes provided by civicrm-core or by the UF. Preserve the original names.
-          $content = preg_replace(';CivixPhar\\\(CRM_|HTML_|DB_|Drupal|JFactory|Civi::);', '$1', $content);
-          $content = preg_replace_callback(';CivixPhar\Civi\([A-Za-z0-9_\\]*);', function($m){
-            if (substr($m[1], 0, 3) === 'Cv\\') return $m[0]; // Civi\Cv is mapped.
-            else return 'Civi\\' . $m[1]; // Nothing else is mapped.
-          }, $content);
-          return $content;
-      },
+
+  'exclude-namespaces' => [
+    // Provided by civicrm
+    'Civi',
+    'Guzzle',
+    'Symfony\Component\DependencyInjection',
+
+    // Drupal8+ bootstrap
+    'Drupal',
+    'Symfony\\Component\\HttpFoundation',
+    'Symfony\\Component\\Routing',
+
+    // Joomla bootstrap
+    'TYPO3\\PharStreamWrapper',
+  ],
+
+  'exclude-classes' => [
+    '/^(CRM_|HTML_|DB_|Log_)/',
+    'civicrm_api3',
+    'DB',
+    'Log',
+    'JFactory',
+    'Civi',
+    'Drupal',
+  ],
+  'exclude-functions' => [
+    '/^civicrm_/',
+    '/^wp_.*/',
+    '/^(drupal|backdrop|user|module)_/',
+    't',
   ],
 
   // Do not generate wrappers/aliases for `civicrm_api()` etc or various CMS-booting functions.
-  'expose-global-functions' => false,
+  'expose-global-functions' => FALSE,
 
   // Do not filter template files
-  'exclude-files' => glob('src/CRM/CivixBundle/Resources/views/*/*.php'),
+  'exclude-files' => array_merge(
+    glob('src/CRM/CivixBundle/Resources/views/*/*.php'),
+    glob('extern/*/*/*.php'),
+    glob('extern/*/*.php'),
+  )
+
 ];

--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -30,6 +30,7 @@ return [
   ],
   'exclude-functions' => [
     '/^civicrm_/',
+    '/_civicrm_api_get_entity_name_from_camel/',
     '/^wp_.*/',
     '/^(drupal|backdrop|user|module)_/',
     't',

--- a/scripts/check-phar.php
+++ b/scripts/check-phar.php
@@ -1,0 +1,85 @@
+#!/usr/bin/env php
+<?php
+
+// This is a sniff-test to ensure that the generated PHAR looks the way it
+// should. In particular, we assert that some classes MUST have
+// namespace-prefixes, and other classes MUST NOT.
+
+global $errors, $pharFile;
+
+if (empty($argv[1]) || !file_exists($argv[1])) {
+  die("Missing argument. Ex: check-phar.php /path/to/my.phar");
+}
+
+$pharFile = $argv[1];
+$errors = [];
+
+assertMatch('src/CRM/CivixBundle/Command/AddPageCommand.php', ';^namespace CRM.CivixBundle.Command;');
+assertNotMatch('src/CRM/CivixBundle/Command/AddPageCommand.php', ';^namespace CivixPhar;');
+
+assertNotMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace Symfony;');
+assertMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace CivixPhar.Symfony;');
+
+assertMatch('src/CRM/CivixBundle/Services.php', ';civicrm_api3;');
+assertNotMatch('src/CRM/CivixBundle/Services.php', ';CivixPhar.civicrm_api3;');
+
+assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';JFactory::;');
+assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';Drupal::;');
+assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';drupal_bootstrap;');
+assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';user_load;');
+assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';wp_set_current_user;');
+foreach (['vendor/civicrm/cv-lib/src/Bootstrap.php', 'vendor/civicrm/cv-lib/src/CmsBootstrap.php'] as $file) {
+  // These two files have lots of CMS symbols. The only thing that should be prefixed is Symfony stuff.
+  $allPrefixed = grepFile($file, ';CivixPhar;');
+  $expectPrefixed = grepFile($file, ';CivixPhar.*(Symfony|Psr.*Log);');
+  if ($allPrefixed !== $expectPrefixed) {
+    $errors[] = "File $file has lines with unexpected prefixing:\n  " . implode("\n  ", array_diff($allPrefixed, $expectPrefixed)) . "\n";
+  }
+}
+assertNotMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';CivixPhar.JFactory;');
+assertNotMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';CivixPhar.Drupal;');
+assertNotMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';CivixPhar..?Symfony..?Component..?HttpFoundation;');
+
+if (empty($errors)) {
+  echo "OK $pharFile\n";
+}
+else {
+  echo "ERROR $pharFile\n";
+  echo implode("", $errors);
+  exit(1);
+}
+
+########################################################################################
+
+/**
+ * Construct full name for a file (within the phar).
+ */
+function getFilename(?string $relpath = NULL): string {
+  global $pharFile;
+  $path = 'phar://' . $pharFile;
+  if ($relpath != NULL) {
+    $path .= '/' . $relpath;
+  }
+  return $path;
+}
+
+function assertMatch(string $relpath, string $regex) {
+  global $errors;
+  $content = explode("\n", file_get_contents(getFilename($relpath)));
+  if (!preg_grep($regex, $content)) {
+    $errors[] = sprintf("Failed: assertMatch(%s, %s)\n", var_export($relpath, 1), var_export($regex, 1));
+  }
+}
+
+function assertNotMatch(string $relpath, string $regex) {
+  global $errors;
+  $content = explode("\n", file_get_contents(getFilename($relpath)));
+  if (!empty($x = preg_grep($regex, $content))) {
+    $errors[] = sprintf("Failed: assertNotMatch(%s, %s)\n", var_export($relpath, 1), var_export($regex, 1));
+  }
+}
+
+function grepFile(string $relpath, string $regex): array {
+  $content = explode("\n", file_get_contents(getFilename($relpath)));
+  return preg_grep($regex, $content);
+}

--- a/shell.nix
+++ b/shell.nix
@@ -10,7 +10,7 @@ let
     sha256 = "0d643wp3l77hv2pmg2fi7vyxn4rwy0iyr8djcw1h5x72315ck9ik";
   };
   pkgs = import pkgSrc {};
-  myphp = pkgs.php74.buildEnv {
+  myphp = pkgs.php81.buildEnv {
     extraConfig = ''
       memory_limit=-1
     '';
@@ -20,5 +20,5 @@ in
 
   pkgs.mkShell {
     # nativeBuildInputs is usually what you want -- tools you need to run
-    nativeBuildInputs = [ myphp pkgs.php74Packages.composer ];
+    nativeBuildInputs = [ myphp pkgs.php81Packages.composer ];
 }

--- a/src/CRM/CivixBundle/Services.php
+++ b/src/CRM/CivixBundle/Services.php
@@ -120,6 +120,10 @@ class Services {
    */
   public static function mixlib(): Mixlib {
     if (!isset(self::$cache[__FUNCTION__])) {
+      if (!class_exists('Mixlib')) {
+        // For some reason, autoloading rule doesn't for this doesn't survive box/php-scoper/phar transofrmation.
+        require_once dirname(__DIR__, 3) . '/extern/src/Mixlib.php';
+      }
       self::$cache[__FUNCTION__] = new Mixlib(dirname(__DIR__, 3) . '/extern/mixin');
     }
     return self::$cache[__FUNCTION__];


### PR DESCRIPTION
The purpose of `php-scoper` is to allow `civix.phar` to run in other environments without provoking class-conflicts. It does this by prefixing (almost all) classes.

The current configuration appears to be inert -- the final output doesn't actually have prefixes nowadays. This brings it back and adds some test-coverage.

Comments
--------------

This is very similar to https://github.com/civicrm/cv/pull/158, except that I had to do some fine-tuning on the include/exclude lists.
