### PR TITLE
upgrade/24.09.1, convert-entity: adds entity-types-php@2 mixin even the extension doesn't define new entities

### DIFF
--- a/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
@@ -31,7 +31,7 @@ class ConvertEntityCommand extends AbstractCommand {
     Civix::boot(['output' => $output]);
     $this->assertCurrentFormat();
 
-    \Civix::io()->note("Finding entities");
+    \Civix::io()->note('Finding legacy xml entities');
 
     $isCore = $input->getOption('core-style');
 
@@ -46,7 +46,11 @@ class ConvertEntityCommand extends AbstractCommand {
       $xmlFiles = $input->getArgument('xmlFiles');
     }
 
-    static::convertEntities($xmlFiles, $isCore);
+    if (!empty($xmlFiles)) {
+      static::convertEntities($xmlFiles, $isCore);
+    } else {
+      \Civix::io()->note('No legacy xml entities found');
+    }
 
     return 0;
   }

--- a/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
+++ b/src/CRM/CivixBundle/Command/ConvertEntityCommand.php
@@ -61,6 +61,9 @@ class ConvertEntityCommand extends AbstractCommand {
    * @throws \Exception
    */
   public static function convertEntities(array $xmlFiles, bool $isCore): void {
+    if (empty($xmlFiles)) {
+      return;
+    }
     $xmlFiles = preg_grep('/files.xml$/', $xmlFiles, PREG_GREP_INVERT);
     $xmlFiles = preg_grep('/Schema.xml$/', $xmlFiles, PREG_GREP_INVERT);
 

--- a/upgrades/24.09.1.up.php
+++ b/upgrades/24.09.1.up.php
@@ -87,6 +87,7 @@ return function (\CRM\CivixBundle\Generator $gen) {
   }
 
   Civix::boot(['output' => Civix::output()]);
-  \CRM\CivixBundle\Command\ConvertEntityCommand::convertEntities($xmlSchemaFiles, FALSE);
-
+  if (!empty($xmlSchemaFiles)) {
+    \CRM\CivixBundle\Command\ConvertEntityCommand::convertEntities($xmlSchemaFiles, FALSE);
+  }
 };


### PR DESCRIPTION
`\CRM\CivixBundle\Command\ConvertEntityCommand::convertEntities()` is called regardless if there are actual legacy xml entities to convert, and it adds the `entity-types-php@2` unconditionally.

In this PR, `convertEntities` is called only if there are files to convert. Also a check is 
added to `convertEntities` to return early if it's called with no xml files.

fixes #372 