### PR TITLE
(REF) Make it easier to access common service-objects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,7 @@
         "totten/process-helper": "^1.0.1"
     },
     "autoload": {
+        "files": ["src/Civix.php"],
         "psr-0": {
             "Mixlib": "extern/src/",
             "CRM\\CivixBundle": "src/"

--- a/scripts/check-phar.php
+++ b/scripts/check-phar.php
@@ -20,8 +20,8 @@ assertNotMatch('src/CRM/CivixBundle/Command/AddPageCommand.php', ';^namespace Ci
 assertNotMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace Symfony;');
 assertMatch('vendor/symfony/console/Input/InputInterface.php', ';^namespace CivixPhar.Symfony;');
 
-assertMatch('src/CRM/CivixBundle/Services.php', ';civicrm_api3;');
-assertNotMatch('src/CRM/CivixBundle/Services.php', ';CivixPhar.civicrm_api3;');
+assertMatch('src/Civix.php', ';civicrm_api3;');
+assertNotMatch('src/Civix.php', ';CivixPhar.civicrm_api3;');
 
 assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';JFactory::;');
 assertMatch('vendor/civicrm/cv-lib/src/CmsBootstrap.php', ';Drupal::;');

--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -87,15 +87,11 @@ class Application extends \Symfony\Component\Console\Application {
    *
    * @return string
    *   Ex: "/var/www/extension/org.example.foobar".
+   * @deprecated
+   * @see \Civix::extDir()
    */
-  public static function findExtDir() {
-    $cwd = rtrim(getcwd(), '/');
-    if (file_exists("$cwd/info.xml")) {
-      return $cwd;
-    }
-    else {
-      throw new \RuntimeException("Failed to find \"info.xml\" ($cwd/). Are you running in the right directory?");
-    }
+  public static function findExtDir(): string {
+    return (string) \Civix::extDir();
   }
 
   /**

--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -28,8 +28,6 @@ use CRM\CivixBundle\Command\MixinCommand;
 use CRM\CivixBundle\Command\PingCommand;
 use CRM\CivixBundle\Command\TestRunCommand;
 use CRM\CivixBundle\Command\UpgradeCommand;
-use Symfony\Component\Console\Input\InputInterface;
-use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends \Symfony\Component\Console\Application {
 
@@ -82,11 +80,6 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new InfoGetCommand();
     $commands[] = new InfoSetCommand();
     return $commands;
-  }
-
-  protected function configureIO(InputInterface $input, OutputInterface $output) {
-    parent::configureIO($input, $output);
-    \Civix::setIO($input, $output);
   }
 
   /**

--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -28,6 +28,8 @@ use CRM\CivixBundle\Command\MixinCommand;
 use CRM\CivixBundle\Command\PingCommand;
 use CRM\CivixBundle\Command\TestRunCommand;
 use CRM\CivixBundle\Command\UpgradeCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
 class Application extends \Symfony\Component\Console\Application {
 
@@ -80,6 +82,11 @@ class Application extends \Symfony\Component\Console\Application {
     $commands[] = new InfoGetCommand();
     $commands[] = new InfoSetCommand();
     return $commands;
+  }
+
+  protected function configureIO(InputInterface $input, OutputInterface $output) {
+    parent::configureIO($input, $output);
+    \Civix::setIO($input, $output);
   }
 
   /**

--- a/src/CRM/CivixBundle/Application.php
+++ b/src/CRM/CivixBundle/Application.php
@@ -98,8 +98,12 @@ class Application extends \Symfony\Component\Console\Application {
     }
   }
 
+  /**
+   * @return string
+   * @deprecated
+   */
   public static function findCivixDir(): string {
-    return dirname(__DIR__, 3);
+    return (string) \Civix::appDir();
   }
 
 }

--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Versioning;
 use LicenseData\Repository;
 use SimpleXMLElement;
@@ -67,7 +67,7 @@ class Info extends XML {
     if (isset($ctx['namespace'])) {
       $civix->addChild('namespace', $ctx['namespace']);
     }
-    $civix->addChild('format', $ctx['civixFormat'] ?? Services::upgradeList()->getHeadVersion());
+    $civix->addChild('format', $ctx['civixFormat'] ?? Civix::upgradeList()->getHeadVersion());
     if (isset($ctx['angularModuleName'])) {
       $civix->addChild('angularModule', $ctx['angularModuleName']);
     }

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Builder;
 
 use CRM\CivixBundle\Builder;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Versioning;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -55,7 +55,7 @@ class Mixins implements Builder {
     $this->outputDir = $outputDir;
     $this->newConstraints = (array) $newConstraints;
     $this->removals = [];
-    $this->allBackports = Services::mixinBackports();
+    $this->allBackports = Civix::mixinBackports();
   }
 
   public function loadInit(&$ctx) {
@@ -124,7 +124,7 @@ class Mixins implements Builder {
 
     // Let's clarify the versions we want.
     $actualDeclarations = array_merge($this->getDeclaredMixinConstraints(), $this->newConstraints);
-    $expectedDeclarations = array_column(Services::mixlib()->resolve($actualDeclarations), 'mixinConstraint');
+    $expectedDeclarations = array_column(Civix::mixlib()->resolve($actualDeclarations), 'mixinConstraint');
     foreach ($expectedDeclarations as $newMixin) {
       $this->addMixinToXml($newMixin);
     }
@@ -151,7 +151,7 @@ class Mixins implements Builder {
     $extraBackports = array_diff($existingBackports, $expectedBackports);
 
     foreach ($missingBackports as $mixinName) {
-      $mixinSpec = Services::mixlib()->get($mixinName);
+      $mixinSpec = Civix::mixlib()->get($mixinName);
       $this->createBackportFile($output, $mixinSpec);
     }
 

--- a/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
+++ b/src/CRM/CivixBundle/Builder/PHPUnitGenerateInitFiles.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,7 +21,7 @@ class PHPUnitGenerateInitFiles {
       $dirs->save($ctx, $output);
 
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($bootstrapFile)));
-      file_put_contents($bootstrapFile, Services::templating()
+      file_put_contents($bootstrapFile, Civix::templating()
         ->render('phpunit-boot-cv.php.php', $ctx));
     }
     else {

--- a/src/CRM/CivixBundle/Builder/Template.php
+++ b/src/CRM/CivixBundle/Builder/Template.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Builder;
 
-use CRM\CivixBundle\Services;
+use Civix;
 
 /**
  * Build/update a file based on a template
@@ -23,7 +23,7 @@ class Template extends Content {
     $this->template = $template;
     $this->path = $path;
     $this->overwrite = $overwrite;
-    $this->templateEngine = $templateEngine ?: Services::templating();
+    $this->templateEngine = $templateEngine ?: Civix::templating();
   }
 
   protected function getContent($ctx): string {

--- a/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractAddPageCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -70,7 +70,7 @@ abstract class AbstractAddPageCommand extends AbstractCommand {
 
     if (!file_exists($phpFile)) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
-      file_put_contents($phpFile, Services::templating()
+      file_put_contents($phpFile, Civix::templating()
         ->render($this->getPhpTemplate($input), $ctx));
     }
     else {
@@ -79,14 +79,14 @@ abstract class AbstractAddPageCommand extends AbstractCommand {
 
     if (!file_exists($tplFile)) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($tplFile)));
-      file_put_contents($tplFile, Services::templating()
+      file_put_contents($tplFile, Civix::templating()
         ->render($this->getTplTemplate($input), $ctx));
     }
     else {
       $output->writeln(sprintf('<error>Skip %s: file already exists</error>', Files::relativize($tplFile)));
     }
 
-    $module = new Module(Services::templating());
+    $module = new Module(Civix::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
 

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -17,6 +17,16 @@ abstract class AbstractCommand extends Command {
     $this->addOption('yes', NULL, InputOption::VALUE_NONE, 'Answer yes to any questions');
   }
 
+  public function run(InputInterface $input, OutputInterface $output) {
+    try {
+      \Civix::ioStack()->push($input, $output);
+      return parent::run($input, $output);
+    }
+    finally {
+      \Civix::ioStack()->pop();
+    }
+  }
+
   /**
    * @var \CRM\CivixBundle\Upgrader
    */

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -31,7 +31,7 @@ abstract class AbstractCommand extends Command {
 
   protected function getUpgrader(): Upgrader {
     if ($this->upgrader === NULL) {
-      $this->upgrader = new Upgrader(Civix::input(), Civix::output(), new Path(\CRM\CivixBundle\Application::findExtDir()));
+      $this->upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
     }
     return $this->upgrader;
   }

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Upgrader;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
@@ -90,7 +90,7 @@ abstract class AbstractCommand extends Command {
   protected function assertCurrentFormat() {
     $info = $this->getModuleInfo($ctx);
     $actualVersion = $info->detectFormat();
-    $expectedVersion = Services::upgradeList()->getHeadVersion();
+    $expectedVersion = Civix::upgradeList()->getHeadVersion();
     if (version_compare($actualVersion, $expectedVersion, '<')) {
       throw new \Exception("This extension requires an upgrade for the file-format (current=$actualVersion; expected=$expectedVersion). Please run 'civix upgrade' before generating code.");
     }

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\ConfirmationQuestion;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class AbstractCommand extends Command {
 
@@ -19,46 +18,20 @@ abstract class AbstractCommand extends Command {
   }
 
   /**
-   * @var \Symfony\Component\Console\Style\StyleInterface
-   */
-  private $io;
-
-  /**
-   * @var Symfony\Component\Console\Input\InputInterface
-   */
-  private $input;
-
-  /**
-   * @var Symfony\Component\Console\Output\OutputInterface
-   */
-  private $output;
-
-  /**
    * @var \CRM\CivixBundle\Upgrader
    */
   private $upgrader;
 
   /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
-   */
-  protected function initialize(InputInterface $input, OutputInterface $output) {
-    parent::initialize($input, $output);
-    $this->io = new SymfonyStyle($input, $output);
-    $this->input = $input;
-    $this->output = $output;
-  }
-
-  /**
    * @return \Symfony\Component\Console\Style\StyleInterface
    */
   protected function getIO() {
-    return $this->io;
+    return Civix::io();
   }
 
   protected function getUpgrader(): Upgrader {
     if ($this->upgrader === NULL) {
-      $this->upgrader = new Upgrader($this->input, $this->output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+      $this->upgrader = new Upgrader(Civix::input(), Civix::output(), new Path(\CRM\CivixBundle\Application::findExtDir()));
     }
     return $this->upgrader;
   }

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,8 +75,8 @@ For more, see https://docs.angularjs.org/guide/directive');
       dirname($ctx['htmlPath']),
     ]);;
 
-    $ext->builders['js'] = new Template('angular-dir.js.php', $ctx['jsPath'], FALSE, Services::templating());
-    $ext->builders['html'] = new Template('angular-dir.html.php', $ctx['htmlPath'], FALSE, Services::templating());
+    $ext->builders['js'] = new Template('angular-dir.js.php', $ctx['jsPath'], FALSE, Civix::templating());
+    $ext->builders['html'] = new Template('angular-dir.html.php', $ctx['htmlPath'], FALSE, Civix::templating());
 
     $ext->init($ctx);
     $ext->save($ctx, $output);

--- a/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularModuleCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -68,8 +68,8 @@ class AddAngularModuleCommand extends AbstractCommand {
       $ext->builders['ang.php']->set($angModMeta);
     }
 
-    $ext->builders['js'] = new Template('angular-module.js.php', $ctx['angularModuleJs'], FALSE, Services::templating());
-    $ext->builders['css'] = new Template('angular-module.css.php', $ctx['angularModuleCss'], FALSE, Services::templating());
+    $ext->builders['js'] = new Template('angular-module.js.php', $ctx['angularModuleJs'], FALSE, Civix::templating());
+    $ext->builders['css'] = new Template('angular-module.css.php', $ctx['angularModuleCss'], FALSE, Civix::templating());
 
     $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['ang-php@1.0']);
     $ext->builders['info'] = $info;

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -75,9 +75,9 @@ For more, see https://docs.angularjs.org/guide');
       dirname($ctx['hlpPath']),
     ]);;
 
-    $ext->builders['ctrl.js'] = new Template('angular-page.js.php', $ctx['jsPath'], FALSE, Services::templating());
-    $ext->builders['html'] = new Template('angular-page.html.php', $ctx['htmlPath'], FALSE, Services::templating());
-    $ext->builders['hlp'] = new Template('angular-page.hlp.php', $ctx['hlpPath'], FALSE, Services::templating());
+    $ext->builders['ctrl.js'] = new Template('angular-page.js.php', $ctx['jsPath'], FALSE, Civix::templating());
+    $ext->builders['html'] = new Template('angular-page.html.php', $ctx['htmlPath'], FALSE, Civix::templating());
+    $ext->builders['hlp'] = new Template('angular-page.hlp.php', $ctx['hlpPath'], FALSE, Civix::templating());
 
     $ext->init($ctx);
     $ext->save($ctx, $output);

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -51,8 +51,8 @@ action names.
     $io = new SymfonyStyle($input, $output);
 
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return;
@@ -103,7 +103,7 @@ action names.
 
     if (!file_exists($ctx['apiFile'])) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($ctx['apiFile'])));
-      file_put_contents($ctx['apiFile'], Services::templating()
+      file_put_contents($ctx['apiFile'], Civix::templating()
         ->render('api.php.php', $ctx));
     }
     else {
@@ -149,7 +149,7 @@ action names.
     $test_dirs->save($ctx, $output);
     if (!file_exists($ctx['apiTestFile'])) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($ctx['apiTestFile'])));
-      file_put_contents($ctx['apiTestFile'], Services::templating()
+      file_put_contents($ctx['apiTestFile'], Civix::templating()
         ->render('test-api.php.php', $ctx));
     }
     else {

--- a/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCaseTypeCommand.php
@@ -3,7 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Builder\Template;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -23,8 +23,8 @@ class AddCaseTypeCommand extends AbstractCommand {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("Requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return 1;

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -26,8 +26,8 @@ class AddCustomDataCommand extends AbstractCommand {
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>generate:custom-xml requires access to local CiviCRM instance. Configure civicrm_api3_conf_path.</error>");
       return;

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -33,8 +33,8 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
    * then...
    */
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
 
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
@@ -140,7 +140,7 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
     $createSql('generateCreateSql', 'auto_install.sql');
     $createSql('generateDropSql', 'auto_uninstall.sql');
 
-    $module = new Module(Services::templating());
+    $module = new Module(Civix::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
     $upgraderClass = str_replace('/', '_', $ctx['namespace']) . '_Upgrader';

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -3,7 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Builder\PHPUnitGenerateInitFiles;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -42,8 +42,8 @@ explicity.');
 
   protected function execute(InputInterface $input, OutputInterface $output) {
     // load Civi to get access to civicrm_api_get_function_name
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>Require access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return 1;
@@ -110,14 +110,14 @@ explicity.');
     $ext->builders['dirs']->save($ctx, $output);
 
     if (in_array('3', $apiVersions)) {
-      $ext->builders['api.php'] = new Template('entity-api.php.php', $ctx['apiFile'], FALSE, Services::templating());
-      $ext->builders['test.php'] = new Template('entity-api3-test.php.php', $ctx['testApi3ClassFile'], FALSE, Services::templating());
+      $ext->builders['api.php'] = new Template('entity-api.php.php', $ctx['apiFile'], FALSE, Civix::templating());
+      $ext->builders['test.php'] = new Template('entity-api3-test.php.php', $ctx['testApi3ClassFile'], FALSE, Civix::templating());
     }
     if (in_array('4', $apiVersions)) {
-      $ext->builders['api4.php'] = new Template('entity-api4.php.php', $ctx['api4File'], FALSE, Services::templating());
+      $ext->builders['api4.php'] = new Template('entity-api4.php.php', $ctx['api4File'], FALSE, Civix::templating());
     }
-    $ext->builders['bao.php'] = new Template('entity-bao.php.php', $ctx['baoClassFile'], FALSE, Services::templating());
-    $ext->builders['entity.xml'] = new Template('entity-schema.xml.php', $ctx['schemaFile'], FALSE, Services::templating());
+    $ext->builders['bao.php'] = new Template('entity-bao.php.php', $ctx['baoClassFile'], FALSE, Civix::templating());
+    $ext->builders['entity.xml'] = new Template('entity-schema.xml.php', $ctx['schemaFile'], FALSE, Civix::templating());
 
     if (!file_exists($ctx['entityTypeFile'])) {
       $mgdEntities = [

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -40,7 +40,7 @@ with most existing extensions+generators.
     $entityId = $input->getArgument('<EntityId>');
 
     // Boot CiviCRM to use api4
-    Services::boot(['output' => $output]);
+    Civix::boot(['output' => $output]);
 
     $upgrader = $this->getUpgrader();
     $upgrader->addMixins(['mgd-php@1.0']);

--- a/src/CRM/CivixBundle/Command/AddReportCommand.php
+++ b/src/CRM/CivixBundle/Command/AddReportCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -98,8 +98,8 @@ class AddReportCommand extends AbstractCommand {
     // Create .php & .tpl by either copying from core source tree or using a civix template
     if ($srcClassName = $input->getOption('copy')) {
       // To locate the original file, we need to bootstrap Civi and search the include path
-      Services::boot(['output' => $output]);
-      $civicrm_api3 = Services::api3();
+      Civix::boot(['output' => $output]);
+      $civicrm_api3 = Civix::api3();
       if (!$civicrm_api3 || !$civicrm_api3->local) {
         $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
         return;
@@ -110,8 +110,8 @@ class AddReportCommand extends AbstractCommand {
       $ext->builders['page.tpl.php'] = new CopyFile($origTplFile, $ctx['reportTplFile'], FALSE);
     }
     else {
-      $ext->builders['report.php'] = new Template('report.php.php', $ctx['reportClassFile'], FALSE, Services::templating());
-      $ext->builders['page.tpl.php'] = new Template('report.tpl.php', $ctx['reportTplFile'], FALSE, Services::templating());
+      $ext->builders['report.php'] = new Template('report.php.php', $ctx['reportClassFile'], FALSE, Civix::templating());
+      $ext->builders['page.tpl.php'] = new Template('report.tpl.php', $ctx['reportTplFile'], FALSE, Civix::templating());
     }
 
     $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);

--- a/src/CRM/CivixBundle/Command/AddSearchCommand.php
+++ b/src/CRM/CivixBundle/Command/AddSearchCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -77,8 +77,8 @@ class AddSearchCommand extends AbstractCommand {
 
     if ($srcClassName = $input->getOption('copy')) {
       // we need bootstrap to set up include path to locate file -- but that's it
-      Services::boot(['output' => $output]);
-      $civicrm_api3 = Services::api3();
+      Civix::boot(['output' => $output]);
+      $civicrm_api3 = Civix::api3();
       if (!$civicrm_api3 || !$civicrm_api3->local) {
         $output->writeln("<error>--copy requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
         return;
@@ -105,8 +105,8 @@ class AddSearchCommand extends AbstractCommand {
       }
     }
     else {
-      $ext->builders['search.php'] = new Template('search.php.php', $ctx['searchClassFile'], FALSE, Services::templating());
-      // $ext->builders['page.tpl.php'] = new Template('search.tpl.php', $ctx['searchTplFile'], FALSE, Services::templating());
+      $ext->builders['search.php'] = new Template('search.php.php', $ctx['searchClassFile'], FALSE, Civix::templating());
+      // $ext->builders['page.tpl.php'] = new Template('search.tpl.php', $ctx['searchTplFile'], FALSE, Civix::templating());
     }
 
     $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), ['mgd-php@1.0']);

--- a/src/CRM/CivixBundle/Command/AddServiceCommand.php
+++ b/src/CRM/CivixBundle/Command/AddServiceCommand.php
@@ -2,7 +2,7 @@
 
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Naming;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -12,7 +12,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AddServiceCommand extends AbstractCommand {
 
   protected function configure() {
-    Services::templating();
+    Civix::templating();
     $this
       ->setName('generate:service')
       ->setDescription('Create a new service')

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -124,7 +124,7 @@ as separate groups:
 
     if (!file_exists($testPath)) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($testPath)));
-      file_put_contents($testPath, Services::templating()
+      file_put_contents($testPath, Civix::templating()
         ->render($templateName, $ctx));
     }
     else {

--- a/src/CRM/CivixBundle/Command/AddThemeCommand.php
+++ b/src/CRM/CivixBundle/Command/AddThemeCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -89,8 +89,8 @@ $ civix generate:theme foobar
       $ext->builders['theme.php']->set($themeMeta);
     }
 
-    $ext->builders['civicrm.css'] = new Template('civicrm.css.php', $ctx['themeCivicrmCss'], FALSE, Services::templating());
-    $ext->builders['bootstrap.css'] = new Template('bootstrap.css.php', $ctx['themeBootstrapCss'], FALSE, Services::templating());
+    $ext->builders['civicrm.css'] = new Template('civicrm.css.php', $ctx['themeCivicrmCss'], FALSE, Civix::templating());
+    $ext->builders['bootstrap.css'] = new Template('bootstrap.css.php', $ctx['themeBootstrapCss'], FALSE, Civix::templating());
 
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Application;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -48,7 +48,7 @@ class AddUpgraderCommand extends AbstractCommand {
     $phpFile = $basedir->string($ctx['namespace'], 'Upgrader.php');
     if (!file_exists($phpFile)) {
       $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
-      file_put_contents($phpFile, Services::templating()
+      file_put_contents($phpFile, Civix::templating()
         ->render('upgrader.php.php', $ctx));
     }
     else {
@@ -61,7 +61,7 @@ class AddUpgraderCommand extends AbstractCommand {
     $info->raiseCompatibilityMinimum('5.38');
     $info->save($ctx, $output);
 
-    $module = new Module(Services::templating());
+    $module = new Module(Civix::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
 

--- a/src/CRM/CivixBundle/Command/ConfigGetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigGetCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -17,7 +17,7 @@ class ConfigGetCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $config = Services::config();
+    $config = Civix::config();
     foreach ($this->getInterestingParameters() as $key) {
       printf("%-40s \"%s\"\n", $key, @$config['parameters'][$key]);
     }

--- a/src/CRM/CivixBundle/Command/ConfigSetCommand.php
+++ b/src/CRM/CivixBundle/Command/ConfigSetCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -24,7 +24,7 @@ class ConfigSetCommand extends AbstractCommand {
     $ext = new Collection();
 
     $output->writeln("<info></info>");
-    $configDir = Services::configDir();
+    $configDir = Civix::configDir();
     $configDir->mkdir();
     $ext->builders['ini'] = new Ini($configDir->string('civix.ini'));
 

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -1,7 +1,6 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Builder\CopyFile;
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Builder\Template;
 use Civix;

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -4,7 +4,7 @@ namespace CRM\CivixBundle\Command;
 use CRM\CivixBundle\Builder\CopyFile;
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Builder\Template;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Naming;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -22,7 +22,7 @@ class InitCommand extends AbstractCommand {
   protected $defaultMixins = ['setting-php@1', 'mgd-php@1', 'smarty-v2@1'];
 
   protected function configure() {
-    Services::templating();
+    Civix::templating();
     $this
       ->setName('generate:module')
       ->setDescription('Create a new CiviCRM Module-Extension (Regenerate module.civix.php if \"key\" not specified)')
@@ -57,7 +57,7 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(['output' => $output]);
+    Civix::boot(['output' => $output]);
 
     $ctx = [];
     $ctx['type'] = 'module';
@@ -148,9 +148,9 @@ class InitCommand extends AbstractCommand {
     ]);
     $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), $this->getMixins($input));
     $ext->builders['info'] = $info;
-    $ext->builders['module'] = new Module(Services::templating());
+    $ext->builders['module'] = new Module(Civix::templating());
     $ext->builders['license'] = new License($licenses->get($ctx['license']), $basedir->string('LICENSE.txt'), FALSE);
-    $ext->builders['readme'] = new Template('readme.md.php', $basedir->string('README.md'), FALSE, Services::templating());
+    $ext->builders['readme'] = new Template('readme.md.php', $basedir->string('README.md'), FALSE, Civix::templating());
     $ext->loadInit($ctx);
     $ext->save($ctx, $output);
 
@@ -164,8 +164,8 @@ class InitCommand extends AbstractCommand {
    * @return bool TRUE on success; FALSE if there's no site or if there's an error
    */
   protected function tryEnable(InputInterface $input, OutputInterface $output, $key) {
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
 
     if ($civicrm_api3 && $civicrm_api3->local) {
       $siteName = \CRM_Utils_System::baseURL();
@@ -194,7 +194,7 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function getDefaultLicense() {
-    $config = Services::config();
+    $config = Civix::config();
     $license = NULL;
     if (!empty($config['parameters']['license'])) {
       $license = $config['parameters']['license'];
@@ -203,7 +203,7 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function getDefaultEmail() {
-    $config = Services::config();
+    $config = Civix::config();
     $value = NULL;
     if (!empty($config['parameters']['email'])) {
       $value = $config['parameters']['email'];
@@ -212,7 +212,7 @@ class InitCommand extends AbstractCommand {
   }
 
   protected function getDefaultAuthor() {
-    $config = Services::config();
+    $config = Civix::config();
     $value = NULL;
     if (!empty($config['parameters']['author'])) {
       $value = $config['parameters']['author'];

--- a/src/CRM/CivixBundle/Command/Mgd.php
+++ b/src/CRM/CivixBundle/Command/Mgd.php
@@ -3,11 +3,11 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Utils\Files;
-use Symfony\Component\Console\Style\StyleInterface;
 
 class Mgd {
 
-  public static function assertManageableEntity(string $entityName, $id, string $extKey, string $managedName, string $managedFileName, StyleInterface $io): void {
+  public static function assertManageableEntity(string $entityName, $id, string $extKey, string $managedName, string $managedFileName): void {
+    $io = \Civix::io();
     $existingMgd = \civicrm_api4('Managed', 'get', [
       'select' => ['module', 'name', 'id'],
       'where' => [

--- a/src/CRM/CivixBundle/Command/MixinCommand.php
+++ b/src/CRM/CivixBundle/Command/MixinCommand.php
@@ -3,7 +3,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class MixinCommand extends AbstractCommand {
 
   protected function configure() {
-    Services::templating();
+    Civix::templating();
     $this
       ->setName('mixin')
       ->setDescription('Inspect and update list of mixins')
@@ -106,8 +106,8 @@ class MixinCommand extends AbstractCommand {
   }
 
   protected function showList(SymfonyStyle $io, Mixins $mixins) {
-    $mixlib = Services::mixlib();
-    $mixinBackports = preg_grep(';@;', array_keys(Services::mixinBackports()));
+    $mixlib = Civix::mixlib();
+    $mixinBackports = preg_grep(';@;', array_keys(Civix::mixinBackports()));
 
     $toNameMajor = function($mixinConstraint) {
       [$mixinName, $mixinVersion] = explode('@', $mixinConstraint);
@@ -160,8 +160,8 @@ class MixinCommand extends AbstractCommand {
 
   protected function findAllMixins(): iterable {
     yield from [];
-    $mixlib = Services::mixlib();
-    $mixinBackports = preg_grep(';@;', array_keys(Services::mixinBackports()));
+    $mixlib = Civix::mixlib();
+    $mixinBackports = preg_grep(';@;', array_keys(Civix::mixinBackports()));
     sort($mixinBackports);
     foreach ($mixinBackports as $id) {
       yield $mixlib->get($id);

--- a/src/CRM/CivixBundle/Command/PingCommand.php
+++ b/src/CRM/CivixBundle/Command/PingCommand.php
@@ -1,7 +1,7 @@
 <?php
 namespace CRM\CivixBundle\Command;
 
-use CRM\CivixBundle\Services;
+use Civix;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -15,8 +15,8 @@ class PingCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(['output' => $output]);
-    $civicrm_api3 = Services::api3();
+    Civix::boot(['output' => $output]);
+    $civicrm_api3 = Civix::api3();
     if ($civicrm_api3->Contact->Get(['option.limit' => 1])) {
       if (empty($civicrm_api3->result->values[0]->contact_type)) {
         $output->writeln('<error>Ping failed: Site reported that it found no contacts</error>');

--- a/src/CRM/CivixBundle/Command/TestRunCommand.php
+++ b/src/CRM/CivixBundle/Command/TestRunCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
@@ -40,7 +40,7 @@ class TestRunCommand extends Command {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    Services::boot(['output' => $output]);
+    Civix::boot(['output' => $output]);
     $basedir = new Path(getcwd());
 
     $output->writeln("<comment>Warning: 'civix test' deprecated.  Run phpunit4 directly from the extension directory instead.</comment>");
@@ -54,7 +54,7 @@ class TestRunCommand extends Command {
     }
 
     // Find the main phpunit
-    $civicrm_api3 = Services::api3();
+    $civicrm_api3 = Civix::api3();
     if (!$civicrm_api3 || !$civicrm_api3->local) {
       $output->writeln("<error>'test' requires access to local CiviCRM source tree. Configure civicrm_api3_conf_path.</error>");
       return 1;
@@ -179,7 +179,7 @@ class TestRunCommand extends Command {
    * @return string temp file path
    */
   protected function getBootstrapFile($key, $clear = FALSE) {
-    $cacheDir = Services::cacheDir();
+    $cacheDir = Civix::cacheDir();
     $file = $cacheDir->string("civix-phpunit.{$key}.php");
     if ($clear || !file_exists($file) || filemtime($file) < time() - self::BOOTSTRAP_TTL) {
       $template_vars = [];
@@ -192,7 +192,7 @@ class TestRunCommand extends Command {
       $template_vars['civicrm_setting']['URL Preferences']['extensionsURL'] = \CRM_Core_BAO_Setting::getItem('URL Preferences', 'extensionsURL');
       $template_vars['civicrm_setting']['Test']['test_extensions'] = array_keys(\CRM_Core_PseudoConstant::getExtensions());
 
-      file_put_contents($file, Services::templating()
+      file_put_contents($file, Civix::templating()
         ->render('phpunit-boot.php.php', $template_vars));
     }
     return $file;

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -2,7 +2,7 @@
 namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Module;
-use CRM\CivixBundle\Services;
+use Civix;
 use CRM\CivixBundle\Upgrader;
 use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Naming;
@@ -15,7 +15,7 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 class UpgradeCommand extends AbstractCommand {
 
   protected function configure() {
-    Services::templating();
+    Civix::templating();
     $this
       ->setName('upgrade')
       ->setDescription('Apply upgrades to the layout of the codebase')
@@ -64,7 +64,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $io->writeln("Current civix format is <info>v{$startVersion}</info>.");
     }
 
-    $upgrades = Services::upgradeList()->findUpgrades($startVersion);
+    $upgrades = Civix::upgradeList()->findUpgrades($startVersion);
     if (empty($upgrades)) {
       $io->writeln("No incremental upgrades required.");
       return 0;
@@ -98,7 +98,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     [$ctx, $info] = $this->loadCtxInfo();
     $basedir = new Path(\CRM\CivixBundle\Application::findExtDir());
 
-    $module = new Module(Services::templating());
+    $module = new Module(Civix::templating());
     $module->loadInit($ctx);
     $module->save($ctx, $output);
 
@@ -106,7 +106,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $phpFile = $basedir->string(Naming::createClassFile($ctx['namespace'], 'Upgrader', 'Base.php'));
       if (file_exists($phpFile)) {
         $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
-        file_put_contents($phpFile, Services::templating()->render('upgrader-base.php.php', $ctx));
+        file_put_contents($phpFile, Civix::templating()->render('upgrader-base.php.php', $ctx));
       }
     }
   }

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -10,7 +10,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Utils\Path;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class UpgradeCommand extends AbstractCommand {
 
@@ -40,17 +39,17 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $startVer = $input->getOption('start');
     if ($startVer !== 'current') {
       $verAliases = ['0' => '13.10.0'];
-      $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+      $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
       $upgrader->updateFormatVersion($verAliases[$startVer] ?? $startVer);
     }
 
-    $this->executeIncrementalUpgrades($input, $output);
-    $this->executeGenericUpgrade($input, $output);
+    $this->executeIncrementalUpgrades();
+    $this->executeGenericUpgrade();
     return 0;
   }
 
-  protected function executeIncrementalUpgrades(InputInterface $input, OutputInterface $output) {
-    $io = new SymfonyStyle($input, $output);
+  protected function executeIncrementalUpgrades() {
+    $io = \Civix::io();
     $io->title('Incremental upgrades');
 
     [$ctx, $info] = $this->loadCtxInfo();
@@ -75,7 +74,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $io->section("Upgrade <info>v{$lastVersion}</info> => <info>v{$upgradeVersion}</info>");
       $io->writeln("<info>Executing upgrade script</info> $upgradeFile");
 
-      $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+      $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
       $func = require $upgradeFile;
       $func($upgrader);
       $upgrader->updateFormatVersion($upgradeVersion);
@@ -83,11 +82,11 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     }
   }
 
-  protected function executeGenericUpgrade(InputInterface $input, OutputInterface $output): void {
-    $io = new SymfonyStyle($input, $output);
+  protected function executeGenericUpgrade(): void {
+    $io = \Civix::io();
     $io->title('General upgrade');
 
-    $upgrader = new Upgrader($input, $output, new Path(\CRM\CivixBundle\Application::findExtDir()));
+    $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
     $upgrader->cleanEmptyHooks();
     $upgrader->cleanEmptyLines();
     $upgrader->reconcileMixins();
@@ -100,12 +99,12 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
 
     $module = new Module(Civix::templating());
     $module->loadInit($ctx);
-    $module->save($ctx, $output);
+    $module->save($ctx, \Civix::output());
 
     if ($ctx['namespace']) {
       $phpFile = $basedir->string(Naming::createClassFile($ctx['namespace'], 'Upgrader', 'Base.php'));
       if (file_exists($phpFile)) {
-        $output->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
+        \Civix::output()->writeln(sprintf('<info>Write</info> %s', Files::relativize($phpFile)));
         file_put_contents($phpFile, Civix::templating()->render('upgrader-base.php.php', $ctx));
       }
     }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -49,15 +49,13 @@ class Upgrader {
   public $infoXml;
 
   /**
-   * @param \Symfony\Component\Console\Input\InputInterface $input
-   * @param \Symfony\Component\Console\Output\OutputInterface $output
    * @param \CRM\CivixBundle\Utils\Path $baseDir
    *   The folder that contains the extension.
    */
-  public function __construct(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output, Path $baseDir) {
-    $this->input = $input;
-    $this->output = $output;
-    $this->io = new SymfonyStyle($input, $output);
+  public function __construct(Path $baseDir) {
+    $this->input = \Civix::input();
+    $this->output = \Civix::output();
+    $this->io = \Civix::io();
     $this->baseDir = $baseDir;
     $this->reloadInfo();
   }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -20,19 +20,19 @@ class Upgrader {
    * @var \Symfony\Component\Console\Input\InputInterface
    * @readonly
    */
-  public $input;
+  private $input;
 
   /**
    * @var \Symfony\Component\Console\Output\OutputInterface
    * @readonly
    */
-  public $output;
+  private $output;
 
   /**
    * @var \Symfony\Component\Console\Style\SymfonyStyle
    * @readonly
    */
-  public $io;
+  private $io;
 
   /**
    * @var \CRM\CivixBundle\Utils\Path
@@ -207,7 +207,7 @@ class Upgrader {
 
     $managedName = $export[0]['name'];
     $managedFileName = $this->baseDir->string('managed', "$managedName.mgd.php");
-    Mgd::assertManageableEntity($entityName, $id, $this->infoXml->getKey(), $managedName, $managedFileName, $this->io);
+    Mgd::assertManageableEntity($entityName, $id, $this->infoXml->getKey(), $managedName, $managedFileName);
     $this->updateMgdPhp($managedFileName, function(PhpData $data) use ($export) {
       $data->set($export);
     });

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -724,15 +724,15 @@ class Upgrader {
   /**
    * Re-read the `info.xml` file.
    *
-   * @return array
+   * @return \CRM\CivixBundle\Builder\Info
    */
-  public function reloadInfo(): array {
+  public function reloadInfo() {
     $this->_ctx = [];
     $this->_ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
     $this->_ctx['type'] = 'module';
     $this->infoXml = new Info($this->baseDir->string('info.xml'));
     $this->infoXml->load($this->_ctx);
-    return [$this->infoXml, $this->_ctx];
+    return $this->infoXml;
   }
 
   /**

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -1,6 +1,7 @@
 <?php
 namespace CRM\CivixBundle;
 
+use Civix;
 use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Builder\PhpData;
@@ -616,7 +617,7 @@ class Upgrader {
     }
 
     $this->io->note("Write " . Files::relativize($classFile, getcwd()));
-    $rendered = Services::templating()->render($template, $tplData);
+    $rendered = Civix::templating()->render($template, $tplData);
     Path::for(dirname($classFile))->mkdir();
     file_put_contents($classFile, $rendered);
   }

--- a/src/CRM/CivixBundle/Upgrader.php
+++ b/src/CRM/CivixBundle/Upgrader.php
@@ -47,8 +47,6 @@ class Upgrader {
    */
   public $infoXml;
 
-  private $_ctx;
-
   /**
    * @param \Symfony\Component\Console\Input\InputInterface $input
    * @param \Symfony\Component\Console\Output\OutputInterface $output
@@ -92,7 +90,8 @@ class Upgrader {
    */
   public function updateInfo(callable $function): void {
     $function($this->infoXml);
-    $this->infoXml->save($this->_ctx, $this->output);
+    $ctx = $this->createDefaultCtx();
+    $this->infoXml->save($ctx, $this->output);
   }
 
   /**
@@ -114,8 +113,9 @@ class Upgrader {
   public function updateMixins(callable $function): void {
     $mixins = new Mixins($this->infoXml, $this->baseDir->string('mixin'));
     $function($mixins);
-    $mixins->save($this->_ctx, $this->output);
-    $this->infoXml->save($this->_ctx, $this->output);
+    $ctx = $this->createDefaultCtx();
+    $mixins->save($ctx, $this->output);
+    $this->infoXml->save($ctx, $this->output);
   }
 
   /**
@@ -133,7 +133,7 @@ class Upgrader {
    */
   public function updatePhpData($path, callable $filter): void {
     $file = Path::for($path)->string();
-    $ctx = [];
+    $ctx = $this->createDefaultCtx();
     $phpData = new PhpData($file);
     $phpData->loadInit($ctx);
     $filter($phpData);
@@ -727,11 +727,9 @@ class Upgrader {
    * @return \CRM\CivixBundle\Builder\Info
    */
   public function reloadInfo() {
-    $this->_ctx = [];
-    $this->_ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
-    $this->_ctx['type'] = 'module';
+    $ctx = $this->createDefaultCtx();
     $this->infoXml = new Info($this->baseDir->string('info.xml'));
-    $this->infoXml->load($this->_ctx);
+    $this->infoXml->load($ctx);
     return $this->infoXml;
   }
 
@@ -778,6 +776,13 @@ class Upgrader {
         $this->io->writeln($lines[$i], SymfonyStyle::OUTPUT_RAW);
       }
     }
+  }
+
+  protected function createDefaultCtx(): array {
+    $ctx = [];
+    $ctx['basedir'] = \CRM\CivixBundle\Application::findExtDir();
+    $ctx['type'] = 'module';
+    return $ctx;
   }
 
 }

--- a/src/CRM/CivixBundle/Utils/IOStack.php
+++ b/src/CRM/CivixBundle/Utils/IOStack.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class IOStack {
+
+  protected $stack = [];
+
+  public function push(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): void {
+    array_unshift($this->stack, [
+      'input' => $input,
+      'output' => $output,
+      'io' => new SymfonyStyle($input, $output),
+    ]);
+  }
+
+  public function pop(): array {
+    return array_shift($this->stack);
+  }
+
+  public function current(string $property) {
+    return $this->stack[0][$property];
+  }
+
+  public function reset() {
+    $this->stack = [];
+  }
+
+}

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -81,7 +81,7 @@ class Civix {
   /**
    * Get the root path of the civix application.
    *
-   * @param array $parts
+   * @param string[] $parts
    *   Optional list of sub-paths
    *   Ex: ['src', 'CRM', 'CivixBundle']
    * @return \CRM\CivixBundle\Utils\Path
@@ -93,9 +93,10 @@ class Civix {
   }
 
   /**
+   * @param string[] $parts
    * @return \CRM\CivixBundle\Utils\Path
    */
-  public static function configDir() {
+  public static function configDir(...$parts): Path {
     if (!isset(self::$cache['configDir'])) {
       $homes = [
         getenv('HOME'), /* Unix */
@@ -111,17 +112,38 @@ class Civix {
         throw new \RuntimeException('Failed to locate home directory. Please set HOME (Unix) or USERPROFILE (Windows).');
       }
     }
-    return self::$cache['configDir'];
+    return Path::for(self::$cache['configDir'], ...$parts);
   }
 
   /**
+   * @param string[] $parts
    * @return \CRM\CivixBundle\Utils\Path
    */
-  public static function cacheDir() {
+  public static function cacheDir(...$parts): Path {
     if (!isset(self::$cache['cacheDir'])) {
       self::$cache['cacheDir'] = self::configDir()->path('cache');
     }
-    return self::$cache['cacheDir'];
+    return Path::for(self::$cache['cacheDir'], ...$parts);
+  }
+
+  /**
+   * Get the root path of the extension being developed.
+   *
+   * @param string[] $parts
+   *   Optional list of sub-paths
+   *   Ex: ['xml', 'Menu', 'foo.xml']
+   * @return \CRM\CivixBundle\Utils\Path
+   *   Ex: '/var/www/example.com/files/civicrm/ext/foobar'
+   */
+  public static function extDir(...$parts): Path {
+    $cwd = rtrim(getcwd(), '/');
+    if (file_exists("$cwd/info.xml")) {
+      return Path::for($cwd, ...$parts);
+    }
+    else {
+      throw new \RuntimeException("Failed to find \"info.xml\" ($cwd/). Are you running in the right directory?");
+    }
+
   }
 
   /**

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -2,7 +2,6 @@
 
 use Civi\Cv\Bootstrap;
 use CRM\CivixBundle\Utils\Path;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Templating\PhpEngine;
 use Symfony\Component\Templating\TemplateNameParser;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
@@ -11,22 +10,28 @@ class Civix {
 
   protected static $cache = [];
 
-  public static function setIO(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): void {
-    static::$cache['input'] = $input;
-    static::$cache['output'] = $output;
-    static::$cache['io'] = new SymfonyStyle($input, $output);
+  /**
+   * Get a list of input/output objects for pending commands.
+   *
+   * @return \CRM\CivixBundle\Utils\IOStack
+   */
+  public static function ioStack(): \CRM\CivixBundle\Utils\IOStack {
+    if (!isset(static::$cache[__FUNCTION__])) {
+      static::$cache[__FUNCTION__] = new \CRM\CivixBundle\Utils\IOStack();
+    }
+    return static::$cache[__FUNCTION__];
   }
 
   public static function input(): \Symfony\Component\Console\Input\InputInterface {
-    return static::$cache['input'];
+    return static::ioStack()->current('input');
   }
 
   public static function output(): \Symfony\Component\Console\Output\OutputInterface {
-    return static::$cache['output'];
+    return static::ioStack()->current('output');
   }
 
   public static function io(): \Symfony\Component\Console\Style\StyleInterface {
-    return static::$cache['io'];
+    return static::ioStack()->current('io');
   }
 
   public static function boot($options = []) {

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -2,13 +2,32 @@
 
 use Civi\Cv\Bootstrap;
 use CRM\CivixBundle\Utils\Path;
+use Symfony\Component\Console\Style\SymfonyStyle;
 use Symfony\Component\Templating\PhpEngine;
 use Symfony\Component\Templating\TemplateNameParser;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
 
 class Civix {
 
-  protected static $cache;
+  protected static $cache = [];
+
+  public static function setIO(\Symfony\Component\Console\Input\InputInterface $input, \Symfony\Component\Console\Output\OutputInterface $output): void {
+    static::$cache['input'] = $input;
+    static::$cache['output'] = $output;
+    static::$cache['io'] = new SymfonyStyle($input, $output);
+  }
+
+  public static function input(): \Symfony\Component\Console\Input\InputInterface {
+    return static::$cache['input'];
+  }
+
+  public static function output(): \Symfony\Component\Console\Output\OutputInterface {
+    return static::$cache['output'];
+  }
+
+  public static function io(): \Symfony\Component\Console\Style\StyleInterface {
+    return static::$cache['io'];
+  }
 
   public static function boot($options = []) {
     if (!isset(self::$cache['boot'])) {

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -1,17 +1,12 @@
 <?php
-namespace CRM\CivixBundle;
 
 use Civi\Cv\Bootstrap;
 use CRM\CivixBundle\Utils\Path;
-use Mixlib;
-use Symfony\Component\Filesystem\Filesystem;
-use Symfony\Component\Templating\EngineInterface;
 use Symfony\Component\Templating\PhpEngine;
 use Symfony\Component\Templating\TemplateNameParser;
 use Symfony\Component\Templating\Loader\FilesystemLoader;
 
-
-class Services {
+class Civix {
 
   protected static $cache;
 
@@ -55,11 +50,11 @@ class Services {
   }
 
   /**
-   * @return EngineInterface
+   * @return \Symfony\Component\Templating\EngineInterface
    */
   public static function templating() {
     if (!isset(self::$cache['templating'])) {
-      $loader = new FilesystemLoader(__DIR__ . '/Resources/views/Code/%name%');
+      $loader = new FilesystemLoader(static::appDir('/src/CRM/CivixBundle/Resources/views/Code/%name%'));
       self::$cache['templating'] = new PhpEngine(new TemplateNameParser(), $loader);
     }
     return self::$cache['templating'];
@@ -84,13 +79,27 @@ class Services {
   }
 
   /**
-   * @return Path
+   * Get the root path of the civix application.
+   *
+   * @param array $parts
+   *   Optional list of sub-paths
+   *   Ex: ['src', 'CRM', 'CivixBundle']
+   * @return \CRM\CivixBundle\Utils\Path
+   *   Ex: '/home/myuser/src/civix'
+   *   Ex: 'phar://usr/local/bin/civix.phar'
+   */
+  public static function appDir(...$parts): Path {
+    return Path::for(dirname(__DIR__), ...$parts);
+  }
+
+  /**
+   * @return \CRM\CivixBundle\Utils\Path
    */
   public static function configDir() {
     if (!isset(self::$cache['configDir'])) {
       $homes = [
-        getenv('HOME'), // Unix
-        getenv('USERPROFILE'), // Windows
+        getenv('HOME'), /* Unix */
+        getenv('USERPROFILE'), /* Windows */
       ];
       foreach ($homes as $home) {
         if (!empty($home)) {
@@ -106,7 +115,7 @@ class Services {
   }
 
   /**
-   * @return Path
+   * @return \CRM\CivixBundle\Utils\Path
    */
   public static function cacheDir() {
     if (!isset(self::$cache['cacheDir'])) {
@@ -122,9 +131,9 @@ class Services {
     if (!isset(self::$cache[__FUNCTION__])) {
       if (!class_exists('Mixlib')) {
         // For some reason, autoloading rule doesn't for this doesn't survive box/php-scoper/phar transofrmation.
-        require_once dirname(__DIR__, 3) . '/extern/src/Mixlib.php';
+        require_once static::appDir('extern/src/Mixlib.php');
       }
-      self::$cache[__FUNCTION__] = new Mixlib(dirname(__DIR__, 3) . '/extern/mixin');
+      self::$cache[__FUNCTION__] = new Mixlib(static::appDir('extern/mixin'));
     }
     return self::$cache[__FUNCTION__];
   }
@@ -134,7 +143,7 @@ class Services {
    */
   public static function mixinBackports(): array {
     if (!isset(self::$cache[__FUNCTION__])) {
-      self::$cache[__FUNCTION__] = require Application::findCivixDir() . '/mixin-backports.php';
+      self::$cache[__FUNCTION__] = require \CRM\CivixBundle\Application::findCivixDir() . '/mixin-backports.php';
     }
     return self::$cache[__FUNCTION__];
   }
@@ -142,9 +151,9 @@ class Services {
   /**
    * @return \CRM\CivixBundle\UpgradeList
    */
-  public static function upgradeList(): UpgradeList {
+  public static function upgradeList(): \CRM\CivixBundle\UpgradeList {
     if (!isset(self::$cache[__FUNCTION__])) {
-      self::$cache[__FUNCTION__] = new UpgradeList();
+      self::$cache[__FUNCTION__] = new \CRM\CivixBundle\UpgradeList();
     }
     return self::$cache[__FUNCTION__];
   }

--- a/tests/e2e/CRMNamingTest.php
+++ b/tests/e2e/CRMNamingTest.php
@@ -31,7 +31,8 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
       'civix_crmnaming.civix.php' => 1,
     ]);
 
-    $this->upgrader = new Upgrader(new ArgvInput(), new NullOutput(), new Path(static::getExtPath()));
+    \Civix::setIO(new ArgvInput(), new NullOutput());
+    $this->upgrader = new Upgrader(new Path(static::getExtPath()));
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "_" instead of "/"
       $info->get()->civix->namespace = 'CRM/NamingTest';

--- a/tests/e2e/CRMNamingTest.php
+++ b/tests/e2e/CRMNamingTest.php
@@ -31,13 +31,17 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
       'civix_crmnaming.civix.php' => 1,
     ]);
 
-    \Civix::setIO(new ArgvInput(), new NullOutput());
+    \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
     $this->upgrader = new Upgrader(new Path(static::getExtPath()));
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "_" instead of "/"
       $info->get()->civix->namespace = 'CRM/NamingTest';
     });
+  }
 
+  protected function tearDown(): void {
+    parent::tearDown();
+    \Civix::ioStack()->reset();
   }
 
   public function testNaming_OnePart(): void {

--- a/tests/e2e/CiviNamingTest.php
+++ b/tests/e2e/CiviNamingTest.php
@@ -31,12 +31,17 @@ class CiviNamingTest extends \PHPUnit\Framework\TestCase {
       'civix_civinaming.civix.php' => 1,
     ]);
 
-    \Civix::setIO(new ArgvInput(), new NullOutput());
+    \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
     $this->upgrader = new Upgrader(new Path(static::getExtPath()));
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "\" instead of "/"
       $info->get()->civix->namespace = 'Civi/NamingTest';
     });
+  }
+
+  protected function tearDown(): void {
+    parent::tearDown();
+    \Civix::ioStack()->reset();
   }
 
   public function testNaming_OnePart(): void {

--- a/tests/e2e/CiviNamingTest.php
+++ b/tests/e2e/CiviNamingTest.php
@@ -31,7 +31,8 @@ class CiviNamingTest extends \PHPUnit\Framework\TestCase {
       'civix_civinaming.civix.php' => 1,
     ]);
 
-    $this->upgrader = new Upgrader(new ArgvInput(), new NullOutput(), new Path(static::getExtPath()));
+    \Civix::setIO(new ArgvInput(), new NullOutput());
+    $this->upgrader = new Upgrader(new Path(static::getExtPath()));
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "\" instead of "/"
       $info->get()->civix->namespace = 'Civi/NamingTest';

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -200,7 +200,8 @@ trait CivixProjectTestTrait {
   public function civixUpgradeHelper(): Upgrader {
     $input = new ArrayInput([]);
     $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
-    return new Upgrader($input, $output, static::getExtPath());
+    \Civix::setIO($input, $output);
+    return new Upgrader(static::getExtPath());
   }
 
   /**

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -200,8 +200,13 @@ trait CivixProjectTestTrait {
   public function civixUpgradeHelper(): Upgrader {
     $input = new ArrayInput([]);
     $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
-    \Civix::setIO($input, $output);
-    return new Upgrader(static::getExtPath());
+    \Civix::ioStack()->push($input, $output);
+    try {
+      return new Upgrader(static::getExtPath());
+    }
+    finally {
+      \Civix::ioStack()->pop();
+    }
   }
 
   /**

--- a/tests/e2e/MultiExtensionTest.php
+++ b/tests/e2e/MultiExtensionTest.php
@@ -37,6 +37,7 @@ class MultiExtensionTest extends \PHPUnit\Framework\TestCase {
   protected function tearDown(): void {
     chdir(static::getWorkspacePath());
     PH::runOk('civibuild restore');
+    \Civix::ioStack()->reset();
   }
 
   public function testAddPage(): void {

--- a/upgrades/16.10.0.up.php
+++ b/upgrades/16.10.0.up.php
@@ -6,7 +6,7 @@
  * At some point in the future, this step could be removed if we configure `info.xml`'s `<upgrader>` option.
  */
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
-  $io = $upgrader->io;
+  $io = \Civix::io();
 
   if (!empty($upgrader->infoXml->get()->upgrader)) {
     $io->note("Found <upgrader> tag. Skip hook_postInstall.");

--- a/upgrades/19.06.2.up.php
+++ b/upgrades/19.06.2.up.php
@@ -18,7 +18,7 @@
  */
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-  $io = $upgrader->io;
+  $io = \Civix::io();
 
   $testFiles = \CRM\CivixBundle\Utils\Files::findFiles($upgrader->baseDir->string('tests'), '*.php');
   $upgrader->updateTextFiles($testFiles, function(string $file, string $content) use ($io, $upgrader) {

--- a/upgrades/20.06.0.up.php
+++ b/upgrades/20.06.0.up.php
@@ -6,7 +6,7 @@
  */
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-  $io = $upgrader->io;
+  $io = \Civix::io();
 
   $files = array_filter([
     $upgrader->baseDir->string('phpunit.xml'),

--- a/upgrades/22.05.0.up.php
+++ b/upgrades/22.05.0.up.php
@@ -2,7 +2,7 @@
 
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-  $io = $upgrader->io;
+  $io = \Civix::io();
   $prefix = $upgrader->infoXml->getFile();
 
   $io->note([

--- a/upgrades/22.05.2.up.php
+++ b/upgrades/22.05.2.up.php
@@ -25,7 +25,7 @@ return function (\CRM\CivixBundle\Upgrader $upgrader) {
 
     $newContent = EvilEx::rewriteMultilineChunk($content, $hookBody, function(array $matchLines) use ($hookFunc, $content, $upgrader, $hasSettingMixin, &$action) {
       /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-      $io = $upgrader->io;
+      $io = \Civix::io();
       $matchLineKeys = array_keys($matchLines);
       $allLines = explode("\n", $content);
       $focusStart = min($matchLineKeys);

--- a/upgrades/22.10.0.up.php
+++ b/upgrades/22.10.0.up.php
@@ -11,7 +11,7 @@ return function (\CRM\CivixBundle\Upgrader $upgrader) {
 
   $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-    $io = $upgrader->io;
+    $io = \Civix::io();
 
     $loaders = $info->getClassloaders();
     $prefixes = array_column($loaders, 'prefix');

--- a/upgrades/22.12.1.up.php
+++ b/upgrades/22.12.1.up.php
@@ -12,7 +12,7 @@ use CRM\CivixBundle\Utils\Naming;
  * - Remove old base class
  */
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
-  $io = $upgrader->io;
+  $io = \Civix::io();
   $io->section('Lifecycle Hooks: Install, Upgrade, etc');
 
   $info = $upgrader->infoXml;

--- a/upgrades/23.01.0.up.php
+++ b/upgrades/23.01.0.up.php
@@ -3,7 +3,7 @@ use CRM\CivixBundle\Utils\Formatting;
 
 return function (\CRM\CivixBundle\Upgrader $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-  $io = $upgrader->io;
+  $io = \Civix::io();
 
   $previewChanges = [];
   $previewChanges[] = ['*_civix_civicrm_config', 'Remove Smarty boilerplate'];

--- a/upgrades/23.02.0.up.php
+++ b/upgrades/23.02.0.up.php
@@ -8,12 +8,12 @@ return function (\CRM\CivixBundle\Upgrader $upgrader) {
   $prefix = $upgrader->infoXml->getFile();
 
   if (is_dir($upgrader->baseDir->string('xml/schema/CRM'))) {
-    $upgrader->io->note([
+    \Civix::io()->note([
       'Civix 23.02 removes `*_civix_civicrm_entityTypes` in favor of a mixin `entity-types-php@1.0`.',
       'This reduces code-duplication and will enable easier updates in the future.',
       'This may raise the minimum requirements to CiviCRM v5.45.',
     ]);
-    if (!$upgrader->io->confirm('Continue with upgrade?')) {
+    if (!\Civix::io()->confirm('Continue with upgrade?')) {
       throw new \RuntimeException('User stopped upgrade');
     }
 

--- a/upgrades/23.02.1.up.php
+++ b/upgrades/23.02.1.up.php
@@ -9,7 +9,7 @@ return function (\CRM\CivixBundle\Upgrader $upgrader) {
 
   $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
-    $io = $upgrader->io;
+    $io = \Civix::io();
 
     $loaders = $info->getClassloaders();
     $prefixes = array_column($loaders, 'prefix');


### PR DESCRIPTION
Before
-------

* Lots of classes juggling around copies of `$input` and/or `$output` and/or `$io`
* The service container `\CRM\CivixBundle\Services` has a long name and is missing commonly used data.

After
-----

* The service container is `\Civix`, and it includes more common elements. You can can do I/O with `Civix::input()`, `Civix::output()`, or `Civix::io()`.

Comments
-----------

~~I don't believe we currently have any cases where you need to re-enter the `Application` with different values of `$input,$output`. But if those come up, then we can figure out a push-pop mechanism.~~ (*The main application doesn't, but the test-suites might-do, and I had to do some revisions for the test-suites anyway. So went ahead and did it.*)