### PR TITLE
generate:form gives PHP Fatal error:  Uncaught TypeError: Return value of "CRM\CivixBundle\Command\AddFormCommand::execute()" must be of the type int, "null" returned. in ...\vendor\symfony\console\Command\Command.php:301

### DIFF
--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -92,6 +92,7 @@ abstract class AbstractAddPageCommand extends AbstractCommand {
     $mixins = new Mixins($info, $basedir->string('mixin'), ['menu-xml@1.0', 'smarty-v2@1.0']);
     $mixins->save($ctx, $output);
     $info->save($ctx, $output);
+    return 0;
   }
 
   abstract protected function getPhpTemplate(InputInterface $input);

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -80,6 +80,7 @@ For more, see https://docs.angularjs.org/guide/directive');
 
     $ext->init($ctx);
     $ext->save($ctx, $output);
+    return 0;
   }
 
   public function toHyphen($dirName) {

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -46,7 +46,7 @@ For more, see https://docs.angularjs.org/guide/directive');
     $attrs = $info->get()->attributes();
     if ($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     $ctx['tsDomain'] = (string) $attrs['key'];

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -77,6 +77,7 @@ class AddAngularModuleCommand extends AbstractCommand {
 
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -51,7 +51,7 @@ For more, see https://docs.angularjs.org/guide');
     $attrs = $info->get()->attributes();
     if ($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     $ctx['tsDomain'] = (string) $attrs['key'];

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -81,6 +81,7 @@ For more, see https://docs.angularjs.org/guide');
 
     $ext->init($ctx);
     $ext->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -160,6 +160,7 @@ action names.
     $phpUnitInitFiles->initPhpunitBootstrap($basedir->string('tests', 'phpunit', 'bootstrap.php'), $ctx, $output);
 
     $info->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -59,6 +59,7 @@ class AddCaseTypeCommand extends AbstractCommand {
     $mixins = new Mixins($info, $basedir->string('mixin'), ['case-xml@1.0']);
     $mixins->save($ctx, $output);
     $info->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -27,7 +27,7 @@ class AddCaseTypeCommand extends AbstractCommand {
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("Requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
-      return;
+      return 1;
     }
 
     $this->assertCurrentFormat();

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -45,7 +45,7 @@ class AddCustomDataCommand extends AbstractCommand {
     $attrs = $info->get()->attributes();
     if ($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     $dirs = new Dirs([

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -77,6 +77,8 @@ class AddCustomDataCommand extends AbstractCommand {
     else {
       $output->writeln(" * NOTE: By default, this file will not be loaded automatically -- you must define installation or upgrade logic to load the file.");
     }
+
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -148,6 +148,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       $output->writeln('<comment>You are missing an upgrader class. Your generated SQL files will not be executed on enable and uninstall. Fix this by running `civix generate:upgrader`.</comment>');
     }
 
+    return 0;
   }
 
   private function orderTables(&$tables, $output) {

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -152,6 +152,8 @@ explicity.');
 
     $output->writeln('<comment>You should now make any changes to the entity xml file and run `civix generate:entity-boilerplate` to generate necessary boilerplate.</comment>');
     $output->writeln('<comment>Note: no changes have been made to the database. You can update the database by uninstalling and re-enabling the extension.</comment>');
+
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -46,7 +46,7 @@ explicity.');
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
-      return;
+      return 1;
     }
 
     $this->assertCurrentFormat();

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -119,6 +119,8 @@ class AddReportCommand extends AbstractCommand {
 
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
+
+    return 0;
   }
 
   /**

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -114,6 +114,8 @@ class AddSearchCommand extends AbstractCommand {
 
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
+
+    return 0;
   }
 
   /**

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -73,6 +73,8 @@ as separate groups:
     $phpUnitInitFiles->initPhpunitBootstrap($basedir->string('tests', 'phpunit', 'bootstrap.php'), $ctx, $output);
     $this->initTestClass(
       $input->getArgument('<CRM_Full_ClassName>'), $this->getTestTemplate($input->getOption('template')), $basedir, $ctx, $output);
+
+    return 0;
   }
 
   protected function getTestTemplate($type) {

--- a/src/CRM/CivixBundle/Command/AddThemeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddThemeCommand.php
@@ -94,6 +94,8 @@ $ civix generate:theme foobar
 
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
+
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -32,7 +32,7 @@ class AddUpgraderCommand extends AbstractCommand {
     $attrs = $info->get()->attributes();
     if ($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     $dirs = [

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -63,6 +63,8 @@ class AddUpgraderCommand extends AbstractCommand {
     $module = new Module(Services::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
+
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -54,6 +54,7 @@ class BuildCommand extends AbstractCommand {
       throw new \RuntimeException('Failed to create zip');
     }
     print $process->getOutput();
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -29,7 +29,7 @@ class BuildCommand extends AbstractCommand {
     $attrs = $info->get()->attributes();
     if ($attrs['type'] != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     $ctx['zipFile'] = $basedir->string('build', $ctx['fullName'] . '.zip');

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -21,6 +21,7 @@ class ConfigGetCommand extends AbstractCommand {
     foreach ($this->getInterestingParameters() as $key) {
       printf("%-40s \"%s\"\n", $key, @$config['parameters'][$key]);
     }
+    return 0;
   }
 
   protected function getInterestingParameters() {

--- a/src/CRM/CivixBundle/Command/ConfigSetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigSetCommand.php
@@ -36,6 +36,7 @@ class ConfigSetCommand extends AbstractCommand {
     $data['parameters'][$input->getArgument('key')] = $input->getArgument('value');
     $ext->builders['ini']->set($data);
     $ext->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/InfoGetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoGetCommand.php
@@ -59,6 +59,8 @@ Common fields:\n * " . implode("\n * ", $fields) . "\n");
     foreach ($info->get()->xpath($xpath) as $node) {
       $output->writeln((string) $node, OutputInterface::OUTPUT_RAW);
     }
+
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/InfoSetCommand.php
+++ b/src/CRM/CivixBundle/Command/InfoSetCommand.php
@@ -60,6 +60,7 @@ Common fields:
     }
 
     $info->save($ctx, $output);
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -156,6 +156,7 @@ class InitCommand extends AbstractCommand {
     $ext->save($ctx, $output);
 
     $this->tryEnable($input, $output, $ctx['fullName']);
+    return 0;
   }
 
   /**

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -72,7 +72,7 @@ class InitCommand extends AbstractCommand {
     // Name should start with an alpha and only contain alphanumeric, - and .
     if (!Naming::isValidFullName($name)) {
       $output->writeln('<error>Malformed package name</error>');
-      return;
+      return 1;
     }
 
     $ctx['basedir'] = $name;
@@ -88,7 +88,7 @@ class InitCommand extends AbstractCommand {
     else {
       $output->writeln("<error>Missing author name or email address</error>");
       $output->writeln("<error>Please pass --author and --email, or set defaults in ~/.gitconfig</error>");
-      return;
+      return 1;
     }
     $ctx['license'] = $input->getOption('license');
     if ($licenses->get($ctx['license'])) {
@@ -97,7 +97,7 @@ class InitCommand extends AbstractCommand {
     }
     else {
       $output->writeln('<error>Unrecognized license (' . $ctx['license'] . ')</error>');
-      return;
+      return 1;
     }
 
     if ($input->getOption('compatibility') === 'current') {

--- a/src/CRM/CivixBundle/Command/PingCommand.php
+++ b/src/CRM/CivixBundle/Command/PingCommand.php
@@ -28,6 +28,7 @@ class PingCommand extends AbstractCommand {
     else {
       $output->writeln('<error>Ping failed: API Error: ' . $civicrm_api3->errorMsg() . '</error>');
     }
+    return 0;
   }
 
 }

--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -50,32 +50,32 @@ class TestRunCommand extends Command {
     $info->load($ctx);
     if ($info->getType() != 'module') {
       $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
+      return 1;
     }
 
     // Find the main phpunit
     $civicrm_api3 = Services::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>'test' requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
-      return;
+      return 1;
     }
     global $civicrm_root;
     if (empty($civicrm_root) || !is_dir($civicrm_root)) {
       $output->writeln("<error>Failed to locate CiviCRM root path: $civicrm_root</error>");
-      return;
+      return 1;
     }
     $phpunit_bin = "$civicrm_root/tools/scripts/phpunit";
     if (!file_exists($phpunit_bin)) {
       $output->writeln("<error>Failed to locate PHPUnit:\n  $phpunit_bin</error>");
       $output->writeln("<error>Have you configured CiviCRM for testing? See also:\n  https://docs.civicrm.org/dev/en/latest/testing/#setup</error>");
-      return;
+      return 1;
     }
     $test_settings_path = "$civicrm_root/tests/phpunit/CiviTest/civicrm.settings.php";
     $test_settings_dist_path = "$civicrm_root/tests/phpunit/CiviTest/civicrm.settings.dist.php";
     if (!file_exists($test_settings_path) && !file_exists($test_settings_dist_path)) {
       $output->writeln("<error>Failed to locate test settings:\n  $test_settings_path</error>");
       $output->writeln("<error>Have you configured CiviCRM for testing? See also:\n  https://docs.civicrm.org/dev/en/latest/testing/#setup</error>");
-      return;
+      return 1;
     }
     if (file_exists($test_settings_path) && self::checkLegacyExtensionSettings($test_settings_path)) {
       $output->writeln("<comment>Warning: Possible conflicts in $test_settings_path</comment>");
@@ -85,7 +85,7 @@ class TestRunCommand extends Command {
     $phpunit_boot = $this->getBootstrapFile($info->getKey(), $input->getOption('clear'));
     if (empty($phpunit_boot) || !file_exists($phpunit_boot)) {
       $output->writeln("<error>Failed to create PHPUnit bootstrap file</error>");
-      return;
+      return 1;
     }
 
     $tests_dir = implode(DIRECTORY_SEPARATOR, [getcwd(), 'tests', 'phpunit']);

--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -121,6 +121,7 @@ class TestRunCommand extends Command {
       $output->write($buffer);
     });
     $output->write("\n");
+    return 0;
   }
 
   /**


### PR DESCRIPTION
In this case I'm using php 8.1 and civix built from source.

It's very similar to https://lab.civicrm.org/dev/civicrm-asset-plugin/-/merge_requests/8/diffs in that more recent versions of symfony require execute() to return an int: https://github.com/symfony/console/blob/v5.4.5/Command/Command.php#L301. And older versions wouldn't care if it's 0 or null.