### PR TITLE
Remove commented-out boilerplate

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -34,31 +34,3 @@ function <?php echo $mainFile ?>_civicrm_install(): void {
 function <?php echo $mainFile ?>_civicrm_enable(): void {
   _<?php echo $mainFile ?>_civix_civicrm_enable();
 }
-
-// --- Functions below this ship commented out. Uncomment as required. ---
-
-/**
- * Implements hook_civicrm_preProcess().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_preProcess
- */
-//function <?php echo $mainFile ?>_civicrm_preProcess($formName, &$form): void {
-//
-//}
-
-/**
- * Implements hook_civicrm_navigationMenu().
- *
- * @link https://docs.civicrm.org/dev/en/latest/hooks/hook_civicrm_navigationMenu
- */
-//function <?php echo $mainFile ?>_civicrm_navigationMenu(&$menu): void {
-//  _<?php echo $mainFile ?>_civix_insert_navigation_menu($menu, 'Mailings', [
-//    'label' => E::ts('New subliminal message'),
-//    'name' => 'mailing_subliminal_message',
-//    'url' => 'civicrm/mailing/subliminal',
-//    'permission' => 'access CiviMail',
-//    'operator' => 'OR',
-//    'separator' => 0,
-//  ]);
-//  _<?php echo $mainFile ?>_civix_navigationMenu($menu);
-//}


### PR DESCRIPTION
Neither of these commented-out functions sets a particularly good example so it ends up just being noise.