### PR TITLE
mixin-backports - Update smarty adapters to v1.0.2

### DIFF
--- a/mixin-backports.php
+++ b/mixin-backports.php
@@ -95,20 +95,20 @@ return [
   ],
   'smarty@1' => [
     // Newer variant. Prettier name.
-    'version' => '1.0.0',
-    'sha256' => 'ec1df0d7eaaf448f04f98eed389eca7c9579908c1632de79b097574b1359e1e0',
-    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/c0abd56792ad2b386a067eaa7d9a500ca9e8de97/mixin/smarty%401/mixin.php',
+    'version' => '1.0.2',
+    'sha256' => '71915fc6c8a826611495f07d9f350e23630c0a90d47cfebe61eca291fe6e7451',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/2b2dfaceabf56966da8be1c605e6cd4131ff8d4f/mixin/smarty%401/mixin.php',
     'local' => 'extern/mixin/smarty@1/mixin.php',
-    'provided-by' => '5.71',
+    'provided-by' => '5.74',
     'minimum' => '5.27', /* Compat may go back to 5.25; only really tested 5.33 */
   ],
   'smarty-v2@1' => [
     // Original variant. Name was more specific than we actually need.
-    'version' => '1.0.1',
-    'sha256' => '6b1e05facc17d414d8e99faf5bdd9fe694ff92cc3d7f9a05e2fe6fc63e3d1948',
-    'remote' => 'https://github.com/civicrm/civicrm-core/raw/7168793c03ef57c06bbfe45f5ff873ebb3657806/mixin/smarty-v2%401/mixin.php',
+    'version' => '1.0.2',
+    'sha256' => '22da33821d990b2a625f353b0c4f11a626eee28708b32c0e77cf62e5d038a49b',
+    'remote' => 'https://raw.githubusercontent.com/civicrm/civicrm-core/2b2dfaceabf56966da8be1c605e6cd4131ff8d4f/mixin/smarty-v2%401/mixin.php',
     'local' => 'extern/mixin/smarty-v2@1/mixin.php',
-    'provided-by' => '5.59',
+    'provided-by' => '5.74',
     'minimum' => '5.27', /* Compat may go back to 5.25; only really tested 5.33 */
   ],
   'theme-php@1' => [


### PR DESCRIPTION
Update to reflect the pending update in https://github.com/civicrm/civicrm-core/pull/30148

Note: The existing 'minimum' was '5.27'. I re-tested that version locally, and Smarty still worked fine.

cc @colemanw 