### PR TITLE
generate:upgrader - New-style upgrader-class should always be installable, even if... (Option B)

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -103,12 +103,12 @@ use <?php echo $_namespace ?>_ExtensionUtil as E;
 <?php if (\Civix::checker()->hasMixinLibrary()) { ?>
 pathload()->addSearchDir(__DIR__ . '/mixin/lib');
 <?php } ?>
-<?php if (\Civix::checker()->hasSchemaPhp() || \Civix::checker()->hasMixinLibrary('civimix-schema@5')) { ?>
 spl_autoload_register('_<?php echo $mainFile ?>_civix_class_loader', TRUE, TRUE);
 
 function _<?php echo $mainFile ?>_civix_class_loader($class) {
 <?php $_clPrefix = 'CiviMix\\Schema\\' . \CRM\CivixBundle\Utils\Naming::createCamelName($mainFile) . '\\' ?>
 <?php $_localBase = $_namespace . '_DAO_Base'; ?>
+  <?php if (\Civix::checker()->hasSchemaPhp()) { ?>
   if ($class === <?php var_export($_localBase); ?>) {
     if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
       class_alias('CRM_Core_DAO_Base', <?php var_export($_localBase); ?>);
@@ -121,7 +121,9 @@ function _<?php echo $mainFile ?>_civix_class_loader($class) {
     }
     return;
   }
+  <?php } ?>
 
+  <?php if (\Civix::checker()->hasUpgrader()) { ?>
   // This allows us to tap-in to the installation process (without incurring real file-reads on typical requests).
   if (strpos($class, <?php var_export($_clPrefix) ?>) === 0) {
     // civimix-schema@5 is designed for backported use in download/activation workflows,
@@ -129,9 +131,9 @@ function _<?php echo $mainFile ?>_civix_class_loader($class) {
     pathload()->loadPackage('civimix-schema@5', TRUE);
     CiviMix\Schema\loadClass($class);
   }
+  <?php } ?>
 }
 
-<?php } ?>
 <?php if (version_compare($_compatibility, '5.45.beta1', '<')) { ?>
 function _<?php echo $mainFile ?>_civix_mixin_polyfill() {
   if (!class_exists('CRM_Extension_MixInfo')) {


### PR DESCRIPTION
When using `generate:upgrader` for new-style upgrader-class, it should always be installable, even if... there are no EFv2 entities. 

Example use case (on 5.78+)

```bash
civibuild restore dmaster
civix generate:module testupgrader --enable=no --no-interaction
cd testupgrader
civix generate:upgrader ## NOTE: No new entities!
cv en testupgrader
```