### PR TITLE
Deprecate api command

### DIFF
--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -12,6 +12,9 @@ use CRM\CivixBundle\Builder\Info;
 use CRM\CivixBundle\Builder\Template;
 use CRM\CivixBundle\Utils\Path;
 
+/**
+ * @deprecated
+ */
 class AddAngularPageCommand extends AbstractCommand {
 
   protected function configure() {

--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -15,6 +15,9 @@ use CRM\CivixBundle\Utils\Path;
 use Exception;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
+/**
+ * @deprecated
+ */
 class AddApiCommand extends AbstractCommand {
   const API_VERSION = 3;
 
@@ -25,7 +28,7 @@ class AddApiCommand extends AbstractCommand {
   protected function configure() {
     $this
       ->setName('generate:api')
-      ->setDescription('Add a new API function to a CiviCRM Module-Extension')
+      ->setDescription('Add APIv3 function (DEPRECATED)')
       ->addArgument('<EntityName>', InputArgument::REQUIRED, 'The entity against which the action runs (eg "Contact", "MyEntity")')
       ->addArgument('<actionname>', InputArgument::REQUIRED, 'The action which will be created (eg "create", "myaction")')
       ->addOption('schedule', NULL, InputOption::VALUE_OPTIONAL, 'Schedule this action as a recurring cron job (' . implode(', ', self::getSchedules()) . ') [For CiviCRM 4.3+]')


### PR DESCRIPTION
APIv3 is officially deprecated so civix should reflect that.

Also adds `@deprecated` annotation to all deprecated commands.