### PR TITLE
ConvertEntity - Don't write maxlength, it's redundant

### DIFF
--- a/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
@@ -277,9 +277,6 @@ class ConvertEntityCommand extends AbstractCommand {
       }
       $attributes = isset($fieldXml->html) ? self::snakeCaseKeys((array) $fieldXml->html) : [];
       unset($attributes['type']);
-      if (!empty($typeAttributes['length'])) {
-        $attributes['maxlength'] = (int) $typeAttributes['length'];
-      }
       // Fix if xml erroneously includes multiple labels
       if (!empty($attributes['label']) && !is_string($attributes['label'])) {
         $attributes['label'] = ((array) $attributes['label'])[0];


### PR DESCRIPTION
The companion to https://github.com/civicrm/civicrm-core/pull/30476