### PR TITLE
EFv2 Tweaks - Warn if EFv1 had a mismatched entity list (#384)

### DIFF
--- a/src/CRM/CivixBundle/Utils/Formatting.php
+++ b/src/CRM/CivixBundle/Utils/Formatting.php
@@ -52,4 +52,18 @@ class Formatting {
     return rtrim($buf);
   }
 
+  /**
+   * @param array $headers
+   * @param array $rows
+   * @return string
+   */
+  public static function table(array $headers, array $rows) {
+    $buffer = new \Symfony\Component\Console\Output\BufferedOutput();
+    $table = new \Symfony\Component\Console\Helper\Table($buffer);
+    $table->setHeaders($headers);
+    $table->setRows($rows);
+    $table->render();
+    return $buffer->fetch();
+  }
+
 }

--- a/upgrades/25.01.0.up.php
+++ b/upgrades/25.01.0.up.php
@@ -61,7 +61,7 @@ return function (\CRM\CivixBundle\Generator $gen) {
       $io->note([
         "In Entity Framework v2, conventions for metadata have changed.",
         "Metadata is usually loaded from schema/*.entityType.php.",
-        "Using hook_civicrm_entityTypes to declare entities may create conflicts.",
+        "We suggest disabling hook_entityTypes and testing with just *.entityType.php. This reduces the risk of conflicts. However, if you need hook_entityTypes, you can still use it.",
       ]);
 
       $actionLabels = [


### PR DESCRIPTION
The main update here addresses #384. It presents a summary about the pre-existing EFv1 data and conditionally warns if this looks inconsistent.

<img width="859" alt="Screenshot 2025-01-25 at 11 26 29 AM" src="https://github.com/user-attachments/assets/9a7e2318-e23a-405e-a0c3-a98827c26bc7" />
