### PR TITLE
Superficial fixes to form template - hints, array syntax

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/form.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/form.php.php
@@ -11,7 +11,11 @@ use <?php echo $_namespace ?>_ExtensionUtil as E;
  * @see https://docs.civicrm.org/dev/en/latest/framework/quickform/
  */
 class <?php echo preg_replace(':/:', '_', $fullClassName) ?> extends CRM_Core_Form {
-  public function buildQuickForm() {
+
+  /**
+   * @throws \CRM_Core_Exception
+   */
+  public function buildQuickForm(): void {
 
     // add form elements
     $this->add(
@@ -21,38 +25,38 @@ class <?php echo preg_replace(':/:', '_', $fullClassName) ?> extends CRM_Core_Fo
       $this->getColorOptions(), // list of options
       TRUE // is required
     );
-    $this->addButtons(array(
-      array(
+    $this->addButtons([
+      [
         'type' => 'submit',
         'name' => E::ts('Submit'),
         'isDefault' => TRUE,
-      ),
-    ));
+      ],
+    ]);
 
     // export form elements
     $this->assign('elementNames', $this->getRenderableElementNames());
     parent::buildQuickForm();
   }
 
-  public function postProcess() {
+  public function postProcess(): void {
     $values = $this->exportValues();
     $options = $this->getColorOptions();
-    CRM_Core_Session::setStatus(E::ts('You picked color "%1"', array(
+    CRM_Core_Session::setStatus(E::ts('You picked color "%1"', [
       1 => $options[$values['favorite_color']],
-    )));
+    ]));
     parent::postProcess();
   }
 
-  public function getColorOptions() {
-    $options = array(
+  public function getColorOptions(): array {
+    $options = [
       '' => E::ts('- select -'),
       '#f00' => E::ts('Red'),
       '#0f0' => E::ts('Green'),
       '#00f' => E::ts('Blue'),
       '#f0f' => E::ts('Purple'),
-    );
-    foreach (array('1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e') as $f) {
-      $options["#{$f}{$f}{$f}"] = E::ts('Grey (%1)', array(1 => $f));
+    ];
+    foreach (['1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e'] as $f) {
+      $options["#{$f}{$f}{$f}"] = E::ts('Grey (%1)', [1 => $f]);
     }
     return $options;
   }
@@ -62,12 +66,12 @@ class <?php echo preg_replace(':/:', '_', $fullClassName) ?> extends CRM_Core_Fo
    *
    * @return array (string)
    */
-  public function getRenderableElementNames() {
+  public function getRenderableElementNames(): array {
     // The _elements list includes some items which should not be
     // auto-rendered in the loop -- such as "qfKey" and "buttons".  These
     // items don't have labels.  We'll identify renderable by filtering on
     // the 'label'.
-    $elementNames = array();
+    $elementNames = [];
     foreach ($this->_elements as $element) {
       /** @var HTML_QuickForm_Element $element */
       $label = $element->getLabel();


### PR DESCRIPTION
This function is pretty prevalent in civix generated stuff - could be a mixin or core function - but probably just getting it to nice arrays etc is a step  forwards

After running it the only php grumble is it can't see that the class is called - @totten would be cool if your phpstorm extension could pick up that xml declarations make it called - but I assume that's a big lift

![image](https://github.com/totten/civix/assets/336308/e4c4fb6b-8ea0-494f-acdc-b3417dcc756a)
