### PR TITLE
Add helpers for naming classes like "Civi\MyExt\Foo"

### DIFF
--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Upgrader;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,12 +24,29 @@ abstract class AbstractCommand extends Command {
   private $io;
 
   /**
+   * @var Symfony\Component\Console\Input\InputInterface
+   */
+  private $input;
+
+  /**
+   * @var Symfony\Component\Console\Output\OutputInterface
+   */
+  private $output;
+
+  /**
+   * @var \CRM\CivixBundle\Upgrader
+   */
+  private $upgrader;
+
+  /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
    */
   protected function initialize(InputInterface $input, OutputInterface $output) {
     parent::initialize($input, $output);
     $this->io = new SymfonyStyle($input, $output);
+    $this->input = $input;
+    $this->output = $output;
   }
 
   /**
@@ -36,6 +54,13 @@ abstract class AbstractCommand extends Command {
    */
   protected function getIO() {
     return $this->io;
+  }
+
+  protected function getUpgrader(): Upgrader {
+    if ($this->upgrader === NULL) {
+      $this->upgrader = new Upgrader($this->input, $this->output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+    }
+    return $this->upgrader;
   }
 
   protected function confirm(InputInterface $input, OutputInterface $output, $message, $default = TRUE) {

--- a/src/CRM/CivixBundle/Utils/Naming.php
+++ b/src/CRM/CivixBundle/Utils/Naming.php
@@ -113,4 +113,33 @@ class Naming {
     return implode('.', $parts);
   }
 
+  public static function createUtilClassName(string $namespace): string {
+    return Naming::createClassName(Naming::coerceNamespace($namespace, 'CRM'), 'ExtensionUtil');
+  }
+
+  /**
+   * Force the use of 'CRM_Foo_Bar' or Civi\Foo\Bar'.
+   *
+   * @param string $namespace
+   *   Either 'CRM_Foobar' or 'Civi\Foobar'
+   * @param string $layout
+   *   Values may be:
+   *     - 'auto': Respect the configured <namespace>
+   *     - 'CRM': Force the use of 'CRM_Foobar'
+   *     - 'Civi': Force the use of 'Civi\Foobar'
+   * @return string
+   *   Either 'CRM_Foobar' or 'Civi\Foobar'
+   */
+  public static function coerceNamespace(string $namespace, string $layout): string {
+    if ($layout === 'CRM') {
+      $namespace = preg_replace(';^Civi\\\;', 'CRM_', $namespace);
+      $namespace = preg_replace(';^Civi/;', 'CRM/', $namespace);
+    }
+    elseif ($layout === 'Civi') {
+      $namespace = preg_replace(';^CRM_;', 'Civi\\', $namespace);
+      $namespace = preg_replace(';^CRM/;', 'Civi/', $namespace);
+    }
+    return $namespace;
+  }
+
 }

--- a/src/CRM/CivixBundle/Utils/Naming.php
+++ b/src/CRM/CivixBundle/Utils/Naming.php
@@ -104,4 +104,13 @@ class Naming {
     return preg_replace(';[_/\\\];', '/', static::createClassName($namespace, ...$suffixes)) . '.php';
   }
 
+  public static function createServiceName(string $namespace, ...$suffixes): string {
+    $namespace = preg_replace(';^(CRM_|Civi\\\);', '', $namespace);
+    $parts = [lcfirst($namespace)];
+    foreach ($suffixes as $suffix) {
+      $parts[] = lcfirst($suffix);
+    }
+    return implode('.', $parts);
+  }
+
 }

--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -89,4 +89,15 @@ class NamingTest extends \PHPUnit\Framework\TestCase {
     $this->assertEquals('Civi/Foobar/Upgrade/Base.php', Naming::createClassFile('Civi/Foobar', ['Upgrade', 'Base']));
   }
 
+  public function testCreateService() {
+    $this->assertEquals('foo.bar', Naming::createServiceName('CRM_Foo', 'Bar'));
+    $this->assertEquals('foo.bar', Naming::createServiceName('Civi\\Foo', 'Bar'));
+
+    $this->assertEquals('fooBar.whizBang', Naming::createServiceName('CRM_FooBar', 'WhizBang'));
+    $this->assertEquals('fooBar.whizBang', Naming::createServiceName('Civi\\FooBar', 'WhizBang'));
+
+    $this->assertEquals('foo.bar.whiz.bang', Naming::createServiceName('CRM_Foo', 'Bar', 'Whiz', 'Bang'));
+    $this->assertEquals('foo.bar.whiz.bang', Naming::createServiceName('Civi\\Foo', 'Bar', 'Whiz', 'Bang'));
+  }
+
 }

--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -100,4 +100,14 @@ class NamingTest extends \PHPUnit\Framework\TestCase {
     $this->assertEquals('foo.bar.whiz.bang', Naming::createServiceName('Civi\\Foo', 'Bar', 'Whiz', 'Bang'));
   }
 
+  public function testCoerceNamespace() {
+    $this->assertEquals('CRM_Foobar', Naming::coerceNamespace('CRM_Foobar', 'auto'));
+    $this->assertEquals('CRM_Foobar', Naming::coerceNamespace('CRM_Foobar', 'CRM'));
+    $this->assertEquals('Civi\\Foobar', Naming::coerceNamespace('CRM_Foobar', 'Civi'));
+
+    $this->assertEquals('Civi\\Foobar', Naming::coerceNamespace('Civi\\Foobar', 'auto'));
+    $this->assertEquals('CRM_Foobar', Naming::coerceNamespace('Civi\\Foobar', 'CRM'));
+    $this->assertEquals('Civi\\Foobar', Naming::coerceNamespace('Civi\\Foobar', 'Civi'));
+  }
+
 }

--- a/tests/e2e/CRMNamingTest.php
+++ b/tests/e2e/CRMNamingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace E2E;
+
+use CRM\CivixBundle\Upgrader;
+use CRM\CivixBundle\Utils\Path;
+use Symfony\Component\Console\Input\ArgvInput;
+use Symfony\Component\Console\Output\NullOutput;
+
+class CRMNamingTest extends \PHPUnit\Framework\TestCase {
+
+  use CivixProjectTestTrait;
+
+  public static $key = 'civix_crmnaming';
+
+  /**
+   * @var \CRM\CivixBundle\Upgrader
+   */
+  protected $upgrader;
+
+  public function setUp(): void {
+    chdir(static::getWorkspacePath());
+    static::cleanDir(static::getKey());
+    $this->civixGenerateModule(static::getKey());
+    chdir(static::getKey());
+
+    $this->assertFileGlobs([
+      'info.xml' => 1,
+      'civix_crmnaming.php' => 1,
+      'civix_crmnaming.civix.php' => 1,
+    ]);
+
+    $this->upgrader = new Upgrader(new ArgvInput(), new NullOutput(), new Path(static::getExtPath()));
+  }
+
+  public function testNaming_OneParts(): void {
+    $vars = $this->upgrader->createClassVars('Widget');
+    $this->assertTrue(is_string($vars['extBaseDir']) && is_dir($vars['extBaseDir']));
+    $this->assertEquals('civix_crmnaming', $vars['extMainFile']);
+    $this->assertEquals('civix_crmnaming', $vars['extKey']);
+    $this->assertEquals('CRM/CivixCrmnaming/Widget.php', $vars['classFile']);
+    $this->assertEquals('CRM_CivixCrmnaming_Widget', $vars['className']);
+    $this->assertEquals('CRM_CivixCrmnaming_Widget', $vars['classNameFull']);
+    $this->assertEquals('', $vars['classNamespace']);
+    $this->assertEquals('', $vars['classNamespaceDecl']);
+    $this->assertEquals('use CRM_CivixCrmnaming_ExtensionUtil as E;', $vars['useE']);
+  }
+
+  public function testNaming_TwoParts(): void {
+    $vars = $this->upgrader->createClassVars(['Widget', 'Gizmo']);
+    $this->assertTrue(is_string($vars['extBaseDir']) && is_dir($vars['extBaseDir']));
+    $this->assertEquals('civix_crmnaming', $vars['extMainFile']);
+    $this->assertEquals('civix_crmnaming', $vars['extKey']);
+    $this->assertEquals('CRM/CivixCrmnaming/Widget/Gizmo.php', $vars['classFile']);
+    $this->assertEquals('CRM_CivixCrmnaming_Widget_Gizmo', $vars['className']);
+    $this->assertEquals('CRM_CivixCrmnaming_Widget_Gizmo', $vars['classNameFull']);
+    $this->assertEquals('', $vars['classNamespace']);
+    $this->assertEquals('', $vars['classNamespaceDecl']);
+    $this->assertEquals('use CRM_CivixCrmnaming_ExtensionUtil as E;', $vars['useE']);
+  }
+
+}

--- a/tests/e2e/CiviNamingTest.php
+++ b/tests/e2e/CiviNamingTest.php
@@ -8,11 +8,11 @@ use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
 
-class CRMNamingTest extends \PHPUnit\Framework\TestCase {
+class CiviNamingTest extends \PHPUnit\Framework\TestCase {
 
   use CivixProjectTestTrait;
 
-  public static $key = 'civix_crmnaming';
+  public static $key = 'civix_civinaming';
 
   /**
    * @var \CRM\CivixBundle\Upgrader
@@ -27,41 +27,40 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
 
     $this->assertFileGlobs([
       'info.xml' => 1,
-      'civix_crmnaming.php' => 1,
-      'civix_crmnaming.civix.php' => 1,
+      'civix_civinaming.php' => 1,
+      'civix_civinaming.civix.php' => 1,
     ]);
 
     $this->upgrader = new Upgrader(new ArgvInput(), new NullOutput(), new Path(static::getExtPath()));
     $this->upgrader->updateInfo(function(Info $info) {
-      // FIXME: Allow "_" instead of "/"
-      $info->get()->civix->namespace = 'CRM/NamingTest';
+      // FIXME: Allow "\" instead of "/"
+      $info->get()->civix->namespace = 'Civi/NamingTest';
     });
-
   }
 
   public function testNaming_OnePart(): void {
     $vars = $this->upgrader->createClassVars('Widget');
     $this->assertTrue(is_string($vars['extBaseDir']) && is_dir($vars['extBaseDir']));
-    $this->assertEquals('civix_crmnaming', $vars['extMainFile']);
-    $this->assertEquals('civix_crmnaming', $vars['extKey']);
-    $this->assertEquals('CRM/NamingTest/Widget.php', $vars['classFile']);
-    $this->assertEquals('CRM_NamingTest_Widget', $vars['className']);
-    $this->assertEquals('CRM_NamingTest_Widget', $vars['classNameFull']);
-    $this->assertEquals('', $vars['classNamespace']);
-    $this->assertEquals('', $vars['classNamespaceDecl']);
+    $this->assertEquals('civix_civinaming', $vars['extMainFile']);
+    $this->assertEquals('civix_civinaming', $vars['extKey']);
+    $this->assertEquals('Civi/NamingTest/Widget.php', $vars['classFile']);
+    $this->assertEquals('Widget', $vars['className']);
+    $this->assertEquals('Civi\\NamingTest\\Widget', $vars['classNameFull']);
+    $this->assertEquals('Civi\\NamingTest', $vars['classNamespace']);
+    $this->assertEquals('namespace Civi\\NamingTest;', $vars['classNamespaceDecl']);
     $this->assertEquals('use CRM_NamingTest_ExtensionUtil as E;', $vars['useE']);
   }
 
   public function testNaming_TwoParts(): void {
     $vars = $this->upgrader->createClassVars(['Widget', 'Gizmo']);
     $this->assertTrue(is_string($vars['extBaseDir']) && is_dir($vars['extBaseDir']));
-    $this->assertEquals('civix_crmnaming', $vars['extMainFile']);
-    $this->assertEquals('civix_crmnaming', $vars['extKey']);
-    $this->assertEquals('CRM/NamingTest/Widget/Gizmo.php', $vars['classFile']);
-    $this->assertEquals('CRM_NamingTest_Widget_Gizmo', $vars['className']);
-    $this->assertEquals('CRM_NamingTest_Widget_Gizmo', $vars['classNameFull']);
-    $this->assertEquals('', $vars['classNamespace']);
-    $this->assertEquals('', $vars['classNamespaceDecl']);
+    $this->assertEquals('civix_civinaming', $vars['extMainFile']);
+    $this->assertEquals('civix_civinaming', $vars['extKey']);
+    $this->assertEquals('Civi/NamingTest/Widget/Gizmo.php', $vars['classFile']);
+    $this->assertEquals('Gizmo', $vars['className']);
+    $this->assertEquals('Civi\\NamingTest\\Widget\\Gizmo', $vars['classNameFull']);
+    $this->assertEquals('Civi\\NamingTest\\Widget', $vars['classNamespace']);
+    $this->assertEquals('namespace Civi\\NamingTest\\Widget;', $vars['classNamespaceDecl']);
     $this->assertEquals('use CRM_NamingTest_ExtensionUtil as E;', $vars['useE']);
   }
 


### PR DESCRIPTION
This is a step toward implementing `civix generate:service`.