### PR TITLE
Fix civilint whitespace errors

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/entity-dao.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/entity-dao.php.php
@@ -15,7 +15,7 @@ if ($classNamespaceDecl) {
  * substantive way. Property annotations may be added, but are not required.
 <?php
 foreach ($properties as $propName => $propType) {
-  echo " * @property $propType \$$propName \n";
+  echo " * @property $propType \$$propName\n";
 }
 ?> */
 class <?php echo $className ?> extends <?php echo $daoBaseClass; ?> {

--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -81,8 +81,9 @@ class <?php echo $_namespace ?>_ExtensionUtil {
   public static function findClass($suffix) {
     return self::CLASS_PREFIX . '_' . str_replace('\\', '_', $suffix);
   }
+<?php if (\Civix::checker()->hasUpgrader()) { ?>
 
-<?php if (\Civix::checker()->hasUpgrader()) { ?>  /**
+  /**
    * @return \CiviMix\Schema\SchemaHelperInterface
    */
   public static function schema() {


### PR DESCRIPTION
Before
------
```
FILE: ...alone-clean/web/core/ext/user_dashboard/user_dashboard.civix.php
----------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
----------------------------------------------------------------------
 76 | ERROR | [x] Expected 1 blank line after function; 2 found
 79 | ERROR | [x] The closing brace for the class must have an empty
    |       |     line before it
----------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```

And 

```
FILE: ...build-2/web/src/ext/oauth-client/CRM/OAuth/DAO/OAuthSysToken.php
----------------------------------------------------------------------
FOUND 15 ERRORS AFFECTING 15 LINES
----------------------------------------------------------------------
 11 | ERROR | [x] Whitespace found at end of line
 12 | ERROR | [x] Whitespace found at end of line
 13 | ERROR | [x] Whitespace found at end of line
 14 | ERROR | [x] Whitespace found at end of line
 15 | ERROR | [x] Whitespace found at end of line
 16 | ERROR | [x] Whitespace found at end of line
 17 | ERROR | [x] Whitespace found at end of line
 18 | ERROR | [x] Whitespace found at end of line
 19 | ERROR | [x] Whitespace found at end of line
 20 | ERROR | [x] Whitespace found at end of line
 21 | ERROR | [x] Whitespace found at end of line
 22 | ERROR | [x] Whitespace found at end of line
 23 | ERROR | [x] Whitespace found at end of line
 24 | ERROR | [x] Whitespace found at end of line
 25 | ERROR | [x] Whitespace found at end of line
----------------------------------------------------------------------
PHPCBF CAN FIX THE 15 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```

After
-------
CIviLint is happy.