### PR TITLE
generate:upgrader - New-style upgrader-class should always be installable, even if... (Option A)

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -103,7 +103,7 @@ use <?php echo $_namespace ?>_ExtensionUtil as E;
 <?php if (\Civix::checker()->hasMixinLibrary()) { ?>
 pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 <?php } ?>
-<?php if (\Civix::checker()->hasSchemaPhp() || \Civix::checker()->hasMixinLibrary('civimix-schema@5')) { ?>
+<?php if (\Civix::checker()->hasSchemaPhp() || \Civix::checker()->hasMixinLibrary('civimix-schema@5') || \Civix::checker()->hasUpgrader()) { ?>
 spl_autoload_register('_<?php echo $mainFile ?>_civix_class_loader', TRUE, TRUE);
 
 function _<?php echo $mainFile ?>_civix_class_loader($class) {


### PR DESCRIPTION
When using `generate:upgrader` for new-style upgrader-class, it should always be installable, even if... there are no EFv2 entities. 

Example use case (on 5.78+)

```bash
civibuild restore dmaster
civix generate:module testupgrader --enable=no --no-interaction
cd testupgrader
civix generate:upgrader ## NOTE: No new entities!
cv en testupgrader
```