### PR TITLE
Convert civimix-schema@5 from PHAR to subdir

### DIFF
--- a/src/CRM/CivixBundle/Utils/MixinLibraries.php
+++ b/src/CRM/CivixBundle/Utils/MixinLibraries.php
@@ -65,6 +65,12 @@ class MixinLibraries {
       }
     }
 
+    // When copying the library to the new folder, we may have a choice about which
+    // format (eg PHAR/DIR/PHP) to provide. In terms of general design/workflow,
+    // PHAR would be sensible here. However, Civi extensions target heterogeneous
+    // environments, and some downstreams have (exaggerated/misplaced) limits re:PHAR.
+    // As a compatibility measure, this code coerces the format (PHAR=>DIR).
+
     switch ($avail->type) {
       case 'php':
       case 'dir':

--- a/upgrades/25.01.1.up.php
+++ b/upgrades/25.01.1.up.php
@@ -1,0 +1,22 @@
+<?php
+
+use CRM\CivixBundle\Utils\MixinLibraries;
+
+/**
+ * Earlier civix revisions would generate `civimix-schema@X.X.X.phar`.
+ * This has compatibility issues with Backdrop.
+ * Convert to `civimix-schema@X.X.X/`.
+ */
+return function (\CRM\CivixBundle\Generator $gen) {
+
+  if ($gen->baseDir->search('glob:mixin/lib/civimix-schema@5.*.phar')) {
+    $io = Civix::io();
+    $io->title("Convert civimix-schema@5");
+
+    $gen->updateMixinLibraries(function (MixinLibraries $mixinLibraries): void {
+      $mixinLibraries->remove('civimix-schema@5');
+      $mixinLibraries->add('civimix-schema@5');
+    });
+  }
+
+};


### PR DESCRIPTION
Overview
---------

Improve compatibility with Backdrop. Note that:

* Backdrop CLI allows you to read PHAR files. So automated `civix` testing with `civimix-schema@XX.phar` had passed on Backdrop. ___Great, but...___
* Backdrop Web UI [completely blocks usage of PHAR files](https://github.com/backdrop/backdrop/blob/1.29.x/core/includes/bootstrap.inc#L768-L770). 🤦 

Switching from PHAR to subdirectory works-around it.

Before
-------

When using EFv2 with civimix-schema@5, the backport is created as a PHAR file.

After
-------

When using EFv2 with civimix-schema@5, the backport is created as a subdirectory.

