### PR TITLE
EFv2 - When upgrading from EFv1, check for conflicting hooks

### DIFF
--- a/src/CRM/CivixBundle/Checker.php
+++ b/src/CRM/CivixBundle/Checker.php
@@ -2,6 +2,8 @@
 
 namespace CRM\CivixBundle;
 
+use CRM\CivixBundle\Builder\Mixins;
+
 /**
  * This is a random grab-bag of conditionals that are show up when deciding how to generate code.
  */
@@ -71,6 +73,18 @@ class Checker {
   public function hasUpgrader(string $pattern = '/.+/'): bool {
     $upgrader = $this->generator->infoXml->get()->upgrader;
     return $upgrader && preg_match($pattern, $upgrader);
+  }
+
+  /**
+   * @param string $pattern
+   *   Regex.
+   * @return bool
+   *   TRUE if any mixin constraint matches the regex.
+   */
+  public function hasMixin(string $pattern = '/.+/'): bool {
+    $mixins = new Mixins($this->generator->infoXml, $this->generator->baseDir->string('mixin'));
+    $declared = $mixins->getDeclaredMixinConstraints();
+    return !empty(preg_grep($pattern, $declared));
   }
 
   /**

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CRM\CivixBundle\Utils;
+namespace CRM\CivixBundle\Parse;
 
 /**
  * Given a PHP file, visit all functions in the file. Use this for primitive

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace CRM\CivixBundle\Parse;
+
+/**
+ * @group unit
+ */
+class PrimitiveFunctionVisitorTest extends \PHPUnit\Framework\TestCase {
+
+  protected function getBasicFile(): string {
+    $code = '<' . '?php ';
+    $code .= "// Woop\n";
+    $code .= "// Woop\n";
+    $code .= "function first() { echo 1; }\n";
+    $code .= "/**\n * Woop\n */\n";
+    $code .= "   function second(array ?\$xs = []) { echo 2; }\n";
+    // TODO Nested block
+    $code .= "if (foo( 'bar' )) { function third(\$a, \$b, \$c) { echo 3; } }\n";
+    return $code;
+  }
+
+  protected function getComplexFile(): string {
+    $code = '<' . '?php ';
+    $code .= "// Complex\n";
+    $code .= '$anon = function(int $a) { return 100; };';
+    $code .= '$bufA = [];';
+    $code .= '(new Stuff())->do(wrapping(200, function($x, $y) use ($buf) { return $x; }));';
+    $code .= 'function zero($a) {};';
+    $code .= '?>';
+    $code .= $this->getBasicFile();
+    $code .= 'function finale($a) {}';
+    return $code;
+  }
+
+  /**
+   * Handy for interactive debugging...
+   */
+  public function testTiny(): void {
+    $code = '<' . '?php ';
+    $code .= "function single(\$a) { return 'bar'; }";
+    PrimitiveFunctionVisitor::visit($code, function (&$func, &$sig, &$code) use (&$visited) {
+      $visited[] = ['func' => $func, 'sig' => $sig, 'code' => $code];
+    });
+    $expected = [];
+    $expected[] = ['func' => 'single', 'sig' => '$a', 'code' => ' return \'bar\'; '];
+    $this->assertEquals($expected, $visited);
+  }
+
+  public function testBasicFileVisitOrder(): void {
+    $input = $this->getBasicFile();
+
+    $visited = [];
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) use (&$visited) {
+      $visited[] = ['func' => $func, 'sig' => $sig, 'code' => $code];
+    });
+    $expected = [];
+    $expected[] = ['func' => 'first', 'sig' => '', 'code' => ' echo 1; '];
+    $expected[] = ['func' => 'second', 'sig' => 'array ?$xs = []', 'code' => ' echo 2; '];
+    $expected[] = ['func' => 'third', 'sig' => '$a, $b, $c', 'code' => ' echo 3; '];
+    $this->assertEquals($expected, $visited);
+
+    $this->assertEquals($input, $output);
+  }
+
+  public function testBasicFileInsertions(): void {
+    $input = $this->getBasicFile();
+
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) {
+      $func .= 'Func';
+      if (!empty($sig)) {
+        $sig .= ', ';
+      }
+      $sig .= 'int $id = 0';
+      $code .= 'echo "00"; ';
+    });
+
+    $expect = '<' . '?php ';
+    $expect .= "// Woop\n";
+    $expect .= "// Woop\n";
+    $expect .= "function firstFunc(int \$id = 0) { echo 1; echo \"00\"; }\n";
+    $expect .= "/**\n * Woop\n */\n";
+    $expect .= "   function secondFunc(array ?\$xs = [], int \$id = 0) { echo 2; echo \"00\"; }\n";
+    $expect .= "if (foo( 'bar' )) { function thirdFunc(\$a, \$b, \$c, int \$id = 0) { echo 3; echo \"00\"; } }\n";
+    $this->assertEquals($expect, $output);
+  }
+
+  public function testBasicFileDeletion(): void {
+    $input = $this->getBasicFile();
+
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) {
+      return ($func === 'second') ? 'DELETE' : NULL;
+    });
+
+    $expect = '<' . '?php ';
+    $expect .= "// Woop\n";
+    $expect .= "// Woop\n";
+    $expect .= "function first() { echo 1; }\n";
+    $expect .= "/**\n * Woop\n */\n";
+    $expect .= "   \n";
+    $expect .= "if (foo( 'bar' )) { function third(\$a, \$b, \$c) { echo 3; } }\n";
+    $this->assertEquals($expect, $output);
+  }
+
+  public function testBasicFileComment(): void {
+    $input = $this->getBasicFile();
+
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) {
+      return ($func === 'third') ? 'COMMENT' : NULL;
+    });
+
+    $expect = '<' . '?php ';
+    $expect .= "// Woop\n";
+    $expect .= "// Woop\n";
+    $expect .= "function first() { echo 1; }\n";
+    $expect .= "/**\n * Woop\n */\n";
+    $expect .= "   function second(array ?\$xs = []) { echo 2; }\n";
+    $expect .= "if (foo( 'bar' )) { \n";
+    $expect .= "// function third(\$a, \$b, \$c) { echo 3; }\n";
+    $expect .= " }\n";
+    $this->assertEquals($expect, $output);
+  }
+
+  public function testMinSpacing(): void {
+    $input = '<' . '?php ';
+    $input .= "function first(){echo 1;}";
+    $input .= "if(foo()){function second(){echo 3;}}";
+
+    $visited = [];
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) use (&$visited) {
+      $visited[] = $func;
+    });
+    $this->assertEquals(['first', 'second'], $visited);
+    $this->assertEquals($input, $output);
+  }
+
+  // public function testComplexFileVisitOrder(): void {
+  //   $input = $this->getComplexFile();
+  //
+  //   $visited = [];
+  //   $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) use (&$visited) {
+  //     $visited[] = $func;
+  //   });
+  //   $this->assertEquals(['zero', 'first', 'second', 'third', 'finale'], $visited);
+  //
+  //   $this->assertEquals($input, $output);
+  // }
+
+  // public function testAnonymousFunctions(): void {
+  //   $input = '<' . '?php ';
+  //   $input .= "// Woop\n";
+  //   $input .= "// Woop\n";
+  //   $input .= "function first() { echo 1; }";
+  //   $input .= "/**\n * Woop\n */\n";
+  // }
+
+}

--- a/src/CRM/CivixBundle/Parse/Token.php
+++ b/src/CRM/CivixBundle/Parse/Token.php
@@ -74,11 +74,20 @@ class Token {
    *   One of:
    *    - Integer: The token-type ID
    *    - String: The raw value of the token
+   *    - Array: List of strings or integers; any one to match
    * @return bool
    */
   public function is($expect): bool {
     if ($expect === NULL) {
       return TRUE; /* wildcard */
+    }
+    if (is_array($expect)) {
+      foreach ($expect as $expectOption) {
+        if ($this->is($expectOption)) {
+          return TRUE;
+        }
+      }
+      return FALSE;
     }
     if (is_int($expect)) {
       return $this->typeId === $expect;

--- a/src/CRM/CivixBundle/Parse/Token.php
+++ b/src/CRM/CivixBundle/Parse/Token.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace CRM\CivixBundle\Parse;
+
+if (!defined('TX_RAW')) {
+  define('TX_RAW', -1);
+}
+
+/**
+ * OOP wrapper of PHP's token.
+ *
+ * For writing recursive-descent parsers, it can get a little tedious
+ * to constantly guard against `is_array()/is_string()`.
+ */
+class Token {
+
+  public static function tokenize(string $code): array {
+    $raw = token_get_all($code);
+    return array_map(function ($t) {
+      return is_array($t) ? new Token($t[0], $t[1]) : new Token(TX_RAW, $t);
+    }, $raw);
+  }
+
+  /**
+   * @param $typeId
+   * @param $value
+   */
+  public function __construct(int $typeId, string $value) {
+    $this->typeId = $typeId;
+    $this->value = $value;
+  }
+
+  protected $typeId;
+  protected $value;
+
+  /**
+   * Get ID code of the token type.
+   *
+   * @return int
+   *   Ex: T_FUNCTION, T_WHITESPACE, TX_RAW
+   */
+  public function typeId(): int {
+    return $this->typeId;
+  }
+
+  /**
+   * Get symbolic name of the token type.
+   *
+   * @return string
+   *   Ex: 'T_FUNCTION', 'T_WHITESPACE_', 'TX_RAW'
+   */
+  public function name(): string {
+    if ($this->typeId === TX_RAW) {
+      return 'TX_RAW';
+    }
+    else {
+      return token_name($this->typeId);
+    }
+  }
+
+  /**
+   * Get literal value of token.
+   *
+   * @return string
+   */
+  public function value(): string {
+    return $this->value;
+  }
+
+  /**
+   * Check if the token matches an expectation
+   *
+   * @param $expect
+   *   One of:
+   *    - Integer: The token-type ID
+   *    - String: The raw value of the token
+   * @return bool
+   */
+  public function is($expect): bool {
+    if ($expect === NULL) {
+      return TRUE; /* wildcard */
+    }
+    if (is_int($expect)) {
+      return $this->typeId === $expect;
+    }
+    if (is_string($expect)) {
+      return $this->value === $expect;
+    }
+    throw new \RuntimeException("Token::is() expects type ID or literal value");
+  }
+
+  public function assert($expect): void {
+    if ($this->is($expect)) {
+      return;
+    }
+
+    if ($expect === TX_RAW) {
+      $expectPretty = 'TX_RAW';
+    }
+    elseif (is_int($expect)) {
+      $expectPretty = token_name($expect);
+    }
+    else {
+      $expectPretty = json_encode($expect, JSON_UNESCAPED_SLASHES);
+    }
+    throw new \RuntimeException(sprintf('Token %s does not match expectation %s', $this->__toString(), $expectPretty));
+  }
+
+  public function __toString(): string {
+    return sprintf("%s [%s] %s", $this->name(), $this->typeId, json_encode($this->value(), JSON_UNESCAPED_SLASHES));
+  }
+
+}

--- a/src/CRM/CivixBundle/Utils/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Utils/PrimitiveFunctionVisitor.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+/**
+ * Given a PHP file, visit all functions in the file. Use this for primitive
+ * checks ("does the function do anything") or primitive manipulations
+ * ("add a new line, or rename the whole thing").
+ *
+ * ## Example 1: Print out a list functions
+ *
+ * PrimitiveFunctionVisitor::visit(file_get_contents('foo.php', function(string $function, string $signature, string $code) {
+ *   printf("FOUND: function %s(%s) {...}\n", $function, $signature);
+ * });
+ *
+ * ## Example 2: Rename a function from 'foo' to 'bar'
+ *
+ * $updated = PrimitiveFunctionVisitor::visit(file_get_contents('foo.php', function(string &$function, string &$signature, string &$code) {
+ *   if ($function === 'foo') {
+ *     $function = 'bar';
+ *   }
+ * });
+ *
+ * ## Example 3: Delete any functions with evil names
+ *
+ * $updated= PrimitiveFunctionVisitor::visit(file_get_contents('foo.php', function(string $function, string $signature, string $code) {
+ *    return (str_contains($function, 'evil')') ? 'DELETE' : NULL;
+ *  });
+ */
+class PrimitiveFunctionVisitor {
+  private $tokens;
+  private $filter;
+  private $currentIndex = 0;
+
+  /**
+   * Parse a PHP script and visit all the function(){} declarations.
+   *
+   * @param string $code
+   *   Fully formed PHP code
+   * @param callable $filter
+   *   This callback is executed against each function.
+   *
+   *   function(string &$functionName, string &$signature, string &$code): ?string
+   *
+   *   Note that inputs are all alterable. Additionally, the result may optionally specify
+   *   an action to perform on the overall function ('DELETE', 'COMMENT').
+   *
+   * @return string
+   */
+  public static function visit(string $code, callable $filter): string {
+    $instance = new self($code, $filter);
+    return $instance->run();
+  }
+
+  public function __construct(string $code, callable $filter) {
+    $this->tokens = token_get_all($code);
+    $this->filter = $filter;
+  }
+
+  public function run(): string {
+    $output = '';
+    while (($token = $this->nextToken()) !== NULL) {
+      if ($this->isToken($token, T_FUNCTION)) {
+        $output .= $this->parseFunction();
+      }
+      else {
+        $output .= is_array($token) ? $token[1] : $token;
+      }
+    }
+    return $output;
+  }
+
+  private function parseFunction(): string {
+    $pad0 = $this->fastForward(T_STRING);
+    $function = $this->nextToken()[1];
+
+    $pad1 = $this->fastForward('(');
+    $signature = $this->parseSection('(', ')');
+
+    $pad2 = $this->fastForward('{');
+    $codeBlock = $this->parseSection('{', '}');
+
+    $result = ($this->filter)($function, $signature, $codeBlock);
+
+    if ($result === 'DELETE') {
+      return '';
+    }
+    elseif ($result === 'COMMENT') {
+      $code = 'function' . $pad0 . $function . $pad1 . '(' . $signature . ')' . $pad2 . '{' . $codeBlock . '}';
+      return "\n" . implode("\n", array_map(
+          function($line) {
+            return "// $line";
+          },
+          explode("\n", $code)
+        )) . "\n";
+    }
+    else {
+      return 'function' . $pad0 . $function . $pad1 . '(' . $signature . ')' . $pad2 . '{' . $codeBlock . '}';
+    }
+  }
+
+  private function parseSection(string $openChar, string $closeChar): string {
+    $this->assertToken($this->peekToken(), $openChar);
+    $section = '';
+    $parenthesisCount = 0;
+
+    while (($token = $this->nextToken()) !== NULL) {
+      $section .= is_array($token) ? $token[1] : $token;
+
+      if ($token === $openChar) {
+        $parenthesisCount++;
+      }
+      elseif ($token === $closeChar) {
+        $parenthesisCount--;
+        if ($parenthesisCount === 0) {
+          break;
+        }
+      }
+    }
+    return substr($section, 1, -1);
+  }
+
+  private function isToken($token, $type): bool {
+    if (is_array($token)) {
+      return $token[0] === $type;
+    }
+    else {
+      return $token === $type;
+    }
+  }
+
+  private function assertToken($token, $type): void {
+    if ($type === NULL) {
+      return;
+    }
+
+    if ($this->isToken($token, $type)) {
+      return;
+    }
+
+    $actualTypeName = is_array($token) ? token_name($token[0]) : $token;
+    $expectTypeName = is_string($type) ? $token : token_name($type);
+    throw new \RuntimeException(sprintf('Token %s does not match type %s', json_encode($actualTypeName), json_encode($expectTypeName)));
+  }
+
+  private function nextToken(?string $assertType = NULL) {
+    if ($this->currentIndex < count($this->tokens)) {
+      $token = $this->tokens[$this->currentIndex++];
+      $this->assertToken($token, $assertType);
+      return $token;
+    }
+    return NULL;
+  }
+
+  private function peekToken() {
+    return $this->tokens[$this->currentIndex] ?? NULL;
+  }
+
+  private function fastForward($expectedToken): string {
+    $output = '';
+    while (($token = $this->peekToken()) !== NULL) {
+      if (is_array($token)) {
+        if ($token[0] === $expectedToken) {
+          break;
+        }
+        else {
+          $output .= $token[1];
+        }
+      }
+      else {
+        if ($token === $expectedToken) {
+          break;
+        }
+        else {
+          $output .= $token;
+        }
+      }
+      $this->nextToken();
+    }
+    return $output;
+  }
+
+}

--- a/upgrades/25.01.0.up.php
+++ b/upgrades/25.01.0.up.php
@@ -1,0 +1,78 @@
+<?php
+
+use CRM\CivixBundle\Utils\PrimitiveFunctionVisitor;
+
+/**
+ * If you have EFv2, then you probably don't want to implement hook_entityTypes directly.
+ *
+ * - After running 24.09.1, it creates '*.entityType.php' files and enables
+ *   entity-type-php@. You shouldn't need a manual declaration.
+ * - Most existing implementations of hook_entityTypes do not provide all
+ *   the properties needed for EFv2.
+ * - Registering twice (with incomplete data) is likely to cause trouble.
+ *
+ * This step will search for `hook_entityTypes` and warn if it's doing any non-trivial work.
+ * It prompts you to (c)omment, (k)eep, or (d)elete the function.
+ */
+return function (\CRM\CivixBundle\Generator $gen) {
+
+  if (!\Civix::checker()->hasSchemaPhp() && !\Civix::checker()->hasMixin('/^entity-types-php@2/')) {
+    // OK, not our problem.
+    return;
+  }
+
+  $gen->updateModulePhp(function (\CRM\CivixBundle\Builder\Info $infoXml, string $body) {
+    $hookFunc = $infoXml->getFile() . '_civicrm_entityTypes';
+    $hookDelegate = '_' . $infoXml->getFile() . '_civix_civicrm_entityTypes';
+
+    /**
+     * @param string $func
+     *   Ex: 'myfile_civicrm_fooBar'
+     * @param string $sig
+     *   Ex: 'array &$arg1, string $arg2'
+     * @param string $code
+     *   Ex: 'echo "Hello";\necho "World";'
+     */
+    return PrimitiveFunctionVisitor::visit($body, function (string &$func, string &$sig, string &$code) use ($infoXml, $hookFunc, $hookDelegate) {
+      if ($func !== $hookFunc || empty($code)) {
+        return NULL;
+      }
+
+      $lines = preg_split(';\n\w*;', $code);
+      $lines = array_map('trim', $lines);
+      $lines = array_filter($lines, function ($line) {
+        return !empty($line) && !preg_match(';^(#|//);', $line);
+      });
+      $delegateRE = '/' . preg_quote($hookDelegate, '/') . '/i';
+
+      // $hasDelegate = !empty(preg_grep($delegateRE, $lines));
+      $hasBespokeLogic = !empty(preg_grep($delegateRE, $lines, PREG_GREP_INVERT));
+
+      if (!$hasBespokeLogic) {
+        return NULL;
+      }
+
+      $io = Civix::io();
+      $io->title("Suspicious Entity Hook");
+
+      $fullCode = sprintf("function %s(%s) {%s}", $func, $sig, $code);
+      Civix::generator()->showCode(explode("\n", $fullCode));
+
+      $io->note([
+        "In Entity Framework v2, conventions for metadata have changed.",
+        "Metadata is usually loaded from schema/*.entityType.php.",
+        "Using hook_civicrm_entityTypes to declare entities may create conflicts.",
+      ]);
+
+      $actionLabels = [
+        'c' => 'Comment-out this function',
+        'k' => 'Keep this function',
+        'd' => 'Delete this function',
+      ];
+      $action = $io->choice("What should we do with {$func}()?", $actionLabels, 'c');
+      $results = ['k' => NULL, 'c' => 'COMMENT', 'd' => 'DELETE'];
+      return $results[$action] ?? NULL;
+    });
+  });
+
+};

--- a/upgrades/25.01.0.up.php
+++ b/upgrades/25.01.0.up.php
@@ -1,6 +1,6 @@
 <?php
 
-use CRM\CivixBundle\Utils\PrimitiveFunctionVisitor;
+use CRM\CivixBundle\Parse\PrimitiveFunctionVisitor;
 
 /**
  * If you have EFv2, then you probably don't want to implement hook_entityTypes directly.


### PR DESCRIPTION
Overview
-------------

"Entity Framework v1" (EFv1) developed gradually over time. If you search `universe`, you will find at least 3 patterns for how entities have been registered, including:

1. Using mixin `entity-types-php@1` (which reads from `xml/schema/**.entityType.php`)
2. Using boilerplate function `_MYNAME_civix_civicrm_entityTypes` (which also reads from `xml/schema/**.entityType.php`)
3. Using static declarations or custom logic in `hook_civicrm_entityTypes`

The upgrader routine in 24.09.1 is generally geared toward the first two.

When I ran `civix upgrade` on Mosaico, I found it landed in that last set -- it has a [non-trivial implementation of hook_civicrm_entityTypes](https://github.com/veda-consulting-company/uk.co.vedaconsulting.mosaico/blob/3.6/mosaico.php#L261-L271).

After running the upgrader, I found that the entities were registered multiple times -- once `entity-types-php@2` (*with fully formed metadata*), and once through `hook_civicrm_entityTypes` (*with incomplete metadata*). The second (incomplete) copy led to activation errors. 

Checking my copy of `universe`, I find >50 extensions with non-trivial content in `hook_civicrm_entityTypes`. There may still be legitimate reasons to implement the hook directly (e.g. dynamic entities). However, if you're using EFv2, then you really should look at these hooks.

After
------

This adds another check to the upgrader. If the extension has EFv2, then we'll report about any non-trivial code in `hook_civicrm_entityTypes`, eg

![Screenshot from 2025-01-18 01-16-21](https://github.com/user-attachments/assets/fa8b1c3e-8c12-42f6-aa4a-14d19c6e3ac6)

It provides options to (c)omment out the old function, (k)eep the old function, or (d)elete the old function.

