### PR TITLE
\CRM\CivixBundle\Builder\PhpData::save set strict flag on in_array

### DIFF
--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -151,13 +151,13 @@ class PhpData implements Builder {
       /**
        * @var \PhpArrayDocument\ArrayItemNode $arrayItem
        */
-      if (in_array($arrayItem->getKey(), $this->keysToTranslate ?: []) && $arrayItem->getValue() instanceof ScalarNode) {
+      if (in_array($arrayItem->getKey(), $this->keysToTranslate ?: [], true) && $arrayItem->getValue() instanceof ScalarNode) {
         $arrayItem->getValue()->setFactory($ts);
       }
-      if (in_array($arrayItem->getKey(), $this->useCallbacks)) {
+      if (in_array($arrayItem->getKey(), $this->useCallbacks, true)) {
         $arrayItem->getValue()->setDeferred(TRUE);
       }
-      if (in_array($arrayItem->getKey(), $this->literals)) {
+      if (in_array($arrayItem->getKey(), $this->literals, true)) {
         $arrayItem->getValue()->setFactory('constant');
       }
     }


### PR DESCRIPTION
`PhpData::save` generates strange output from the input data on PHP<8.0.0.
For example during `convert-entity` command:

If the legacy xml entity files contains `<import>` or `<export>` elements in a `<field>` element
```
<field>
...
  <import>true</import>
  <export>true</export>
...
</field>
```
will be converted in the generated `.entityType.php` to
```
'usage' => [
  constant(fn() => 'import'),
  'export',
  'duplicate_matching',
],
```
which emits a PHP WARNING when evaluated.

This is due to loose type checking in `in_array()` in PHP prior to 8.0.0

This PR adds strict type checking to `in_array()`.