### PR TITLE
Drop redundant assertions

### DIFF
--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -51,6 +51,7 @@ abstract class AbstractCommand extends Command {
   }
 
   protected function assertCurrentFormat() {
+    // Note: getModuleInfo() asserts that type is 'module'
     $info = $this->getModuleInfo($ctx);
     $actualVersion = $info->detectFormat();
     $expectedVersion = Civix::upgradeList()->getHeadVersion();

--- a/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularDirectiveCommand.php
@@ -44,10 +44,6 @@ For more, see https://docs.angularjs.org/guide/directive');
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
     $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return 1;
-    }
 
     $ctx['tsDomain'] = (string) $attrs['key'];
     $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['angularModuleName'];

--- a/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
+++ b/src/CRM/CivixBundle/Command/AddAngularPageCommand.php
@@ -49,10 +49,6 @@ For more, see https://docs.angularjs.org/guide');
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
     $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return 1;
-    }
 
     $ctx['tsDomain'] = (string) $attrs['key'];
     $ctx['angularModuleName'] = $input->getOption('am') ? $input->getOption('am') : $ctx['angularModuleName'];

--- a/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
+++ b/src/CRM/CivixBundle/Command/AddCustomDataCommand.php
@@ -42,11 +42,6 @@ class AddCustomDataCommand extends AbstractCommand {
 
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return 1;
-    }
 
     $dirs = new Dirs([
       $basedir->string('xml'),

--- a/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityBoilerplateCommand.php
@@ -53,12 +53,6 @@ class AddEntityBoilerplateCommand extends AbstractCommand {
     $basedir = new Path($ctx['basedir']);
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    $attrs = $info->get()->attributes();
-
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
-    }
 
     $xmlSchemaGlob = "xml/schema/{$ctx['namespace']}/*.xml";
     $absXmlSchemaGlob = $basedir->string($xmlSchemaGlob);

--- a/src/CRM/CivixBundle/Command/AddEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/AddEntityCommand.php
@@ -63,11 +63,6 @@ explicity.');
 
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return;
-    }
 
     if (!preg_match('/^[A-Za-z0-9]+$/', $input->getArgument('<EntityName>'))) {
       throw new Exception("Entity name must be alphanumeric camel-case");

--- a/src/CRM/CivixBundle/Command/AddTestCommand.php
+++ b/src/CRM/CivixBundle/Command/AddTestCommand.php
@@ -64,10 +64,6 @@ as separate groups:
 
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    if ($info->getType() != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $info->getType() . '</error>');
-      return;
-    }
 
     $phpUnitInitFiles = new PHPUnitGenerateInitFiles();
     $phpUnitInitFiles->initPhpunitXml($basedir->string('phpunit.xml.dist'), $ctx, $output);

--- a/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
+++ b/src/CRM/CivixBundle/Command/AddUpgraderCommand.php
@@ -30,11 +30,6 @@ class AddUpgraderCommand extends AbstractCommand {
 
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return 1;
-    }
 
     $dirs = [
       $basedir->string('sql'),

--- a/src/CRM/CivixBundle/Command/BuildCommand.php
+++ b/src/CRM/CivixBundle/Command/BuildCommand.php
@@ -26,11 +26,6 @@ class BuildCommand extends AbstractCommand {
 
     $info = new Info($basedir->string('info.xml'));
     $info->load($ctx);
-    $attrs = $info->get()->attributes();
-    if ($attrs['type'] != 'module') {
-      $output->writeln('<error>Wrong extension type: ' . $attrs['type'] . '</error>');
-      return 1;
-    }
 
     $ctx['zipFile'] = $basedir->string('build', $ctx['fullName'] . '.zip');
     $cmdArgs = [


### PR DESCRIPTION
All of these commands use the helper `assertCurrentFormat()`. Among other things, that helper asserts that the extension-type is 'module'.

So these checks are redundant.