### PR TITLE
Add `export` command for managed entities and afforms

### DIFF
--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -10,6 +10,7 @@ use CRM\CivixBundle\Command\AddCustomDataCommand;
 use CRM\CivixBundle\Command\AddEntityCommand;
 use CRM\CivixBundle\Command\AddEntityBoilerplateCommand;
 use CRM\CivixBundle\Command\AddFormCommand;
+use CRM\CivixBundle\Command\AddManagedEntityCommand;
 use CRM\CivixBundle\Command\AddPageCommand;
 use CRM\CivixBundle\Command\AddReportCommand;
 use CRM\CivixBundle\Command\AddSearchCommand;
@@ -59,6 +60,7 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new AddEntityCommand();
     $commands[] = new AddEntityBoilerplateCommand();
     $commands[] = new AddFormCommand();
+    $commands[] = new AddManagedEntityCommand();
     $commands[] = new AddPageCommand();
     $commands[] = new AddReportCommand();
     $commands[] = new AddSearchCommand();

--- a/src/CRM/CivixBundle/Builder/Content.php
+++ b/src/CRM/CivixBundle/Builder/Content.php
@@ -1,0 +1,61 @@
+<?php
+namespace CRM\CivixBundle\Builder;
+
+use CRM\CivixBundle\Builder;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Simply write a string to a file
+ */
+class Content implements Builder {
+
+  private $content;
+  protected $path;
+  protected $overwrite;
+
+  /**
+   * @param string $content
+   * @param string $path
+   * @param bool|string $overwrite TRUE (always overwrite), FALSE (preserve with error), 'ignore' (preserve quietly)
+   * @param
+   */
+  public function __construct(string $content, string $path, $overwrite = FALSE) {
+    $this->content = $content;
+    $this->path = $path;
+    $this->overwrite = $overwrite;
+  }
+
+  public function loadInit(&$ctx) {
+  }
+
+  public function init(&$ctx) {
+  }
+
+  public function load(&$ctx) {
+  }
+
+  /**
+   * Write the content
+   */
+  public function save(&$ctx, OutputInterface $output) {
+    $parent = dirname($this->path);
+    if (!is_dir($parent)) {
+      mkdir($parent, Dirs::MODE, TRUE);
+    }
+    if (file_exists($this->path) && $this->overwrite === 'ignore') {
+      // do nothing
+    }
+    elseif (file_exists($this->path) && !$this->overwrite) {
+      $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
+    }
+    else {
+      $output->writeln("<info>Write</info> " . $this->path);
+      file_put_contents($this->path, $this->getContent($ctx));
+    }
+  }
+
+  protected function getContent($ctx): string {
+    return $this->content;
+  }
+
+}

--- a/src/CRM/CivixBundle/Builder/Dirs.php
+++ b/src/CRM/CivixBundle/Builder/Dirs.php
@@ -12,8 +12,17 @@ class Dirs implements Builder {
   // Note: Permissions will be further restricted by umask
   const MODE = 0777;
 
-  public function __construct($paths) {
+  /**
+   * @var string[]
+   */
+  private $paths;
+
+  public function __construct($paths = []) {
     $this->paths = $paths;
+  }
+
+  public function addPath(string $path) {
+    $this->paths[] = $path;
   }
 
   public function loadInit(&$ctx) {

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -137,6 +137,10 @@ class Info extends XML {
     return empty($this->xml->name) ? 'FIXME' : $this->xml->name;
   }
 
+  public function getExtensionUtilClass(): string {
+    return str_replace('/', '_', $this->getNamespace()) . '_ExtensionUtil';
+  }
+
   /**
    * Get the namespace into which civix should place files
    * @return string

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -6,7 +6,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarExporter\VarExporter;
 
 /**
- * Read/write a serialized data file based on PHP's var_export() format
+ * Write a data file in PHP format
  */
 class PhpData implements Builder {
 
@@ -21,9 +21,19 @@ class PhpData implements Builder {
   protected $data;
 
   /**
-   * @var
+   * @var string
    */
   protected $header;
+
+  /**
+   * @var string[]
+   */
+  private $keysToTranslate;
+
+  /**
+   * @var string
+   */
+  private $extensionUtil;
 
   public function __construct($path, $header = NULL) {
     $this->path = $path;
@@ -66,26 +76,79 @@ class PhpData implements Builder {
   }
 
   /**
+   * Specify fields that will be wrapped in E::ts()
+   *
+   * @param array $keysToTranslate
+   * @return void
+   */
+  public function useTs(array $keysToTranslate) {
+    $this->keysToTranslate = $keysToTranslate;
+  }
+
+  /**
+   * Adds `use Foo_ExtensionUtil as E;` to the top of the file
+   *
+   * @param string $extensionUtilClass
+   * @return void
+   */
+  public function useExtensionUtil(string $extensionUtilClass) {
+    $this->extensionUtil = $extensionUtilClass;
+  }
+
+  /**
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
     $output->writeln("<info>Write</info> " . $this->path);
 
     $content = "<?php\n";
+    if ($this->extensionUtil) {
+      $content .= "use $this->extensionUtil as E;\n";
+    }
     if ($this->header) {
       $content .= $this->header;
     }
     $content .= "\nreturn ";
-    $content .= preg_replace_callback('/^ +/m',
-      // VarExporter indents with 4x spaces. Civi/Drupal code standard is 2x spaces.
+    $data = $this->reduceIndentation(VarExporter::export($this->data));
+    $data = $this->ucConstants($data);
+    if ($this->keysToTranslate) {
+      $data = $this->translateStrings($data, $this->keysToTranslate);
+    }
+    $content .= "$data;\n";
+    file_put_contents($this->path, $content);
+  }
+
+  /**
+   * VarExporter indents with 4x spaces. Civi/Drupal code standard is 2x spaces.
+   */
+  private function reduceIndentation(string $data): string {
+    return preg_replace_callback('/^ +/m',
       function($m) {
         $spaces = $m[0];
         return substr($spaces, 0, ceil(strlen($spaces) / 2));
       },
-      VarExporter::export($this->data)
+      $data
     );
-    $content .= ";\n";
-    file_put_contents($this->path, $content);
+  }
+
+  /**
+   * Uppercase constants to match Civi/Drupal code standard
+   */
+  private function ucConstants(string $data): string {
+    foreach (['null', 'false', 'true'] as $const) {
+      $uc = strtoupper($const);
+      $data = str_replace(" $const,", " $uc,", $data);
+    }
+    return $data;
+  }
+
+  /**
+   * Wrap strings in E::ts()
+   */
+  private function translateStrings(string $data, array $keysToTranslate): string {
+    $keys = implode('|', array_unique($keysToTranslate));
+    $data = preg_replace("/'($keys)' => ('[^']+'),/", "'\$1' => E::ts(\$2),", $data);
+    return $data;
   }
 
 }

--- a/src/CRM/CivixBundle/Builder/Template.php
+++ b/src/CRM/CivixBundle/Builder/Template.php
@@ -1,20 +1,16 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
-use CRM\CivixBundle\Builder;
 use CRM\CivixBundle\Services;
-use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * Build/update a file based on a template
  */
-class Template implements Builder {
+class Template extends Content {
 
   protected $template;
-  protected $path;
   protected $xml;
   protected $templateEngine;
-  protected $enable;
 
   /**
    * @param string $template
@@ -23,41 +19,15 @@ class Template implements Builder {
    * @param \Symfony\Component\Templating\EngineInterface|null $templateEngine
    * @param
    */
-  public function __construct(string $template, string $path, $overwrite, $templateEngine = NULL) {
+  public function __construct(string $template, string $path, $overwrite = FALSE, $templateEngine = NULL) {
     $this->template = $template;
     $this->path = $path;
     $this->overwrite = $overwrite;
     $this->templateEngine = $templateEngine ?: Services::templating();
-    $this->enable = FALSE;
   }
 
-  public function loadInit(&$ctx) {
-  }
-
-  public function init(&$ctx) {
-  }
-
-  public function load(&$ctx) {
-  }
-
-  /**
-   * Write the xml document
-   */
-  public function save(&$ctx, OutputInterface $output) {
-    $parent = dirname($this->path);
-    if (!is_dir($parent)) {
-      mkdir($parent, Dirs::MODE, TRUE);
-    }
-    if (file_exists($this->path) && $this->overwrite === 'ignore') {
-      // do nothing
-    }
-    elseif (file_exists($this->path) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
-    }
-    else {
-      $output->writeln("<info>Write</info> " . $this->path);
-      file_put_contents($this->path, $this->templateEngine->render($this->template, $ctx));
-    }
+  protected function getContent($ctx): string {
+    return $this->templateEngine->render($this->template, $ctx);
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -9,11 +9,33 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class AbstractCommand extends Command {
 
   protected function configure() {
     $this->addOption('yes', NULL, InputOption::VALUE_NONE, 'Answer yes to any questions');
+  }
+
+  /**
+   * @var \Symfony\Component\Console\Style\StyleInterface
+   */
+  private $io;
+
+  /**
+   * @param \Symfony\Component\Console\Input\InputInterface $input
+   * @param \Symfony\Component\Console\Output\OutputInterface $output
+   */
+  protected function initialize(InputInterface $input, OutputInterface $output) {
+    parent::initialize($input, $output);
+    $this->io = new SymfonyStyle($input, $output);
+  }
+
+  /**
+   * @return \Symfony\Component\Console\Style\StyleInterface
+   */
+  protected function getIO() {
+    return $this->io;
   }
 
   protected function confirm(InputInterface $input, OutputInterface $output, $message, $default = TRUE) {

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -1,0 +1,150 @@
+<?php
+namespace CRM\CivixBundle\Command;
+
+use CRM\CivixBundle\Builder\Content;
+use CRM\CivixBundle\Builder\Mixins;
+use CRM\CivixBundle\Services;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use CRM\CivixBundle\Builder\Collection;
+use CRM\CivixBundle\Builder\Dirs;
+use CRM\CivixBundle\Builder\PhpData;
+use CRM\CivixBundle\Utils\Path;
+
+class AddManagedEntityCommand extends AbstractCommand {
+
+  protected function configure() {
+    parent::configure();
+    $this
+      ->setName('generate:managed')
+      ->setDescription('Exports a record in packaged format for distribution in this extension')
+      ->addArgument('<EntityName>', InputArgument::REQUIRED, 'API entity name (Ex: "SavedSearch")')
+      ->addArgument('<EntityId>', InputArgument::REQUIRED, 'Id of entity to be exported (or name if exporting an Afform)')
+      ->setHelp('Uses APIv4 Export to save existing records as .mgd.php files.
+Specify the name of the entity and the id.
+The file will be saved to the managed directory.
+
+This command also works to export Afforms to the ang directory.');
+  }
+
+  protected function execute(InputInterface $input, OutputInterface $output) {
+    $this->assertCurrentFormat();
+
+    $ctx = [];
+    $ctx['type'] = 'module';
+    $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
+    $basedir = new Path($ctx['basedir']);
+    $info = $this->getModuleInfo($ctx);
+
+    $entityName = $input->getArgument('<EntityName>');
+    $entityId = $input->getArgument('<EntityId>');
+
+    $ext = new Collection();
+    $ext->builders['dirs'] = new Dirs();
+
+    // Boot CiviCRM to use api4
+    Services::boot(['output' => $output]);
+
+    // Fields that most probably should be wrapped in E::ts()
+    $localizable = ['title', 'label', 'description', 'text'];
+
+    // Export Afform
+    if ($entityName === 'Afform') {
+      $ext->builders['dirs']->addPath($basedir->string('ang'));
+      $afformName = $entityId;
+
+      $fields = \civicrm_api4('Afform', 'getFields', [
+        'checkPermissions' => FALSE,
+        'where' => [['type', '=', 'Field']],
+      ])->indexBy('name');
+      $afform = \civicrm_api4('Afform', 'get', [
+        'where' => [['name', '=', $afformName]],
+        'checkPermissions' => FALSE,
+        'select' => ['*', 'search_displays'],
+        'layoutFormat' => 'html',
+      ])->first();
+      if (!$afform) {
+        $output->writeln("Error: Afform $afformName not found.");
+        return 1;
+      }
+
+      // An Afform consists of 2 files - a layout file and a meta file
+      $layoutFileName = $basedir->string('ang', $entityId . '.aff.html');
+      $metaFileName = $basedir->string('ang', $entityId . '.aff.php');
+
+      // Export layout file
+      $ext->builders['afformLayout' . $afformName] = new Content($afform['layout'], $layoutFileName, TRUE);
+
+      // If Afform contains embedded search displays, queue those to be exported as .mgd.php
+      if (!empty($afform['search_displays'])) {
+        $searchNames = array_map(function ($item) {
+          return explode('.', $item)[0];
+        }, $afform['search_displays']);
+        $entityId = (array) \civicrm_api4('SavedSearch', 'get', [
+          'where' => [['name', 'IN', $searchNames]],
+          'checkPermissions' => FALSE,
+        ], ['id']);
+        if ($entityId) {
+          $entityName = 'SavedSearch';
+        }
+      }
+
+      // Export meta file
+      unset($afform['search_displays'], $afform['name'], $afform['layout']);
+      // Simplify meta file by removing values that match the defaults
+      foreach ($afform as $field => $value) {
+        if ($value === $fields[$field]['default_value']) {
+          unset($afform[$field]);
+        }
+      }
+      $phpData = new PhpData($metaFileName);
+      $phpData->useExtensionUtil($info->getExtensionUtilClass());
+      $phpData->useTs($localizable);
+      $phpData->set($afform);
+      $ext->builders['afformMeta' . $afformName] = $phpData;
+    }
+
+    // Export mgd.php
+    if ($entityName !== 'Afform') {
+      $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);
+      $ext->builders['dirs']->addPath($basedir->string('managed'));
+      foreach ((array) $entityId as $id) {
+        $export = (array) \civicrm_api4($entityName, 'export', [
+          'id' => $id,
+          'checkPermissions' => FALSE,
+        ]);
+        if (!$export) {
+          $output->writeln("Error: $entityName $id not found.");
+          return 1;
+        }
+        $managedName = $export[0]['name'];
+        $entityCount = count($export);
+
+        // Lookup entity-specific fields that should be wrapped in E::ts()
+        foreach ($export as $item) {
+          $fields = (array) \civicrm_api4($item['entity'], 'getFields', [
+            'where' => [['localizable', '=', TRUE]],
+            'checkPermissions' => FALSE,
+          ], ['name']);
+          $localizable = array_merge($localizable, $fields);
+        }
+
+        $output->writeln("Exporting $managedName with $entityCount " . ($entityCount === 1 ? 'record.' : 'records.'));
+        $managedFileName = $basedir->string('managed', $managedName . '.mgd.php');
+        $phpData = new PhpData($managedFileName);
+        $phpData->useExtensionUtil($info->getExtensionUtilClass());
+        $phpData->useTs($localizable);
+        $phpData->set($export);
+        $ext->builders['mgd.php' . $id] = $phpData;
+      }
+    }
+
+    $ext->builders['info'] = $info;
+
+    $ext->loadInit($ctx);
+    $ext->save($ctx, $output);
+    return 0;
+  }
+
+}

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -14,10 +14,16 @@ use CRM\CivixBundle\Utils\Path;
 
 class AddManagedEntityCommand extends AbstractCommand {
 
+  /**
+   * Fields that most probably should be wrapped in E::ts()
+   * @var array
+   */
+  private $localizable = ['title', 'label', 'description', 'text'];
+
   protected function configure() {
     parent::configure();
     $this
-      ->setName('generate:managed')
+      ->setName('export')
       ->setDescription('Exports a record in packaged format for distribution in this extension')
       ->addArgument('<EntityName>', InputArgument::REQUIRED, 'API entity name (Ex: "SavedSearch")')
       ->addArgument('<EntityId>', InputArgument::REQUIRED, 'Id of entity to be exported (or name if exporting an Afform)')
@@ -34,110 +40,28 @@ This command also works to export Afforms to the ang directory.');
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
-    $basedir = new Path($ctx['basedir']);
     $info = $this->getModuleInfo($ctx);
-
-    $entityName = $input->getArgument('<EntityName>');
-    $entityId = $input->getArgument('<EntityId>');
 
     $ext = new Collection();
     $ext->builders['dirs'] = new Dirs();
 
+    $entityName = $input->getArgument('<EntityName>');
+    $entityId = $input->getArgument('<EntityId>');
+
     // Boot CiviCRM to use api4
     Services::boot(['output' => $output]);
 
-    // Fields that most probably should be wrapped in E::ts()
-    $localizable = ['title', 'label', 'description', 'text'];
-
-    // Export Afform
-    if ($entityName === 'Afform') {
-      $ext->builders['dirs']->addPath($basedir->string('ang'));
-      $afformName = $entityId;
-
-      $fields = \civicrm_api4('Afform', 'getFields', [
-        'checkPermissions' => FALSE,
-        'where' => [['type', '=', 'Field']],
-      ])->indexBy('name');
-      $afform = \civicrm_api4('Afform', 'get', [
-        'where' => [['name', '=', $afformName]],
-        'checkPermissions' => FALSE,
-        'select' => ['*', 'search_displays'],
-        'layoutFormat' => 'html',
-      ])->first();
-      if (!$afform) {
-        $output->writeln("Error: Afform $afformName not found.");
-        return 1;
+    try {
+      if ($entityName === 'Afform') {
+        $this->exportAfform($entityId, $info, $ext, $ctx);
       }
-
-      // An Afform consists of 2 files - a layout file and a meta file
-      $layoutFileName = $basedir->string('ang', $entityId . '.aff.html');
-      $metaFileName = $basedir->string('ang', $entityId . '.aff.php');
-
-      // Export layout file
-      $ext->builders['afformLayout' . $afformName] = new Content($afform['layout'], $layoutFileName, TRUE);
-
-      // If Afform contains embedded search displays, queue those to be exported as .mgd.php
-      if (!empty($afform['search_displays'])) {
-        $searchNames = array_map(function ($item) {
-          return explode('.', $item)[0];
-        }, $afform['search_displays']);
-        $entityId = (array) \civicrm_api4('SavedSearch', 'get', [
-          'where' => [['name', 'IN', $searchNames]],
-          'checkPermissions' => FALSE,
-        ], ['id']);
-        if ($entityId) {
-          $entityName = 'SavedSearch';
-        }
+      else {
+        $this->exportMgd($entityName, $entityId, $info, $ext, $ctx);
       }
-
-      // Export meta file
-      unset($afform['search_displays'], $afform['name'], $afform['layout']);
-      // Simplify meta file by removing values that match the defaults
-      foreach ($afform as $field => $value) {
-        if ($value === $fields[$field]['default_value']) {
-          unset($afform[$field]);
-        }
-      }
-      $phpData = new PhpData($metaFileName);
-      $phpData->useExtensionUtil($info->getExtensionUtilClass());
-      $phpData->useTs($localizable);
-      $phpData->set($afform);
-      $ext->builders['afformMeta' . $afformName] = $phpData;
     }
-
-    // Export mgd.php
-    if ($entityName !== 'Afform') {
-      $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);
-      $ext->builders['dirs']->addPath($basedir->string('managed'));
-      foreach ((array) $entityId as $id) {
-        $export = (array) \civicrm_api4($entityName, 'export', [
-          'id' => $id,
-          'checkPermissions' => FALSE,
-        ]);
-        if (!$export) {
-          $output->writeln("Error: $entityName $id not found.");
-          return 1;
-        }
-        $managedName = $export[0]['name'];
-        $entityCount = count($export);
-
-        // Lookup entity-specific fields that should be wrapped in E::ts()
-        foreach ($export as $item) {
-          $fields = (array) \civicrm_api4($item['entity'], 'getFields', [
-            'where' => [['localizable', '=', TRUE]],
-            'checkPermissions' => FALSE,
-          ], ['name']);
-          $localizable = array_merge($localizable, $fields);
-        }
-
-        $output->writeln("Exporting $managedName with $entityCount " . ($entityCount === 1 ? 'record.' : 'records.'));
-        $managedFileName = $basedir->string('managed', $managedName . '.mgd.php');
-        $phpData = new PhpData($managedFileName);
-        $phpData->useExtensionUtil($info->getExtensionUtilClass());
-        $phpData->useTs($localizable);
-        $phpData->set($export);
-        $ext->builders['mgd.php' . $id] = $phpData;
-      }
+    catch (\Exception $e) {
+      $output->writeln("Error: " . $e->getMessage());
+      return 1;
     }
 
     $ext->builders['info'] = $info;
@@ -145,6 +69,105 @@ This command also works to export Afforms to the ang directory.');
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
     return 0;
+  }
+
+  private function exportMgd($entityName, $id, $info, $ext, $ctx) {
+    $basedir = new Path($ctx['basedir']);
+    $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);
+    $ext->builders['dirs']->addPath($basedir->string('managed'));
+
+    $export = (array) \civicrm_api4($entityName, 'export', [
+      'checkPermissions' => FALSE,
+      'id' => $id,
+    ]);
+    if (!$export) {
+      throw new \Exception("$entityName $id not found.");
+    }
+    $managedName = $export[0]['name'];
+
+    $localizable = $this->localizable;
+    // Lookup entity-specific fields that should be wrapped in E::ts()
+    foreach ($export as $item) {
+      $fields = (array) \civicrm_api4($item['entity'], 'getFields', [
+        'checkPermissions' => FALSE,
+        'where' => [['localizable', '=', TRUE]],
+      ], ['name']);
+      $localizable = array_merge($localizable, $fields);
+    }
+
+    $managedFileName = $basedir->string('managed', "$managedName.mgd.php");
+    $phpData = new PhpData($managedFileName);
+    $phpData->useExtensionUtil($info->getExtensionUtilClass());
+    $phpData->useTs($localizable);
+    $phpData->set($export);
+    $ext->builders["$managedName.mgd.php"] = $phpData;
+  }
+
+  private function exportAfform($afformName, $info, $ext, $ctx) {
+    $basedir = new Path($ctx['basedir']);
+    $ext->builders['dirs']->addPath($basedir->string('ang'));
+
+    $fields = \civicrm_api4('Afform', 'getFields', [
+      'checkPermissions' => FALSE,
+      'where' => [['type', '=', 'Field']],
+    ])->indexBy('name');
+    // Will throw exception if not found
+    $afform = \civicrm_api4('Afform', 'get', [
+      'checkPermissions' => FALSE,
+      'where' => [['name', '=', $afformName]],
+      'select' => ['*', 'search_displays'],
+      'layoutFormat' => 'html',
+    ])->single();
+
+    // An Afform consists of 2 files - a layout file and a meta file
+    $layoutFileName = $basedir->string('ang', "$afformName.aff.html");
+    $metaFileName = $basedir->string('ang', "$afformName.aff.php");
+
+    // Export layout file
+    $ext->builders["$afformName.aff.html"] = new Content($afform['layout'], $layoutFileName, TRUE);
+
+    // Export meta file
+    $meta = $afform;
+    unset($meta['name'], $meta['layout'], $meta['search_displays'], $meta['navigation']);
+    // Simplify meta file by removing values that match the defaults
+    foreach ($meta as $field => $value) {
+      if ($field !== 'type' && $value == $fields[$field]['default_value']) {
+        unset($meta[$field]);
+      }
+    }
+    $phpData = new PhpData($metaFileName);
+    $phpData->useExtensionUtil($info->getExtensionUtilClass());
+    $phpData->useTs($this->localizable);
+    $phpData->set($meta);
+    $ext->builders["$afformName.aff.php"] = $phpData;
+
+    // Export navigation menu item pointing to afform, if present
+    if (!empty($afform['server_route'])) {
+      $navigation = \civicrm_api4('Navigation', 'get', [
+        'checkPermissions' => FALSE,
+        'select' => ['id'],
+        'where' => [['url', '=', $afform['server_route']], ['is_active', '=', TRUE]],
+        // Just the first one; multiple domains are handled by `CRM_Core_ManagedEntities`
+        'orderBy' => ['domain_id' => 'ASC'],
+      ])->first();
+      if ($navigation) {
+        $this->exportMgd('Navigation', $navigation['id'], $info, $ext, $ctx);
+      }
+    }
+
+    // Export embedded search display(s)
+    if (!empty($afform['search_displays'])) {
+      $searchNames = array_map(function ($item) {
+        return explode('.', $item)[0];
+      }, $afform['search_displays']);
+      $searchIds = \civicrm_api4('SavedSearch', 'get', [
+        'checkPermissions' => FALSE,
+        'where' => [['name', 'IN', $searchNames]],
+      ], ['id']);
+      foreach ($searchIds as $id) {
+        $this->exportMgd('SavedSearch', $id, $info, $ext, $ctx);
+      }
+    }
   }
 
 }

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -24,14 +24,19 @@ class AddManagedEntityCommand extends AbstractCommand {
     parent::configure();
     $this
       ->setName('export')
-      ->setDescription('Exports a record in packaged format for distribution in this extension')
+      ->setDescription('(Experimental) Exports a record in packaged format for distribution in this extension')
       ->addArgument('<EntityName>', InputArgument::REQUIRED, 'API entity name (Ex: "SavedSearch")')
       ->addArgument('<EntityId>', InputArgument::REQUIRED, 'Id of entity to be exported (or name if exporting an Afform)')
       ->setHelp('Uses APIv4 Export to save existing records as .mgd.php files.
 Specify the name of the entity and the id.
 The file will be saved to the managed directory.
 
-This command also works to export Afforms to the ang directory.');
+This command also works to export Afforms to the ang directory.
+
+The command has some support for updating (re-exporting) managed records.
+However, this is experimental. At time of writing, it does not interoperate
+with most existing extensions+generators.
+');
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {

--- a/tests/e2e/AddManagedEntityTest.php
+++ b/tests/e2e/AddManagedEntityTest.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace E2E;
+
+use ProcessHelper\ProcessHelper;
+
+class AddManagedEntityTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civix_exportmgd';
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+
+    $this->assertFileGlobs([
+      'info.xml' => 1,
+      'civix_exportmgd.php' => 1,
+      'civix_exportmgd.civix.php' => 1,
+    ]);
+    $this->civixMixin(['--disable-all' => TRUE]);
+  }
+
+  public function testAddMgd(): void {
+    $this->assertMixinStatuses(['mgd-php@1' => 'off']);
+    $this->assertFileGlobs(['managed/OptionGroup_preferred_communication_method.mgd.php' => 0]);
+
+    $tester = static::civix('generate:managed');
+    $tester->execute(['<EntityName>' => 'OptionGroup', '<EntityId>' => 1]);
+    if ($tester->getStatusCode() !== 0) {
+      throw new \RuntimeException(sprintf("Failed to generate mgd (%s)", static::getKey()));
+    }
+
+    $this->assertMixinStatuses(['mgd-php@1' => 'on']);
+    $this->assertFileGlobs(['managed/OptionGroup_preferred_communication_method.mgd.php' => 1]);
+
+    ProcessHelper::runOk('php -l managed/OptionGroup_preferred_communication_method.mgd.php');
+    $expectPhrases = [
+      "use CRM_CivixExportmgd_ExtensionUtil as E;",
+      "'title' => E::ts('Preferred Communication Method')",
+      "'option_group_id.name' => 'preferred_communication_method'",
+      "'label' => E::ts('Phone')",
+      "'value' => '1'",
+      "'label' => E::ts('Email')",
+      "'value' => '2'",
+    ];
+    $this->assertStringSequence($expectPhrases, file_get_contents('managed/OptionGroup_preferred_communication_method.mgd.php'));
+  }
+
+}

--- a/tests/e2e/AddManagedEntityTest.php
+++ b/tests/e2e/AddManagedEntityTest.php
@@ -28,7 +28,7 @@ class AddManagedEntityTest extends \PHPUnit\Framework\TestCase {
     $this->assertMixinStatuses(['mgd-php@1' => 'off']);
     $this->assertFileGlobs(['managed/OptionGroup_preferred_communication_method.mgd.php' => 0]);
 
-    $tester = static::civix('generate:managed');
+    $tester = static::civix('export');
     $tester->execute(['<EntityName>' => 'OptionGroup', '<EntityId>' => 1]);
     if ($tester->getStatusCode() !== 0) {
       throw new \RuntimeException(sprintf("Failed to generate mgd (%s)", static::getKey()));

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -152,6 +152,23 @@ trait CivixProjectTestTrait {
   }
 
   /**
+   * Update the mixin settings by calling `civix mixin`.
+   *
+   * @param array $options
+   *  Ex: ['--disable-all' => TRUE]
+   *  Ex: ['--enable' => 'foo@1']
+   * @return \Symfony\Component\Console\Tester\CommandTester
+   */
+  public function civixMixin(array $options): CommandTester {
+    $tester = static::civix('mixin');
+    $tester->execute($options);
+    if ($tester->getStatusCode() !== 0) {
+      throw new \RuntimeException(sprintf("Failed to call \"civix mixin\" with options: %s", json_encode($options)));
+    }
+    return $tester;
+  }
+
+  /**
    * Run the 'upgrade' command (non-interactively; all default choices).
    *
    * @param array $options


### PR DESCRIPTION
Adds a useful command which exports Afforms and managed records, leveraging the APIv4 Export action which collects sub-records into a single `.mgd.php` file (or in the case of Afforms, `.aff.php` and `.aff.html` *and* `.mgd.php`s for the search displays).
The resulting file includes `E::ts()` around translatable strings.

For a full demonstration, try exporting an existing afform, e.g.:
```
cv en civi_campaign
cd ext/civi_pledge # or any empty-ish extension
civix export Afform afsearchCampaignDashboard
```
It will write out the 2 files for the Afform plus 3 files for the 3 embedded SavedSearches into your extension (in this example `civi_pledge`), plus the navigation menu item.