### PR TITLE
Smarty Substitution - Recommend 'smarty@1' or 'smarty-v2@1' depending on environment

### DIFF
--- a/mixin-backports.php
+++ b/mixin-backports.php
@@ -85,7 +85,17 @@ return [
     'provided-by' => '5.45.beta1',
     'minimum' => '5.27', /* Compat may go back further; haven't tested */
   ],
+  'smarty@1' => [
+    // Newer variant. Prettier name.
+    'version' => '1.0.0',
+    'sha256' => 'ec1df0d7eaaf448f04f98eed389eca7c9579908c1632de79b097574b1359e1e0',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/c0abd56792ad2b386a067eaa7d9a500ca9e8de97/mixin/smarty%401/mixin.php',
+    'local' => 'extern/mixin/smarty@1/mixin.php',
+    'provided-by' => '5.71',
+    'minimum' => '5.27', /* Compat may go back to 5.25; only really tested 5.33 */
+  ],
   'smarty-v2@1' => [
+    // Original variant. Name was more specific than we actually need.
     'version' => '1.0.1',
     'sha256' => '6b1e05facc17d414d8e99faf5bdd9fe694ff92cc3d7f9a05e2fe6fc63e3d1948',
     'remote' => 'https://github.com/civicrm/civicrm-core/raw/7168793c03ef57c06bbfe45f5ff873ebb3657806/mixin/smarty-v2%401/mixin.php',

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -76,6 +76,9 @@ class Mixins implements Builder {
   public function removeMixin(string $mixinNameOrConstraint) {
     [$mixinName] = explode('@', $mixinNameOrConstraint);
     $this->removals[] = $mixinName;
+
+    $regex = ';^' . preg_quote($mixinName, ';') . '@;';
+    $this->newConstraints = preg_grep($regex, $this->newConstraints, PREG_GREP_INVERT);
   }
 
   /**

--- a/src/CRM/CivixBundle/Builder/Mixins.php
+++ b/src/CRM/CivixBundle/Builder/Mixins.php
@@ -28,11 +28,13 @@ class Mixins implements Builder {
 
   /**
    * @var string[]
+   *   Ex: ['smarty@1.0']
    */
   protected $newConstraints;
 
   /**
    * @var string[]
+   *   Ex: ['smarty-v2']
    */
   protected $removals;
 
@@ -74,6 +76,36 @@ class Mixins implements Builder {
   public function removeMixin(string $mixinNameOrConstraint) {
     [$mixinName] = explode('@', $mixinNameOrConstraint);
     $this->removals[] = $mixinName;
+  }
+
+  /**
+   * Lookup the existing constraint
+   * @param string $mixin
+   *   Ex: 'smarty-v2'
+   * @param bool $checkPending
+   *   TRUE if you want to check the *effective* value, with any pending updates.
+   *   FALSE if you want to check the *pre-existing* value, before pending updates.
+   * @return string|null
+   *   Ex: '1.0.0'
+   */
+  public function findMixinConstraint(string $mixin, bool $checkPending = TRUE) {
+    if ($checkPending) {
+      if (in_array($mixin, $this->removals)) {
+        return NULL;
+      }
+      foreach ($this->newConstraints as $newConstraint) {
+        if (strpos($newConstraint, "$mixin@") === 0) {
+          return explode('@', $newConstraint)[1];
+        }
+      }
+    }
+
+    $nodes = $this->info->get()->xpath('mixins/mixin[starts-with(text(), "' . $mixin . '@")]');
+    foreach ($nodes as $existingMixinXml) {
+      return explode('@', (string) $existingMixinXml)[1];
+    }
+
+    return NULL;
   }
 
   public function removeAllMixins() {


### PR DESCRIPTION
Overview
------------

As of Civi 5.71 (https://github.com/civicrm/civicrm-core/pull/29187), the `smarty-v2` mixin has a new name: `smarty`. Because... it's not necessarily Smarty v2. Both names will continue to work in the same way. However, we should start encouraging the new name.

Before
--------

Whenever `civix` activates Smarty support, it uses `smarty-v2@1.x.x`.

After
------

Whenever `civix` activates Smarty support, it checks the compatibility (eg `<ver>5.50</ver>` or `<ver>5.75</ver>`). If the target is 5.71+, then it will prefer the new name.

Comments
--------------

There's a trade-off in how one does this:

* We could do a straight rule to switch all ext's to `smarty@`. This will push the newer name sooner... but you're more likely to get backport files (`mixin/smarty@1.0.0.mixin.php`)
* We could do a conditional rule (`smarty2@` if less than `<ver>5.71</ver>`; and` smarty@` for newer). Then it'll take a bit longer to push folks to the new name `smarty@`... but you don't get as many files.

TBH, I think both problems are superficial, and I don't think it really matters. My guess is that we'd get more pushback about extra-files than about the old-name, so that's what this PR does.