### PR TITLE
Remove unnecessary phpcs comments

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-bao.php.php
@@ -2,9 +2,8 @@
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
-// phpcs:disable
+
 use <?php echo $_namespace ?>_ExtensionUtil as E;
-// phpcs:enable
 
 class <?php echo $baoClassName ?> extends <?php echo $daoClassName ?> {
 

--- a/src/CRM/CivixBundle/Resources/views/Code/module.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.php.php
@@ -4,9 +4,8 @@ $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
 
 require_once '<?php echo $mainFile ?>.civix.php';
-// phpcs:disable
+
 use <?php echo $_namespace ?>_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Implements hook_civicrm_config().

--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -2,9 +2,8 @@
 echo "<?php\n";
 $_namespace = preg_replace(':/:', '_', $namespace);
 ?>
-// phpcs:disable
+
 use <?php echo $_namespace ?>_ExtensionUtil as E;
-// phpcs:enable
 
 /**
  * Collection of upgrade steps.


### PR DESCRIPTION
Not necessary because we have already taught `civilint` to ignore unused `E;`