### PR TITLE
(REF) Convert "Upgrader" to "Generator"

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,4 +29,10 @@
       </exclude>
     </whitelist>
   </filter>
+
+  <listeners>
+    <listener class="CRM\CivixBundle\CivixTestListener">
+      <arguments/>
+    </listener>
+  </listeners>
 </phpunit>

--- a/src/CRM/CivixBundle/CivixTestListener.php
+++ b/src/CRM/CivixBundle/CivixTestListener.php
@@ -1,0 +1,13 @@
+<?php
+namespace CRM\CivixBundle;
+
+use PHPUnit\Framework\Test;
+
+class CivixTestListener implements \PHPUnit\Framework\TestListener {
+  use \PHPUnit\Framework\TestListenerDefaultImplementation;
+
+  public function startTest(Test $test): void {
+    \Civix::reset();
+  }
+
+}

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -32,13 +32,6 @@ abstract class AbstractCommand extends Command {
    */
   private $upgrader;
 
-  /**
-   * @return \Symfony\Component\Console\Style\StyleInterface
-   */
-  protected function getIO() {
-    return Civix::io();
-  }
-
   protected function getUpgrader(): Upgrader {
     if ($this->upgrader === NULL) {
       $this->upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -3,7 +3,6 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Info;
 use Civix;
-use CRM\CivixBundle\Upgrader;
 use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -25,18 +24,6 @@ abstract class AbstractCommand extends Command {
     finally {
       \Civix::ioStack()->pop();
     }
-  }
-
-  /**
-   * @var \CRM\CivixBundle\Upgrader
-   */
-  private $upgrader;
-
-  protected function getUpgrader(): Upgrader {
-    if ($this->upgrader === NULL) {
-      $this->upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
-    }
-    return $this->upgrader;
   }
 
   protected function confirm(InputInterface $input, OutputInterface $output, $message, $default = TRUE) {

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -42,13 +42,13 @@ with most existing extensions+generators.
     // Boot CiviCRM to use api4
     Civix::boot(['output' => $output]);
 
-    $upgrader = \Civix::generator();
-    $upgrader->addMixins(['mgd-php@1.0']);
+    $gen = \Civix::generator();
+    $gen->addMixins(['mgd-php@1.0']);
     if ($entityName === 'Afform') {
-      $upgrader->exportAfform($entityId);
+      $gen->exportAfform($entityId);
     }
     else {
-      $upgrader->exportMgd($entityName, $entityId);
+      $gen->exportMgd($entityName, $entityId);
     }
 
     return 0;

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -42,7 +42,7 @@ with most existing extensions+generators.
     // Boot CiviCRM to use api4
     Civix::boot(['output' => $output]);
 
-    $upgrader = \Civix::upgrader();
+    $upgrader = \Civix::generator();
     $upgrader->addMixins(['mgd-php@1.0']);
     if ($entityName === 'Afform') {
       $upgrader->exportAfform($entityId);

--- a/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddManagedEntityCommand.php
@@ -42,7 +42,7 @@ with most existing extensions+generators.
     // Boot CiviCRM to use api4
     Civix::boot(['output' => $output]);
 
-    $upgrader = $this->getUpgrader();
+    $upgrader = \Civix::upgrader();
     $upgrader->addMixins(['mgd-php@1.0']);
     if ($entityName === 'Afform') {
       $upgrader->exportAfform($entityId);

--- a/src/CRM/CivixBundle/Command/AddServiceCommand.php
+++ b/src/CRM/CivixBundle/Command/AddServiceCommand.php
@@ -23,7 +23,7 @@ class AddServiceCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $up = \Civix::upgrader();
+    $up = \Civix::generator();
     $up->addMixins(['scan-classes@1.0']);
 
     $servicePrefix = $up->infoXml->getFile();

--- a/src/CRM/CivixBundle/Command/AddServiceCommand.php
+++ b/src/CRM/CivixBundle/Command/AddServiceCommand.php
@@ -23,7 +23,7 @@ class AddServiceCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $up = $this->getUpgrader();
+    $up = \Civix::upgrader();
     $up->addMixins(['scan-classes@1.0']);
 
     $servicePrefix = $up->infoXml->getFile();

--- a/src/CRM/CivixBundle/Command/AddServiceCommand.php
+++ b/src/CRM/CivixBundle/Command/AddServiceCommand.php
@@ -23,11 +23,11 @@ class AddServiceCommand extends AbstractCommand {
   }
 
   protected function execute(InputInterface $input, OutputInterface $output) {
-    $up = \Civix::generator();
-    $up->addMixins(['scan-classes@1.0']);
+    $gen = \Civix::generator();
+    $gen->addMixins(['scan-classes@1.0']);
 
-    $servicePrefix = $up->infoXml->getFile();
-    $namespace = Naming::coerceNamespace($up->infoXml->getNamespace(), $input->getOption('naming'));
+    $servicePrefix = $gen->infoXml->getFile();
+    $namespace = Naming::coerceNamespace($gen->infoXml->getNamespace(), $input->getOption('naming'));
 
     if ($input->isInteractive()) {
       $defaultName = $input->getArgument('name') ?? Naming::createServiceName($servicePrefix, 'myService');
@@ -54,7 +54,7 @@ class AddServiceCommand extends AbstractCommand {
     $baseNameParts = array_map('ucfirst', explode('.', $baseName));
     $className = Naming::createClassName($namespace, ...$baseNameParts);
 
-    $up->addClass($className, 'service.php.php', [
+    $gen->addClass($className, 'service.php.php', [
       'service' => $serviceName,
     ]);
   }

--- a/src/CRM/CivixBundle/Command/AddServiceCommand.php
+++ b/src/CRM/CivixBundle/Command/AddServiceCommand.php
@@ -31,12 +31,12 @@ class AddServiceCommand extends AbstractCommand {
 
     if ($input->isInteractive()) {
       $defaultName = $input->getArgument('name') ?? Naming::createServiceName($servicePrefix, 'myService');
-      $this->getIO()->note([
+      Civix::io()->note([
         'The service name is a short machine name. It may appear in contexts like:',
         sprintf('Civi::service("%s")->doSomething()', $defaultName),
         sprintf('It is recommended to always have a naming prefix (such as "%s").', $servicePrefix),
       ]);
-      $serviceName = $this->getIO()->ask('Service name', $defaultName, function ($answer) {
+      $serviceName = Civix::io()->ask('Service name', $defaultName, function ($answer) {
         if ('' === trim($answer)) {
           throw new \Exception('Service name cannot be empty');
         }

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -73,10 +73,10 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $io->section("Upgrade <info>v{$lastVersion}</info> => <info>v{$upgradeVersion}</info>");
       $io->writeln("<info>Executing upgrade script</info> $upgradeFile");
 
-      $upgrader = Civix::generator();
+      $gen = Civix::generator();
       $func = require $upgradeFile;
-      $func($upgrader);
-      $upgrader->updateFormatVersion($upgradeVersion);
+      $func($gen);
+      $gen->updateFormatVersion($upgradeVersion);
       $lastVersion = $upgradeVersion;
     }
   }
@@ -85,10 +85,10 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $io = \Civix::io();
     $io->title('General upgrade');
 
-    $upgrader = Civix::generator();
-    $upgrader->cleanEmptyHooks();
-    $upgrader->cleanEmptyLines();
-    $upgrader->reconcileMixins();
+    $gen = Civix::generator();
+    $gen->cleanEmptyHooks();
+    $gen->cleanEmptyLines();
+    $gen->reconcileMixins();
 
     /**
      * @var \CRM\CivixBundle\Builder\Info $info

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -3,7 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Module;
 use Civix;
-use CRM\CivixBundle\Upgrader;
+use CRM\CivixBundle\Generator;
 use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Naming;
 use Symfony\Component\Console\Input\InputInterface;
@@ -39,7 +39,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $startVer = $input->getOption('start');
     if ($startVer !== 'current') {
       $verAliases = ['0' => '13.10.0'];
-      Civix::upgrader()->updateFormatVersion($verAliases[$startVer] ?? $startVer);
+      Civix::generator()->updateFormatVersion($verAliases[$startVer] ?? $startVer);
     }
 
     $this->executeIncrementalUpgrades();
@@ -73,7 +73,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $io->section("Upgrade <info>v{$lastVersion}</info> => <info>v{$upgradeVersion}</info>");
       $io->writeln("<info>Executing upgrade script</info> $upgradeFile");
 
-      $upgrader = Civix::upgrader();
+      $upgrader = Civix::generator();
       $func = require $upgradeFile;
       $func($upgrader);
       $upgrader->updateFormatVersion($upgradeVersion);
@@ -85,7 +85,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $io = \Civix::io();
     $io->title('General upgrade');
 
-    $upgrader = Civix::upgrader();
+    $upgrader = Civix::generator();
     $upgrader->cleanEmptyHooks();
     $upgrader->cleanEmptyLines();
     $upgrader->reconcileMixins();

--- a/src/CRM/CivixBundle/Command/UpgradeCommand.php
+++ b/src/CRM/CivixBundle/Command/UpgradeCommand.php
@@ -39,8 +39,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $startVer = $input->getOption('start');
     if ($startVer !== 'current') {
       $verAliases = ['0' => '13.10.0'];
-      $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
-      $upgrader->updateFormatVersion($verAliases[$startVer] ?? $startVer);
+      Civix::upgrader()->updateFormatVersion($verAliases[$startVer] ?? $startVer);
     }
 
     $this->executeIncrementalUpgrades();
@@ -74,7 +73,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
       $io->section("Upgrade <info>v{$lastVersion}</info> => <info>v{$upgradeVersion}</info>");
       $io->writeln("<info>Executing upgrade script</info> $upgradeFile");
 
-      $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
+      $upgrader = Civix::upgrader();
       $func = require $upgradeFile;
       $func($upgrader);
       $upgrader->updateFormatVersion($upgradeVersion);
@@ -86,7 +85,7 @@ Most upgrade steps should be safe to re-run repeatedly, but this is not guarante
     $io = \Civix::io();
     $io->title('General upgrade');
 
-    $upgrader = new Upgrader(new Path(\CRM\CivixBundle\Application::findExtDir()));
+    $upgrader = Civix::upgrader();
     $upgrader->cleanEmptyHooks();
     $upgrader->cleanEmptyLines();
     $upgrader->reconcileMixins();

--- a/src/CRM/CivixBundle/Generator.php
+++ b/src/CRM/CivixBundle/Generator.php
@@ -12,9 +12,9 @@ use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 /**
- * The "Upgrader" class is a utility provided to various upgrade-scripts.
+ * The "Generator" class is a utility provided to various upgrade-scripts.
  */
-class Upgrader {
+class Generator {
 
   /**
    * @var \Symfony\Component\Console\Input\InputInterface

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -204,4 +204,12 @@ class Civix {
     return self::$cache[__FUNCTION__];
   }
 
+  public static function reset(): void {
+    $new = [];
+    if (isset(static::$cache['boot'])) {
+      $new['boot'] = static::$cache['boot'];
+    }
+    static::$cache = $new;
+  }
+
 }

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -195,18 +195,19 @@ class Civix {
   }
 
   /**
-   * Get the upgrader-object for manipulating the extension.
+   * Get the generator-object for manipulating the extension.
    *
    * @param string|Path|null $extDir
    *   Base path of the extension that we wish to manipulate.
    *   If null, use the default (per CWD).
-   * @return \CRM\CivixBundle\Upgrader
+   *
+   * @return \CRM\CivixBundle\Generator
    */
-  public static function upgrader($extDir = NULL): \CRM\CivixBundle\Upgrader {
+  public static function generator($extDir = NULL): \CRM\CivixBundle\Generator {
     $extDir = ($extDir === NULL) ? Civix::extdir() : Path::for($extDir);
     $cacheKey = (string) $extDir;
     if (!isset(self::$cache[__FUNCTION__][$cacheKey])) {
-      self::$cache[__FUNCTION__][$cacheKey] = new \CRM\CivixBundle\Upgrader($extDir);
+      self::$cache[__FUNCTION__][$cacheKey] = new \CRM\CivixBundle\Generator($extDir);
     }
     return self::$cache[__FUNCTION__][$cacheKey];
   }

--- a/src/Civix.php
+++ b/src/Civix.php
@@ -195,6 +195,23 @@ class Civix {
   }
 
   /**
+   * Get the upgrader-object for manipulating the extension.
+   *
+   * @param string|Path|null $extDir
+   *   Base path of the extension that we wish to manipulate.
+   *   If null, use the default (per CWD).
+   * @return \CRM\CivixBundle\Upgrader
+   */
+  public static function upgrader($extDir = NULL): \CRM\CivixBundle\Upgrader {
+    $extDir = ($extDir === NULL) ? Civix::extdir() : Path::for($extDir);
+    $cacheKey = (string) $extDir;
+    if (!isset(self::$cache[__FUNCTION__][$cacheKey])) {
+      self::$cache[__FUNCTION__][$cacheKey] = new \CRM\CivixBundle\Upgrader($extDir);
+    }
+    return self::$cache[__FUNCTION__][$cacheKey];
+  }
+
+  /**
    * @return \CRM\CivixBundle\UpgradeList
    */
   public static function upgradeList(): \CRM\CivixBundle\UpgradeList {

--- a/tests/e2e/CRMNamingTest.php
+++ b/tests/e2e/CRMNamingTest.php
@@ -13,7 +13,7 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
   public static $key = 'civix_crmnaming';
 
   /**
-   * @var \CRM\CivixBundle\Upgrader
+   * @var \CRM\CivixBundle\Generator
    */
   protected $upgrader;
 
@@ -30,7 +30,7 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
     ]);
 
     \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
-    $this->upgrader = \Civix::upgrader(static::getExtPath());
+    $this->upgrader = \Civix::generator(static::getExtPath());
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "_" instead of "/"
       $info->get()->civix->namespace = 'CRM/NamingTest';

--- a/tests/e2e/CRMNamingTest.php
+++ b/tests/e2e/CRMNamingTest.php
@@ -3,8 +3,6 @@
 namespace E2E;
 
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Upgrader;
-use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -32,7 +30,7 @@ class CRMNamingTest extends \PHPUnit\Framework\TestCase {
     ]);
 
     \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
-    $this->upgrader = new Upgrader(new Path(static::getExtPath()));
+    $this->upgrader = \Civix::upgrader(static::getExtPath());
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "_" instead of "/"
       $info->get()->civix->namespace = 'CRM/NamingTest';

--- a/tests/e2e/CiviNamingTest.php
+++ b/tests/e2e/CiviNamingTest.php
@@ -3,8 +3,6 @@
 namespace E2E;
 
 use CRM\CivixBundle\Builder\Info;
-use CRM\CivixBundle\Upgrader;
-use CRM\CivixBundle\Utils\Path;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -32,7 +30,7 @@ class CiviNamingTest extends \PHPUnit\Framework\TestCase {
     ]);
 
     \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
-    $this->upgrader = new Upgrader(new Path(static::getExtPath()));
+    $this->upgrader = \Civix::upgrader(static::getExtPath());
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "\" instead of "/"
       $info->get()->civix->namespace = 'Civi/NamingTest';

--- a/tests/e2e/CiviNamingTest.php
+++ b/tests/e2e/CiviNamingTest.php
@@ -13,7 +13,7 @@ class CiviNamingTest extends \PHPUnit\Framework\TestCase {
   public static $key = 'civix_civinaming';
 
   /**
-   * @var \CRM\CivixBundle\Upgrader
+   * @var \CRM\CivixBundle\Generator
    */
   protected $upgrader;
 
@@ -30,7 +30,7 @@ class CiviNamingTest extends \PHPUnit\Framework\TestCase {
     ]);
 
     \Civix::ioStack()->push(new ArgvInput(), new NullOutput());
-    $this->upgrader = \Civix::upgrader(static::getExtPath());
+    $this->upgrader = \Civix::generator(static::getExtPath());
     $this->upgrader->updateInfo(function(Info $info) {
       // FIXME: Allow "\" instead of "/"
       $info->get()->civix->namespace = 'Civi/NamingTest';

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -202,7 +202,7 @@ trait CivixProjectTestTrait {
     $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
     \Civix::ioStack()->push($input, $output);
     try {
-      return new Upgrader(static::getExtPath());
+      return \Civix::upgrader(static::getExtPath());
     }
     finally {
       \Civix::ioStack()->pop();

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -3,7 +3,7 @@
 namespace E2E;
 
 use CRM\CivixBundle\Application;
-use CRM\CivixBundle\Upgrader;
+use CRM\CivixBundle\Generator;
 use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Path;
 use ProcessHelper\ProcessHelper as PH;
@@ -195,14 +195,14 @@ trait CivixProjectTestTrait {
   /**
    * Get the upgrade-utility/helper.
    *
-   * @return \CRM\CivixBundle\Upgrader
+   * @return \CRM\CivixBundle\Generator
    */
-  public function civixUpgradeHelper(): Upgrader {
+  public function civixUpgradeHelper(): Generator {
     $input = new ArrayInput([]);
     $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
     \Civix::ioStack()->push($input, $output);
     try {
-      return \Civix::upgrader(static::getExtPath());
+      return \Civix::generator(static::getExtPath());
     }
     finally {
       \Civix::ioStack()->pop();

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -197,7 +197,7 @@ trait CivixProjectTestTrait {
    *
    * @return \CRM\CivixBundle\Generator
    */
-  public function civixUpgradeHelper(): Generator {
+  public function civixGeneratorHelper(): Generator {
     $input = new ArrayInput([]);
     $output = new StreamOutput(fopen('php://memory', 'w', FALSE));
     \Civix::ioStack()->push($input, $output);

--- a/upgrades/16.10.0.up.php
+++ b/upgrades/16.10.0.up.php
@@ -5,7 +5,7 @@
  *
  * At some point in the future, this step could be removed if we configure `info.xml`'s `<upgrader>` option.
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   $io = \Civix::io();
 
   if (!empty($upgrader->infoXml->get()->upgrader)) {

--- a/upgrades/16.10.0.up.php
+++ b/upgrades/16.10.0.up.php
@@ -5,18 +5,18 @@
  *
  * At some point in the future, this step could be removed if we configure `info.xml`'s `<upgrader>` option.
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   $io = \Civix::io();
 
-  if (!empty($upgrader->infoXml->get()->upgrader)) {
+  if (!empty($gen->infoXml->get()->upgrader)) {
     $io->note("Found <upgrader> tag. Skip hook_postInstall.");
     return;
   }
 
   // Give a notice if the new `CRM/*/Upgrader/Base` has a substantive change.
   // Note: The change is actually done in the generic regen. This is just a notice.
-  $phpBaseClass = \CRM\CivixBundle\Utils\Naming::createClassName($upgrader->infoXml->getNamespace(), 'Upgrader', 'Base');
-  $phpBaseFile = \CRM\CivixBundle\Utils\Naming::createClassFile($upgrader->infoXml->getNamespace(), 'Upgrader', 'Base');
+  $phpBaseClass = \CRM\CivixBundle\Utils\Naming::createClassName($gen->infoXml->getNamespace(), 'Upgrader', 'Base');
+  $phpBaseFile = \CRM\CivixBundle\Utils\Naming::createClassFile($gen->infoXml->getNamespace(), 'Upgrader', 'Base');
   if (file_exists($phpBaseFile)) {
     $content = file_get_contents($phpBaseFile);
     if (preg_match('|CRM_Core_BAO_Setting::setItem\(.revision, *.Extension.|', $content)) {
@@ -31,11 +31,11 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
       }
     }
 
-    $upgrader->addHookDelegation('civicrm_postInstall', '',
+    $gen->addHookDelegation('civicrm_postInstall', '',
       "This hook is important for supporting the new version of $phpBaseClass.");
   }
   else {
-    $upgrader->addHookDelegation('civicrm_postInstall', '',
+    $gen->addHookDelegation('civicrm_postInstall', '',
       'If you use civix to facilitate database upgrades ("civix generate:upgrader"), then you should enable this stub. Otherwise, it is not needed.');
   }
 

--- a/upgrades/19.06.2.up.php
+++ b/upgrades/19.06.2.up.php
@@ -16,15 +16,15 @@
  * To be consistent and forward-compatible, you should consider updating your
  * existing unit-tests to use the name base-classes.
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 
-  $testFiles = \CRM\CivixBundle\Utils\Files::findFiles($upgrader->baseDir->string('tests'), '*.php');
-  $upgrader->updateTextFiles($testFiles, function(string $file, string $content) use ($io, $upgrader) {
+  $testFiles = \CRM\CivixBundle\Utils\Files::findFiles($gen->baseDir->string('tests'), '*.php');
+  $gen->updateTextFiles($testFiles, function(string $file, string $content) use ($io, $gen) {
     $old = 'PHPUnit_Framework_TestCase';
     $new = 'PHPUnit\Framework\TestCase';
-    $relFile = \CRM\CivixBundle\Utils\Files::relativize($file, $upgrader->baseDir->string() . '/');
+    $relFile = \CRM\CivixBundle\Utils\Files::relativize($file, $gen->baseDir->string() . '/');
 
     if (strpos($content, $old) === FALSE) {
       return $content;

--- a/upgrades/19.06.2.up.php
+++ b/upgrades/19.06.2.up.php
@@ -16,7 +16,7 @@
  * To be consistent and forward-compatible, you should consider updating your
  * existing unit-tests to use the name base-classes.
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 

--- a/upgrades/20.06.0.up.php
+++ b/upgrades/20.06.0.up.php
@@ -4,7 +4,7 @@
  * If you have a generated `phpunit.xml` or `phpunit.xml.dist` file, it may include the old option `syntaxCheck="false"`.
  * You can remove this.  The option has been inert and will raise errors in newer versions of PHPUnit.
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 

--- a/upgrades/20.06.0.up.php
+++ b/upgrades/20.06.0.up.php
@@ -4,16 +4,16 @@
  * If you have a generated `phpunit.xml` or `phpunit.xml.dist` file, it may include the old option `syntaxCheck="false"`.
  * You can remove this.  The option has been inert and will raise errors in newer versions of PHPUnit.
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 
   $files = array_filter([
-    $upgrader->baseDir->string('phpunit.xml'),
-    $upgrader->baseDir->string('phpunit.xml.dist'),
+    $gen->baseDir->string('phpunit.xml'),
+    $gen->baseDir->string('phpunit.xml.dist'),
   ], 'file_exists');
-  $upgrader->updateTextFiles($files, function(string $file, string $oldContent) use ($io, $upgrader) {
-    $relFile = \CRM\CivixBundle\Utils\Files::relativize($file, $upgrader->baseDir->string() . '/');
+  $gen->updateTextFiles($files, function(string $file, string $oldContent) use ($io, $gen) {
+    $relFile = \CRM\CivixBundle\Utils\Files::relativize($file, $gen->baseDir->string() . '/');
 
     $content = $oldContent;
     $content = preg_replace(';(\s+)syntaxCheck="[^\"]+">;', '>', $content);

--- a/upgrades/22.05.0.up.php
+++ b/upgrades/22.05.0.up.php
@@ -1,9 +1,9 @@
 <?php
 
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
-  $prefix = $upgrader->infoXml->getFile();
+  $prefix = $gen->infoXml->getFile();
 
   $io->note([
     "Civix v22.05 converts several functions to mixins. This reduces code-duplication and will enable easier updates in the future.",
@@ -32,8 +32,8 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
     'glob:*.theme.php' => 'theme-php@1.0.0',
   ];
   $mixins = array_filter($filePatterns,
-    function (string $mixin, string $pattern) use ($upgrader, $io) {
-      $flagFiles = $upgrader->baseDir->search($pattern);
+    function (string $mixin, string $pattern) use ($gen, $io) {
+      $flagFiles = $gen->baseDir->search($pattern);
       $io->note($flagFiles
         ? "Enable \"$mixin\". There are files matching pattern \"$pattern\"."
         : "Skip \"$mixin\". There are no files matching pattern \"$pattern\"."
@@ -42,9 +42,9 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
     },
     ARRAY_FILTER_USE_BOTH
   );
-  $upgrader->addMixins($mixins);
+  $gen->addMixins($mixins);
 
-  $upgrader->removeHookDelegation([
+  $gen->removeHookDelegation([
     "_{$prefix}_civix_civicrm_angularModules",
     "_{$prefix}_civix_civicrm_managed",
     "_{$prefix}_civix_civicrm_alterSettingsFolders",

--- a/upgrades/22.05.0.up.php
+++ b/upgrades/22.05.0.up.php
@@ -1,6 +1,6 @@
 <?php
 
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
   $prefix = $upgrader->infoXml->getFile();

--- a/upgrades/22.05.2.up.php
+++ b/upgrades/22.05.2.up.php
@@ -3,7 +3,7 @@
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Utils\EvilEx;
 
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   $mixins = new Mixins($upgrader->infoXml, $upgrader->baseDir->string('mixin'));
   $declared = $mixins->getDeclaredMixinConstraints();
   $hasSettingMixin = (bool) preg_grep('/^setting-php@/', $declared);

--- a/upgrades/22.05.2.up.php
+++ b/upgrades/22.05.2.up.php
@@ -3,14 +3,14 @@
 use CRM\CivixBundle\Builder\Mixins;
 use CRM\CivixBundle\Utils\EvilEx;
 
-return function (\CRM\CivixBundle\Generator $upgrader) {
-  $mixins = new Mixins($upgrader->infoXml, $upgrader->baseDir->string('mixin'));
+return function (\CRM\CivixBundle\Generator $gen) {
+  $mixins = new Mixins($gen->infoXml, $gen->baseDir->string('mixin'));
   $declared = $mixins->getDeclaredMixinConstraints();
   $hasSettingMixin = (bool) preg_grep('/^setting-php@/', $declared);
   $action = NULL;
 
-  $upgrader->updateModulePhp(function (\CRM\CivixBundle\Builder\Info $info, string $content) use ($upgrader, $hasSettingMixin, &$action) {
-    $prefix = $upgrader->infoXml->getFile();
+  $gen->updateModulePhp(function (\CRM\CivixBundle\Builder\Info $info, string $content) use ($gen, $hasSettingMixin, &$action) {
+    $prefix = $gen->infoXml->getFile();
     $hookFunc = "{$prefix}_civicrm_alterSettingsFolders";
     $hookBody = [
       'static $configured = FALSE;',
@@ -23,7 +23,7 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
       '}',
     ];
 
-    $newContent = EvilEx::rewriteMultilineChunk($content, $hookBody, function(array $matchLines) use ($hookFunc, $content, $upgrader, $hasSettingMixin, &$action) {
+    $newContent = EvilEx::rewriteMultilineChunk($content, $hookBody, function(array $matchLines) use ($hookFunc, $content, $gen, $hasSettingMixin, &$action) {
       /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
       $io = \Civix::io();
       $matchLineKeys = array_keys($matchLines);
@@ -32,7 +32,7 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
       $focusEnd = max($matchLineKeys);
 
       $io->note("The following chunk resembles an older template for \"{$hookFunc}()\".");
-      $upgrader->showCode($allLines, $focusStart - 4, $focusEnd + 4, $focusStart, $focusEnd);
+      $gen->showCode($allLines, $focusStart - 4, $focusEnd + 4, $focusStart, $focusEnd);
 
       if ($hasSettingMixin) {
         $io->note([
@@ -55,12 +55,12 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
     });
 
     if ($action === 'm' && !$hasSettingMixin) {
-      $upgrader->updateMixins(function (Mixins $mixins) {
+      $gen->updateMixins(function (Mixins $mixins) {
         $mixins->addMixin('setting-php@1.0.0');
       });
     }
     elseif ($action === 'b' && $hasSettingMixin) {
-      $upgrader->updateMixins(function (Mixins $mixins) {
+      $gen->updateMixins(function (Mixins $mixins) {
         $mixins->removeMixin('setting-php');
       });
     }

--- a/upgrades/22.10.0.up.php
+++ b/upgrades/22.10.0.up.php
@@ -7,15 +7,15 @@
  *
  * Just add the '<psr0>` bit to everything.
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
 
-  $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
+  $gen->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($gen) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
     $io = \Civix::io();
 
     $loaders = $info->getClassloaders();
     $prefixes = array_column($loaders, 'prefix');
-    if (file_exists($upgrader->baseDir->string('CRM')) && !in_array('CRM_', $prefixes)) {
+    if (file_exists($gen->baseDir->string('CRM')) && !in_array('CRM_', $prefixes)) {
       $io->section('"CRM" Class-loader');
       $io->note([
         'Older templates enabled class-loading via "hook_config" and "include_path".',

--- a/upgrades/22.10.0.up.php
+++ b/upgrades/22.10.0.up.php
@@ -7,7 +7,7 @@
  *
  * Just add the '<psr0>` bit to everything.
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
 
   $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */

--- a/upgrades/22.12.1.up.php
+++ b/upgrades/22.12.1.up.php
@@ -11,7 +11,7 @@ use CRM\CivixBundle\Utils\Naming;
  * - Use core's base class
  * - Remove old base class
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   $io = \Civix::io();
   $io->section('Lifecycle Hooks: Install, Upgrade, etc');
 

--- a/upgrades/22.12.1.up.php
+++ b/upgrades/22.12.1.up.php
@@ -11,15 +11,15 @@ use CRM\CivixBundle\Utils\Naming;
  * - Use core's base class
  * - Remove old base class
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   $io = \Civix::io();
   $io->section('Lifecycle Hooks: Install, Upgrade, etc');
 
-  $info = $upgrader->infoXml;
+  $info = $gen->infoXml;
   $MIN_COMPAT = '5.38';
   $oldCompat = $info->getCompatibilityVer();
   $nameSpace = $info->getNamespace();
-  $mainFile = $upgrader->baseDir->string($info->getFile() . '.php');
+  $mainFile = $gen->baseDir->string($info->getFile() . '.php');
   $upgraderClass = Naming::createClassName($nameSpace, 'Upgrader');
   $upgraderFile = Naming::createClassFile($nameSpace, 'Upgrader');
   $upgraderBaseClass = Naming::createClassName($nameSpace, 'Upgrader', 'Base');
@@ -70,7 +70,7 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
   }
 
   $prefix = $info->getFile();
-  $upgrader->removeHookDelegation([
+  $gen->removeHookDelegation([
     "_{$prefix}_civix_civicrm_postInstall",
     "_{$prefix}_civix_civicrm_uninstall",
     "_{$prefix}_civix_civicrm_disable",
@@ -78,7 +78,7 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
   ]);
 
   if ($hasUpgrader) {
-    $upgrader->updateInfo(function(\CRM\CivixBundle\Builder\Info $info) use ($MIN_COMPAT, $upgraderClass) {
+    $gen->updateInfo(function(\CRM\CivixBundle\Builder\Info $info) use ($MIN_COMPAT, $upgraderClass) {
       $info->raiseCompatibilityMinimum($MIN_COMPAT);
       // Add <upgrader> tag
       if (!$info->get()->xpath('upgrader')) {
@@ -86,7 +86,7 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
       }
     });
     // Switch base class
-    $upgrader->updateTextFiles([$upgraderFile], function(string $file, string $content) use ($upgraderBaseClass) {
+    $gen->updateTextFiles([$upgraderFile], function(string $file, string $content) use ($upgraderBaseClass) {
       return str_replace($upgraderBaseClass, 'CRM_Extension_Upgrader_Base', $content);
     });
   }

--- a/upgrades/23.01.0.up.php
+++ b/upgrades/23.01.0.up.php
@@ -1,7 +1,7 @@
 <?php
 use CRM\CivixBundle\Utils\Formatting;
 
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 
@@ -13,8 +13,8 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
     'find:*.tpl' => 'smarty-v2@1.0.0',
   ];
   $mixins = array_filter($filePatterns,
-    function (string $mixin, string $pattern) use ($upgrader, $io, &$previewChanges) {
-      $flagFiles = $upgrader->baseDir->search($pattern);
+    function (string $mixin, string $pattern) use ($gen, $io, &$previewChanges) {
+      $flagFiles = $gen->baseDir->search($pattern);
       $previewChanges[] = [
         'info.xml',
         $flagFiles ? "Enable $mixin" : "Skip $mixin. (No files match \"$pattern\")",
@@ -40,6 +40,6 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
     throw new \RuntimeException('User stopped upgrade');
   }
 
-  $upgrader->addMixins($mixins);
+  $gen->addMixins($mixins);
 
 };

--- a/upgrades/23.01.0.up.php
+++ b/upgrades/23.01.0.up.php
@@ -1,7 +1,7 @@
 <?php
 use CRM\CivixBundle\Utils\Formatting;
 
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
   /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
   $io = \Civix::io();
 

--- a/upgrades/23.02.0.up.php
+++ b/upgrades/23.02.0.up.php
@@ -3,11 +3,11 @@
 /**
  * Upgrade hook_civicrm_entityTypes to use mixin
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
 
-  $prefix = $upgrader->infoXml->getFile();
+  $prefix = $gen->infoXml->getFile();
 
-  if (is_dir($upgrader->baseDir->string('xml/schema/CRM'))) {
+  if (is_dir($gen->baseDir->string('xml/schema/CRM'))) {
     \Civix::io()->note([
       'Civix 23.02 removes `*_civix_civicrm_entityTypes` in favor of a mixin `entity-types-php@1.0`.',
       'This reduces code-duplication and will enable easier updates in the future.',
@@ -17,10 +17,10 @@ return function (\CRM\CivixBundle\Generator $upgrader) {
       throw new \RuntimeException('User stopped upgrade');
     }
 
-    $upgrader->addMixins(['entity-types-php@1.0']);
+    $gen->addMixins(['entity-types-php@1.0']);
   }
 
-  $upgrader->removeHookDelegation([
+  $gen->removeHookDelegation([
     "_{$prefix}_civix_civicrm_entityTypes",
   ]);
 

--- a/upgrades/23.02.0.up.php
+++ b/upgrades/23.02.0.up.php
@@ -3,7 +3,7 @@
 /**
  * Upgrade hook_civicrm_entityTypes to use mixin
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
 
   $prefix = $upgrader->infoXml->getFile();
 

--- a/upgrades/23.02.1.up.php
+++ b/upgrades/23.02.1.up.php
@@ -5,7 +5,7 @@
  * However, as older extensions adopt newer technologies (like `Civi\Api4`), it helps
  * to add a similar to them.
  */
-return function (\CRM\CivixBundle\Upgrader $upgrader) {
+return function (\CRM\CivixBundle\Generator $upgrader) {
 
   $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */

--- a/upgrades/23.02.1.up.php
+++ b/upgrades/23.02.1.up.php
@@ -5,9 +5,9 @@
  * However, as older extensions adopt newer technologies (like `Civi\Api4`), it helps
  * to add a similar to them.
  */
-return function (\CRM\CivixBundle\Generator $upgrader) {
+return function (\CRM\CivixBundle\Generator $gen) {
 
-  $upgrader->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($upgrader) {
+  $gen->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($gen) {
     /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
     $io = \Civix::io();
 


### PR DESCRIPTION
Overview
---------

Take the existing `Upgrader` concept and convert it to a more general `Generator` concept.

Motivation
-----------

1. It can be used for generating new code *or* generating upgraded code.

2. It's confusing to use the same word ("Upgrader") to describe both (a) the thing inside civix that manipulates ext-code and (b) the thing inside an ext that manipulates DB schema.

Change
-------

* __Before__: Various calls to `new Upgrader(...)` and/or `$this->getUpgrader()`
* __After__: Various calls to `Civix::generator()`