### PR TITLE
Export - exclude readonly fields from .aff.php file

### DIFF
--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -168,10 +168,12 @@ with most existing extensions+generators.
 
     // Export meta file
     $meta = $afform;
-    unset($meta['name'], $meta['layout'], $meta['search_displays'], $meta['navigation']);
-    // Simplify meta file by removing values that match the defaults
+    unset($meta['name'], $meta['layout'], $meta['navigation']);
+    // Simplify meta file by removing readonly fields and values that match the defaults
     foreach ($meta as $field => $value) {
-      if ($field !== 'type' && $value == $fields[$field]['default_value']) {
+      if ($fields[$field]['readonly'] ||
+        ($field !== 'type' && $value == $fields[$field]['default_value'])
+      ) {
         unset($meta[$field]);
       }
     }


### PR DESCRIPTION
Noticed in some of the sprint PRs a `modified_date` was sneaking into the `.aff.php` file.

Excluding all `readonly` fields gets rid of that, and also  don't need to hard-code unsetting "search_displays" because it's also `readonly` in the metadata.