### PR TITLE
Update references from extension aliases to the CRM_Core_Extension

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/api.php.php
@@ -26,7 +26,7 @@ function _<?php echo $apiFunction ?>_spec(&$spec) {
  *
  * @see civicrm_api3_create_success
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function <?php echo $apiFunction ?>($params) {
   if (array_key_exists('magicword', $params) && $params['magicword'] == 'sesame') {
@@ -43,6 +43,6 @@ function <?php echo $apiFunction ?>($params) {
     return civicrm_api3_create_success($returnValues, $params, '<?php echo $entityNameCamel; ?>', '<?php echo $actionNameCamel; ?>');
   }
   else {
-    throw new API_Exception(/*error_message*/ 'Everyone knows that the magicword is "sesame"', /*error_code*/ 'magicword_incorrect');
+    throw new CRM_Core_Exception(/*error_message*/ 'Everyone knows that the magicword is "sesame"', /*error_code*/ 'magicword_incorrect');
   }
 }

--- a/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-api.php.php
@@ -24,7 +24,7 @@ function _<?php echo $apiFunctionPrefix ?>create_spec(&$spec) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function <?php echo $apiFunctionPrefix ?>create($params) {
   return _civicrm_api3_basic_create(_civicrm_api3_get_BAO(__FUNCTION__), $params, <?php var_export($entityNameCamel); ?>);
@@ -38,7 +38,7 @@ function <?php echo $apiFunctionPrefix ?>create($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function <?php echo $apiFunctionPrefix ?>delete($params) {
   return _civicrm_api3_basic_delete(_civicrm_api3_get_BAO(__FUNCTION__), $params);
@@ -52,7 +52,7 @@ function <?php echo $apiFunctionPrefix ?>delete($params) {
  * @return array
  *   API result descriptor
  *
- * @throws API_Exception
+ * @throws CRM_Core_Exception
  */
 function <?php echo $apiFunctionPrefix ?>get($params) {
   return _civicrm_api3_basic_get(_civicrm_api3_get_BAO(__FUNCTION__), $params, TRUE, <?php var_export($entityNameCamel); ?>);


### PR DESCRIPTION
Prior to CiviCRM 5.52 we threw a mismash of these extensions. They all had to work everywhere because it was unpredictable. In 5.52 we made the API_Exception and CiviCRM_Api3_Exception aliases of CRM_Core_Exception. However, on the off chance people are creating extensions for really old civi versions with the latest civix it would still be handled on those older versions (we were always throwing CRM_Core_Exception all over the show)