### PR TITLE
Upgrader - Fix core version downgrading & linting error

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/upgrader.php.php
@@ -3,7 +3,7 @@ echo "<" . "?php\n";
 if ($classNamespaceDecl) {
   echo "$classNamespaceDecl\n\n";
 }
-echo "$useE\n";
+echo "$useE\n\n";
 ?>
 /**
  * Collection of upgrade steps.


### PR DESCRIPTION
When running the command `civix generate:upgrader` on a core ext, I noticed two problems:
1. The compatability version was downgraded.
2. There was a linting error in the generated file.

Fixed 1 by teaching the function `raiseCompatibilityMinimum` to [work with the '[civicrm.majorVersion]' token](https://github.com/totten/civix/pull/376).
Fixed 2 by adding a newline after the `use` statement