### PR TITLE
upgrades/24.09.01: only add step to update Upgrader if there is an Upgrader

### DIFF
--- a/upgrades/24.09.1.up.php
+++ b/upgrades/24.09.1.up.php
@@ -20,11 +20,8 @@ return function (\CRM\CivixBundle\Generator $gen) {
     $steps[] = "Update mixin entity-types-php@1 to entity-types-php@2";
   }
 
-  if ($oldClass && $oldClass !== $newClass) {
-    $steps[] = "Update info.xml to use $newClass (which delegates to $delegateClass)";
-  }
-  else {
-    $steps[] = "Update info.xml to use $newClass";
+  if (!empty($oldClass)) {
+    $steps[] = $oldClass !== $newClass ? "Update info.xml to use $newClass (which delegates to $delegateClass)" : "Update info.xml to use $newClass";
   }
   if (!empty($relSqlFiles)) {
     $steps[] = 'Delete ' . implode(' and ', $relSqlFiles);


### PR DESCRIPTION
If an extension has no Upgrader defined in `info.xml`, this upgrade step will tell that:
```
Update info.xml to use CiviMix\Schema\{MyExtension}\AutomaticUpgrader
```
but it won't do it.

It's just confusing for the user.
In this PR, the displayed planned actions are matched to the actual ones.