### PR TITLE
Export - warn but don't block exporting duplicate managed entity

### DIFF
--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -122,7 +122,7 @@ with most existing extensions+generators.
     ])->first();
     if ($existingMgd) {
       if ($existingMgd['module'] !== $extKey || $existingMgd['name'] !== $managedName) {
-        $this->getIO()->error([
+        $this->getIO()->warning([
           sprintf("Requested entity (%s) is already managed by \"%s\" (#%s). Adding new entity \"%s\" would create conflict.",
             "$entityName $id",
             $existingMgd['module'] . ':' . $existingMgd['name'],
@@ -130,7 +130,6 @@ with most existing extensions+generators.
             "$extKey:$managedName"
           ),
         ]);
-        throw new \Exception('Export would create conflict between extensions');
       }
       if (!file_exists($managedFileName)) {
         $this->getIO()->warning([


### PR DESCRIPTION
Per discussion, sometimes there's a legit reason to export a managed entity that already exists.

The use-case here is that Afform autogenerates a managed entity for navigation items that belong to the form, but civix exports them as managed entities in their own right. This isn't a real conflict but civix thinks it is.