### PR TITLE
Default to version 1.0.0 instead of 1.0

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -53,7 +53,7 @@ class Info extends XML {
     }
 
     $xml->addChild('releaseDate', date('Y-m-d'));
-    $xml->addChild('version', '1.0');
+    $xml->addChild('version', '1.0.0');
     $xml->addChild('develStage', 'alpha');
     $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin']);
     $xml->addChild('comments', 'This is a new, undeveloped module');


### PR DESCRIPTION
I would like to recommend that people use `x.y.z` as versions numbers, instead of `x.y`. For now, it's just a recommendation. It makes it easier use composer (which requires semantic versioning).

Related discussion:

- https://lab.civicrm.org/documentation/docs/dev/-/merge_requests/1197#note_170192
- https://lab.civicrm.org/infra/extdir/-/issues/7