### PR TITLE
PhpData - Use structured document instead of regex

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,7 @@
         "civicrm/cv-lib": "~0.3.51",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
+        "civicrm/php-array-doc": "~0.1.4",
         "symfony/console": "^4|^5",
         "symfony/filesystem": "^4|^5",
         "symfony/process": "^4|^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9d1ee5420fb1539794be981453b4b749",
+    "content-hash": "82c149e1cd619c69283bfec3563c9c78",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -150,6 +150,45 @@
                 "source": "https://github.com/civicrm/cv-lib/tree/v0.3.51"
             },
             "time": "2024-06-25T21:02:58+00:00"
+        },
+        {
+            "name": "civicrm/php-array-doc",
+            "version": "v0.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/totten/php-array-doc.git",
+                "reference": "c462840f178d3ccce652baa7e01b8d4bf1e92750"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/totten/php-array-doc/zipball/c462840f178d3ccce652baa7e01b8d4bf1e92750",
+                "reference": "c462840f178d3ccce652baa7e01b8d4bf1e92750",
+                "shasum": ""
+            },
+            "require": {
+                "php": "~7.3|~8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PhpArrayDocument\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Tim Otten",
+                    "email": "totten@civicrm.org"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/totten/php-array-doc/issues",
+                "source": "https://github.com/totten/php-array-doc/tree/v0.1.4"
+            },
+            "time": "2024-06-26T21:38:17+00:00"
         },
         {
             "name": "psr/container",


### PR DESCRIPTION
* Use structured mechanisms to target/format elements in the data tree
* Closes the loopholes that arise from regex
* Supports either `fn() => ...` (php>=7.4) or `function(){ ... }` (php<7.4)