### PR TITLE
"export" - Convert to helper-style. Refine afform exports. Prettier console messages.

### DIFF
--- a/src/CRM/CivixBundle/Builder/Content.php
+++ b/src/CRM/CivixBundle/Builder/Content.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -46,10 +47,10 @@ class Content implements Builder {
       // do nothing
     }
     elseif (file_exists($this->path) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
+      $output->writeln("<error>Skip " . Files::relativize($this->path) . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write</info> " . $this->path);
+      $output->writeln("<info>Write</info> " . Files::relativize($this->path));
       file_put_contents($this->path, $this->getContent($ctx));
     }
   }

--- a/src/CRM/CivixBundle/Builder/CopyClass.php
+++ b/src/CRM/CivixBundle/Builder/CopyClass.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -47,15 +48,14 @@ class CopyClass implements Builder {
   public function save(&$ctx, OutputInterface $output) {
     // NOTE: assume classloaders, etal, are already setup
     $clazz = new \ReflectionClass($this->srcClassName);
-
     if (file_exists($this->tgtFile) && $this->overwrite == 'ignore') {
       // do nothing
     }
     elseif (file_exists($this->tgtFile) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->tgtFile . ": file already exists</error>");
+      $output->writeln("<error>Skip " . Files::relativize($this->tgtFile) . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write</info> " . $this->tgtFile);
+      $output->writeln("<info>Write</info> " . Files::relativize($this->tgtFile));
       $content = file_get_contents($clazz->getFileName(), TRUE);
       // FIXME parser
       $content = strtr($content, [

--- a/src/CRM/CivixBundle/Builder/CopyFile.php
+++ b/src/CRM/CivixBundle/Builder/CopyFile.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -41,10 +42,10 @@ class CopyFile implements Builder {
       // do nothing
     }
     elseif (file_exists($this->to) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->to . ": file already exists</error>");
+      $output->writeln("<error>Skip " . Files::relativize($this->to) . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write</info> " . $this->to);
+      $output->writeln("<info>Write</info> " . Files::relativize($this->to));
       $content = file_get_contents($this->from, TRUE);
       file_put_contents($this->to, $content);
     }

--- a/src/CRM/CivixBundle/Builder/CustomDataXML.php
+++ b/src/CRM/CivixBundle/Builder/CustomDataXML.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -46,10 +47,10 @@ class CustomDataXML implements Builder {
       // do nothing
     }
     elseif (file_exists($this->path) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
+      $output->writeln("<error>Skip " . Files::relativize($this->path) . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write</info> " . $this->path);
+      $output->writeln("<info>Write</info> " . Files::relativize($this->path));
       file_put_contents($this->path, $this->export->toXML());
     }
   }

--- a/src/CRM/CivixBundle/Builder/Ini.php
+++ b/src/CRM/CivixBundle/Builder/Ini.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -68,7 +69,7 @@ class Ini implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write</info> " . $this->path);
+    $output->writeln("<info>Write</info> " . Files::relativize($this->path));
 
     $content = '';
     foreach ($this->data as $topKey => $data) {

--- a/src/CRM/CivixBundle/Builder/License.php
+++ b/src/CRM/CivixBundle/Builder/License.php
@@ -1,6 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
+use CRM\CivixBundle\Utils\Files;
 use SimpleXMLElement;
 use DOMDocument;
 use CRM\CivixBundle\Builder;
@@ -39,10 +40,10 @@ class License implements Builder {
       // do nothing
     }
     elseif (file_exists($this->path) && !$this->overwrite) {
-      $output->writeln("<error>Skip " . $this->path . ": file already exists</error>");
+      $output->writeln("<error>Skip " . Files::relativize($this->path) . ": file already exists</error>");
     }
     else {
-      $output->writeln("<info>Write</info> " . $this->path);
+      $output->writeln("<info>Write</info> " . Files::relativize($this->path));
       $text = strtr($this->license->getText(), [
         '<YEAR>' => date('Y'),
         '<OWNER>' => sprintf('%s <%s>', $ctx['author'], $ctx['email']),

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Versioning;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -176,7 +177,7 @@ class Mixins implements Builder {
     if (!is_dir(dirname($file))) {
       mkdir(dirname($file), Dirs::MODE, TRUE);
     }
-    $output->writeln("<info>Write</info> $file");
+    $output->writeln("<info>Write</info> " . Files::relativize($file));
     file_put_contents($file, $mixin['src']);
   }
 

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -183,7 +183,7 @@ class Mixins implements Builder {
 
   protected function removeBackportFile(OutputInterface $output, string $file): void {
     if (file_exists($file)) {
-      $output->writeln("<info>Remove</info> $file");
+      $output->writeln("<info>Remove</info> " . Files::relativize($file));
       unlink($file);
     }
   }

--- a/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
+++ b/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
@@ -1,6 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
 class PHPUnitGenerateInitFiles {
@@ -18,12 +19,12 @@ class PHPUnitGenerateInitFiles {
       ]);
       $dirs->save($ctx, $output);
 
-      $output->writeln(sprintf('<info>Write</info> %s', $bootstrapFile));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($bootstrapFile)));
       file_put_contents($bootstrapFile, Services::templating()
         ->render('phpunit-boot-cv.php.php', $ctx));
     }
     else {
-      $output->writeln(sprintf('<comment>Skip %s: file already exists</comment>', $bootstrapFile));
+      $output->writeln(sprintf('<comment>Skip %s: file already exists</comment>', Files::relativize($bootstrapFile)));
     }
   }
 

--- a/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
+++ b/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
@@ -1,5 +1,6 @@
 <?php
 namespace CRM\CivixBundle\Builder;
+
 use CRM\CivixBundle\Services;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -40,7 +41,7 @@ class PHPUnitGenerateInitFiles {
       $phpunitXml->save($ctx, $output);
     }
     else {
-      $output->writeln(sprintf('<comment>Skip %s: file already exists</comment>', $phpunitXmlFile));
+      $output->writeln(sprintf('<comment>Skip %s: file already exists</comment>', Files::relativize($phpunitXmlFile)));
     }
   }
 

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarExporter\VarExporter;
@@ -102,7 +103,7 @@ class PhpData implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write</info> " . $this->path);
+    $output->writeln("<info>Write</info> " . Files::relativize($this->path));
     Path::for(dirname($this->path))->mkdir();
 
     $content = "<?php\n";

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
+use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\VarExporter\VarExporter;
 
@@ -9,6 +10,8 @@ use Symfony\Component\VarExporter\VarExporter;
  * Write a data file in PHP format
  */
 class PhpData implements Builder {
+
+  const COMMON_LOCALIZBLE = 'title,label,description,text';
 
   /**
    * @var string
@@ -100,6 +103,7 @@ class PhpData implements Builder {
    */
   public function save(&$ctx, OutputInterface $output) {
     $output->writeln("<info>Write</info> " . $this->path);
+    Path::for(dirname($this->path))->mkdir();
 
     $content = "<?php\n";
     if ($this->extensionUtil) {

--- a/src/CRM/CivixBundle/Builder/XML.php
+++ b/src/CRM/CivixBundle/Builder/XML.php
@@ -1,6 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
+use CRM\CivixBundle\Utils\Files;
 use SimpleXMLElement;
 use DOMDocument;
 use CRM\CivixBundle\Builder;
@@ -59,7 +60,7 @@ class XML implements Builder {
    * Write the xml document
    */
   public function save(&$ctx, OutputInterface $output) {
-    $output->writeln("<info>Write</info> " . $this->path);
+    $output->writeln("<info>Write</info> " . Files::relativize($this->path));
 
     // force pretty printing with encode/decode cycle
     $outXML = $this->get()->saveXML();

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -68,21 +69,21 @@ abstract class AbstractAddPageCommand extends AbstractCommand {
     }
 
     if (!file_exists($phpFile)) {
-      $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
       file_put_contents($phpFile, Services::templating()
         ->render($this->getPhpTemplate($input), $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $phpFile));
+      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($phpFile)));
     }
 
     if (!file_exists($tplFile)) {
-      $output->writeln(sprintf('<info>Write</info> %s', $tplFile));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($tplFile)));
       file_put_contents($tplFile, Services::templating()
         ->render($this->getTplTemplate($input), $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $tplFile));
+      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($tplFile)));
     }
 
     $module = new Module(Services::templating());

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -107,7 +107,7 @@ action names.
         ->render('api.php.php', $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $ctx['apiFile']));
+      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($ctx['apiFile'])));
     }
 
     if ($input->getOption('schedule')) {
@@ -139,7 +139,7 @@ action names.
         $mgdBuilder->save($ctx, $output);
       }
       else {
-        $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $ctx['apiCronFile']));
+        $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($ctx['apiCronFile'])));
       }
     }
 
@@ -153,7 +153,7 @@ action names.
         ->render('test-api.php.php', $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $ctx['apiTestFile']));
+      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($ctx['apiTestFile'])));
     }
 
     $phpUnitInitFiles = new PHPUnitGenerateInitFiles();

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -101,7 +102,7 @@ action names.
     $dirs->save($ctx, $output);
 
     if (!file_exists($ctx['apiFile'])) {
-      $output->writeln(sprintf('<info>Write</info> %s', $ctx['apiFile']));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($ctx['apiFile'])));
       file_put_contents($ctx['apiFile'], Services::templating()
         ->render('api.php.php', $ctx));
     }
@@ -147,7 +148,7 @@ action names.
     ]);
     $test_dirs->save($ctx, $output);
     if (!file_exists($ctx['apiTestFile'])) {
-      $output->writeln(sprintf('<info>Write</info> %s', $ctx['apiTestFile']));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($ctx['apiTestFile'])));
       file_put_contents($ctx['apiTestFile'], Services::templating()
         ->render('test-api.php.php', $ctx));
     }

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Info;
@@ -104,7 +105,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       $dao->run();
       ob_end_clean();
       $daoFileName = $basedir->string("{$table['base']}{$table['fileName']}");
-      $output->writeln("<info>Write</info> $daoFileName");
+      $output->writeln("<info>Write</info>" . Files::relativize($daoFileName));
     }
 
     $schema = new \CRM_Core_CodeGen_Schema($config);
@@ -121,7 +122,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
       // We're poking into an internal class+function (`$schema->$generator()`) that changed in v5.23.
       // Beginning in 5.23: $schema->$function() returns an array with file content.
       // Before 5.23: $schema->$function($fileName) creates $fileName and returns void.
-      $output->writeln("<info>Write</info> $filePath");
+      $output->writeln("<info>Write</info> " . Files::relativize($filePath));
       if (version_compare(\CRM_Utils_System::version(), '5.23.alpha1', '>=')) {
         $data = $schema->$generator();
         if (!file_put_contents($filePath, reset($data))) {

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -3,7 +3,6 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Content;
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Services;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
@@ -44,6 +43,8 @@ with most existing extensions+generators.
   protected function execute(InputInterface $input, OutputInterface $output) {
     $this->assertCurrentFormat();
 
+    $this->getUpgrader()->addMixins(['mgd-php@1.0']);
+
     $ctx = [];
     $ctx['type'] = 'module';
     $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
@@ -80,7 +81,6 @@ with most existing extensions+generators.
 
   private function exportMgd($entityName, $id, Info $info, $ext, $ctx) {
     $basedir = new Path($ctx['basedir']);
-    $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);
     $ext->builders['dirs']->addPath($basedir->string('managed'));
 
     $export = (array) \civicrm_api4($entityName, 'export', [

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -59,17 +59,11 @@ with most existing extensions+generators.
     // Boot CiviCRM to use api4
     Services::boot(['output' => $output]);
 
-    try {
-      if ($entityName === 'Afform') {
-        $this->exportAfform($entityId, $info, $ext, $ctx);
-      }
-      else {
-        $this->exportMgd($entityName, $entityId, $info, $ext, $ctx);
-      }
+    if ($entityName === 'Afform') {
+      $this->exportAfform($entityId, $info, $ext, $ctx);
     }
-    catch (\Exception $e) {
-      $output->writeln("Error: " . $e->getMessage());
-      return 1;
+    else {
+      $this->exportMgd($entityName, $entityId, $info, $ext, $ctx);
     }
 
     $ext->builders['info'] = $info;

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -2,6 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -122,12 +123,12 @@ as separate groups:
     $dirs->save($ctx, $output);
 
     if (!file_exists($testPath)) {
-      $output->writeln(sprintf('<info>Write</info> %s', $testPath));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($testPath)));
       file_put_contents($testPath, Services::templating()
         ->render($templateName, $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', $testPath));
+      $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($testPath)));
     }
   }
 

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Application;
 use CRM\CivixBundle\Services;
+use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Builder\Dirs;
@@ -46,12 +47,12 @@ class AddUpgraderCommand extends AbstractCommand {
 
     $phpFile = $basedir->string($ctx['namespace'], 'Upgrader.php');
     if (!file_exists($phpFile)) {
-      $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
+      $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
       file_put_contents($phpFile, Services::templating()
         ->render('upgrader.php.php', $ctx));
     }
     else {
-      $output->writeln(sprintf('<error>Skip %s: file already exists, defer to customized version</error>', $phpFile));
+      $output->writeln(sprintf('<error>Skip %s: file already exists, defer to customized version</error>', Files::relativize($phpFile)));
     }
 
     if (!$info->get()->xpath('upgrader')) {

--- a/src/CRM/CivixBundle/Command/Mgd.php
+++ b/src/CRM/CivixBundle/Command/Mgd.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace CRM\CivixBundle\Command;
+
+use CRM\CivixBundle\Utils\Files;
+use Symfony\Component\Console\Style\StyleInterface;
+
+class Mgd {
+
+  public static function assertManageableEntity(string $entityName, $id, string $extKey, string $managedName, string $managedFileName, StyleInterface $io): void {
+    $existingMgd = \civicrm_api4('Managed', 'get', [
+      'select' => ['module', 'name', 'id'],
+      'where' => [
+        ['entity_type', '=', $entityName],
+        ['entity_id', '=', $id],
+      ],
+      'checkPermissions' => FALSE,
+    ])->first();
+    if ($existingMgd) {
+      if ($existingMgd['module'] !== $extKey || $existingMgd['name'] !== $managedName) {
+        $io->warning([
+          sprintf("Requested entity (%s) is already managed by \"%s\" (#%s). Adding new entity \"%s\" would create conflict.",
+            "$entityName $id",
+            $existingMgd['module'] . ':' . $existingMgd['name'],
+            $existingMgd['id'],
+            "$extKey:$managedName"
+          ),
+        ]);
+      }
+      if (!file_exists($managedFileName)) {
+        $io->warning([
+          sprintf('The managed entity (%s) already exists in the database, but the expected file (%s) does not exist.',
+            "$extKey:$managedName",
+            Files::relativize($managedFileName, \CRM\CivixBundle\Application::findExtDir())
+          ),
+          'The new file will be created, but you may have a conflict within this extension.',
+        ]);
+      }
+    }
+  }
+
+}

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -4,6 +4,7 @@ namespace CRM\CivixBundle\Command;
 use CRM\CivixBundle\Builder\Module;
 use CRM\CivixBundle\Services;
 use CRM\CivixBundle\Upgrader;
+use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Naming;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -104,7 +105,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     if ($ctx['namespace']) {
       $phpFile = $basedir->string(Naming::createClassFile($ctx['namespace'], 'Upgrader', 'Base.php'));
       if (file_exists($phpFile)) {
-        $output->writeln(sprintf('<info>Write</info> %s', $phpFile));
+        $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
         file_put_contents($phpFile, Services::templating()->render('upgrader-base.php.php', $ctx));
       }
     }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -249,10 +249,12 @@ class Upgrader {
       ])->indexBy('name');
 
       $meta = $afform;
-      unset($meta['name'], $meta['layout'], $meta['search_displays'], $meta['navigation']);
-      // Simplify meta file by removing values that match the defaults
+      unset($meta['name'], $meta['layout'], $meta['navigation']);
+      // Simplify meta file by removing readonly fields and values that match the defaults
       foreach ($meta as $field => $value) {
-        if ($field !== 'type' && $value == $fields[$field]['default_value']) {
+        if ($fields[$field]['readonly'] ||
+          ($field !== 'type' && $value == $fields[$field]['default_value'])
+        ) {
           unset($meta[$field]);
         }
       }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -417,9 +417,7 @@ class Upgrader {
 
     $this->io->note("Write " . Files::relativize($classFile, getcwd()));
     $rendered = Services::templating()->render($template, $tplData);
-    if (!is_dir(dirname($classFile))) {
-      mkdir(dirname($classFile), 0777, TRUE);
-    }
+    Path::for(dirname($classFile))->mkdir();
     file_put_contents($classFile, $rendered);
   }
 

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -415,7 +415,7 @@ class Upgrader {
       }
     }
 
-    $this->io->note("Write $classFile");
+    $this->io->note("Write " . Files::relativize($classFile, getcwd()));
     $rendered = Services::templating()->render($template, $tplData);
     if (!is_dir(dirname($classFile))) {
       mkdir(dirname($classFile), 0777, TRUE);

--- a/src/CRM/CivixBundle/Utils/Files.php
+++ b/src/CRM/CivixBundle/Utils/Files.php
@@ -85,6 +85,8 @@ class Files {
       $directory = strtr($directory, '\\', '/');
       $basePath = strtr($basePath, '\\', '/');
     }
+    $basePath = rtrim($basePath, '/') . '/';
+
     if (substr($directory, 0, strlen($basePath)) == $basePath) {
       return substr($directory, strlen($basePath));
     }

--- a/src/CRM/CivixBundle/Utils/Files.php
+++ b/src/CRM/CivixBundle/Utils/Files.php
@@ -76,11 +76,14 @@ class Files {
    * Make a file path relative to some base dir.
    *
    * @param $directory
-   * @param $basePath
+   * @param string|null $basePath
    *
    * @return string
    */
-  public static function relativize($directory, $basePath) {
+  public static function relativize($directory, $basePath = NULL) {
+    if ($basePath === NULL) {
+      $basePath = getcwd();
+    }
     if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
       $directory = strtr($directory, '\\', '/');
       $basePath = strtr($basePath, '\\', '/');

--- a/src/CRM/CivixBundle/Utils/Path.php
+++ b/src/CRM/CivixBundle/Utils/Path.php
@@ -9,8 +9,30 @@ class Path {
    */
   protected $basedir;
 
+  /**
+   * @param string|Path $basedir
+   * @param string[] $args
+   *   Optionally append to the path
+   * @return Path
+   */
+  public static function for($basedir, ...$args): Path {
+    $result = new Path($basedir);
+    if (!empty($args)) {
+      $result = $result->path(...$args);
+    }
+    return $result;
+  }
+
+  /**
+   * @param string|Path $basedir
+   */
   public function __construct($basedir) {
-    $this->basedir = $basedir;
+    if ($basedir instanceof Path) {
+      $this->basedir = $basedir->basedir;
+    }
+    else {
+      $this->basedir = $basedir;
+    }
   }
 
   public function __toString(): string {
@@ -48,16 +70,15 @@ class Path {
    * Make a folder for this path (if necessary).
    *
    * @param int $mode
-   * @return bool
-   *   TRUE if folder exists/is-created. FALSE if an error prevented it.
    */
-  public function mkdir($mode = 0777) {
+  public function mkdir($mode = 0777): void {
     $args = func_get_args();
     $dir = call_user_func_array([$this, 'string'], $args);
     if (!is_dir($dir)) {
-      return mkdir($dir, $mode, TRUE);
+      if (!mkdir($dir, $mode, TRUE)) {
+        throw new \RuntimeException("Failed to make directory: $path");
+      }
     }
-    return TRUE;
   }
 
   /**


### PR DESCRIPTION
## Gist (Non-technical)

Reorganize the `export` command. Fix a bug with re-exporting existing files.

## Gist (Technical)

Move helper functions from `AddManagedEntityCommand` to `Upgrader`

## Discussion

This is a stylistic change and a functional fix.

* The stylistic issue is that civix currently has two code-styles in the code-generation logic.
    * (*older*) Most of the `generate:xxx` commands work with `CRM\CivixBundle\Builder\*` classes (with an OOP hierarchy). 
    * (*newer*) Most of the auto-upgrade steps (`upgrade/*.up.php`) use `CRM\CivixBundle\Upgrade::*`  functions.
    * When working on the upgrade-steps, I found it a bit tedious to use the `Builder` contract for everything.
    * The basic advantages of the newer style are: (1) it has access to more utilities (`$this->infoXml`, `$this->io`, and so on*), (2) it's easier to incorporate prompts/user-feedback, (3) it's easier to compose/mix multiple steps,
    * Going forward, I'd like to switch the general UX style of civix to be more interactive-by-default. We get some miscommunication because important options (like `<compatibility>`) have been hidden-by-default. The "Upgrader" is generally more agreeable with this style of interaction. (*It's not perfect either. Maybe it evolves more. But it's comparatively easier...*)
    * There is small functional compromise here -- the older style allows you plan a batch of changes and then execute them together. So theoretically you can bailout before executing the batch. However, I don't think this is particularly valuable in practice. (*This falls well short of "atomicity"...  And the protection provided by `git` is more effective...*) 
* The functional issue is that `civix export` didn't seem to write updates correctly. (*It said that it was writing new files, but the content never changed.*) I strongly suspect this had to do with how the `Builder` lifecycles were arranged (`loadInit()`, `save()`, etc) . But it didn't seem worthwhile to dig into if the goal is generally change the style anyway.

## And also...

* Includes a tweak for the afform exporter to omit unnecessary properties (side-port of @colemanw's #322) 
* Includes a cleanup of the console messages to  show prettier paths (aka #324).


