### PR TITLE
Paths - On Windows, normalize to forward-slash

### DIFF
--- a/src/CRM/CivixBundle/Utils/NamingTest.php
+++ b/src/CRM/CivixBundle/Utils/NamingTest.php
@@ -2,6 +2,9 @@
 
 namespace CRM\CivixBundle\Utils;
 
+/**
+ * @group unit
+ */
 class NamingTest extends \PHPUnit\Framework\TestCase {
 
   public function getFullNameExamples() {

--- a/src/CRM/CivixBundle/Utils/Path.php
+++ b/src/CRM/CivixBundle/Utils/Path.php
@@ -33,7 +33,7 @@ class Path {
       $this->basedir = $basedir->basedir;
     }
     else {
-      $this->basedir = $basedir;
+      $this->basedir = static::normalize($basedir);
     }
   }
 
@@ -52,7 +52,7 @@ class Path {
   public function string() {
     $args = func_get_args();
     array_unshift($args, $this->basedir);
-    return implode(DIRECTORY_SEPARATOR, $args);
+    return static::normalize(implode('/', $args));
   }
 
   /**
@@ -65,7 +65,7 @@ class Path {
   public function path() {
     $args = func_get_args();
     array_unshift($args, $this->basedir);
-    return new Path(implode(DIRECTORY_SEPARATOR, $args));
+    return new Path(implode('/', $args));
   }
 
   /**
@@ -106,6 +106,10 @@ class Path {
       default:
         throw new \RuntimeException("Unrecognized file pattern: $pattern");
     }
+  }
+
+  protected static function normalize(string $path) {
+    return str_replace('\\', '/', $path);
   }
 
 }

--- a/src/CRM/CivixBundle/Utils/PathTest.php
+++ b/src/CRM/CivixBundle/Utils/PathTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+/**
+ * @group unit
+ */
+class PathTest extends \PHPUnit\Framework\TestCase {
+
+  public function testPathFor() {
+    $this->assertEquals('/var/www', Path::for('/var/www'));
+    $this->assertEquals('e:/project/web', Path::for('e:\\project\\web'));
+    $this->assertEquals('e:/project/web/ab/cd/ef', Path::for('e:\\project\\web', 'ab', 'cd\\ef'));
+    $this->assertEquals('/var/www/foo/bar', Path::for('/var/www', 'foo/bar'));
+    $this->assertEquals('/var/www/foo/bar', Path::for('/var/www', 'foo\bar'));
+    $this->assertEquals('/var/www/foobar/whizbang', Path::for('/var/www', 'foobar', 'whizbang'));
+  }
+
+  public function testPathString() {
+    $base = Path::for('/var/www');
+    $this->assertEquals('/var/www', $base->string());
+    $this->assertEquals('/var/www/foo', $base->string('foo'));
+    $this->assertEquals('/var/www/foo/bar', $base->string('foo', 'bar'));
+    $this->assertEquals('/var/www/foo/bar', $base->string('foo/bar'));
+    $this->assertEquals('/var/www/foo/bar', $base->string('foo\\bar'));
+  }
+
+  public function testPathChild() {
+    $this->assertEquals('/var/www/foo', (string) Path::for('/var')->path('www')->path('foo'));
+    $this->assertEquals('/var/www/foo/whiz/bang', (string) Path::for('/var')->path('www', 'foo')->path('whiz/bang'));
+    $this->assertEquals('e:/work/www/foo/whiz/bang', (string) Path::for('e:\\work')->path('www', 'foo')->path('whiz\\bang'));
+  }
+
+}


### PR DESCRIPTION
As reported by loren-bm on ([Mattermost](https://chat.civicrm.org/civicrm/pl/ruo9km1w4idz7mh34jczhpeirr)), there's a recent regression when running `civix upgrade` on Windows:

```
Executing upgrade script phar://E:/d10/vendor/civicrm/cli-tools/extern/civix.phar/upgrades\24.09.0.up.php

In Checker.php line 55:

  [RuntimeException]
  Unrecognized library: civimix-schema@5
```

The underlying problem involves the switch to `Webmozart\Glob` -- @demeritcowboy found that it expects to have paths normalized using `/`. This is not entirely unusual. Symfony Filesystem v5.4+ has a [similar normalization policy](https://github.com/symfony/filesystem/blob/7.0/Path.php#L114-L117).

This revision *should* fix the error. The approach is a little more aggressive, in that it flip-flips on the approach to normalizing paths:

* __Before__: `Path` helper tries to use native `DIRECTORY_SEPARATOR`. But it doesn't try very hard. So in practice, you probably a get a mix of delimiters.
* __After__: `Path` helper tries to consistently use `/` on both Windows and Unix. 

I've posted an example build of `civix.phar` at:

https://ephemera.civicrm.org/civix/civix.phar-2024-09-25-windows