### PR TITLE
Fix php-scoper rule for polyfill-80

### DIFF
--- a/scoper.inc.php
+++ b/scoper.inc.php
@@ -44,6 +44,7 @@ return [
     glob('src/CRM/CivixBundle/Resources/views/*/*.php'),
     glob('extern/*/*/*.php'),
     glob('extern/*/*.php'),
+    glob('vendor/symfony/polyfill-php80/Resources/stubs/*php'), /* polyfill-php80@1.27.0 + box@4.8.3 */
   ),
 
 ];


### PR DESCRIPTION
This should fix a regression where `civix.phar` fails to load on php7.

```
Fatal error: Uncaught Error: Interface 'Stringable' not found in phar:///home/cividev/bin/civix/vendor/symfony/polyfill-php80/PhpToken.php:18
Stack trace:
#0 phar:///home/cividev/bin/civix/.box/vendor/composer/ClassLoader.php(582): include()
#1 phar:///home/cividev/bin/civix/.box/vendor/composer/ClassLoader.php(433): Composer\Autoload\{closure}()
#2 [internal function]: Composer\Autoload\ClassLoader->loadClass()
#3 phar:///home/cividev/bin/civix/vendor/symfony/polyfill-php80/Resources/stubs/PhpToken.php(14): spl_autoload_call()
#4 phar:///home/cividev/bin/civix/.box/vendor/composer/ClassLoader.php(582): include('phar:///home/ci...')
#5 phar:///home/cividev/bin/civix/.box/vendor/composer/ClassLoader.php(433): Composer\Autoload\{closure}()
#6 [internal function]: Composer\Autoload\ClassLoader->loadClass()
#7 phar:///home/cividev/bin/civix/vendor/autoload.php(37): spl_autoload_call()
#8 phar:///home/cividev/bin/civix/vendor/autoload.php(45): humbug_phpscoper_expose_class()
#9 phar:///home/cividev/bin/civix/bin/civix(19): req in phar:///home/cividev/bin/civix/vendor/symfony/polyfill-php80/PhpToken.php on line 18
```
