### PR TITLE
Generate civix.phar on box 4.6.1

### DIFF
--- a/nix/buildkit.nix
+++ b/nix/buildkit.nix
@@ -1,10 +1,10 @@
 { pkgs ? import <nixpkgs> {} }:
 
 ## Get civicrm-buildkit from github.
-## Based on "master" branch circa 2023-08-22 10:32 UTC
+## Based on "master" branch circa 2024-02-26 04:31 UTC
 import (pkgs.fetchzip {
-  url = "https://github.com/civicrm/civicrm-buildkit/archive/04b338a52bbf0bdc21edafe564b875138c1db12c.tar.gz";
-  sha256 = "1r6m830lyv6xf0yxz392izhwlnbahhc7s4r71riyqryzkr6psfyd";
+  url = "https://github.com/civicrm/civicrm-buildkit/archive/d6f6b8dd2d5944c35cd78cb319fef21673214b35.tar.gz";
+  sha256 = "02p2yzdfgv66a2zf8i36h6pjfi78wnp92m3klij7fqbfd9mpvi5a";
 })
 
 ## Get a local copy of civicrm-buildkit. (Useful for developing patches.)

--- a/shell.nix
+++ b/shell.nix
@@ -15,7 +15,7 @@ in
   pkgs.mkShell {
     nativeBuildInputs = buildkit.profiles.base ++ [
 
-      (buildkit.pins.v2305.php81.buildEnv {
+      (buildkit.pins.v2305.php82.buildEnv {
         extraConfig = ''
           memory_limit=-1
         '';


### PR DESCRIPTION
This should address a compatibility issue on Windows/PHP 8.3