### PR TITLE
Merge `--yes` with the more conventional `--no-interaction`

### DIFF
--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -8,7 +8,6 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\ConfirmationQuestion;
 
 abstract class AbstractCommand extends Command {
 
@@ -37,19 +36,6 @@ abstract class AbstractCommand extends Command {
     finally {
       \Civix::ioStack()->pop();
     }
-  }
-
-  protected function confirm(InputInterface $input, OutputInterface $output, $message, $default = TRUE) {
-    $message = '<info>' . $message . '</info>'; /* FIXME Let caller stylize */
-    if ($input->getOption('yes')) {
-      $output->writeln($message . ($default ? 'Y' : 'N'));
-      return $default;
-    }
-
-    /** @var \Symfony\Component\Console\Helper\QuestionHelper $helper */
-    $helper = $this->getHelper('question');
-    $question = new ConfirmationQuestion($message, $default);
-    return (bool) $helper->ask($input, $output, $question);
   }
 
   protected function getModuleInfo(&$ctx): Info {

--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -13,7 +13,20 @@ use Symfony\Component\Console\Question\ConfirmationQuestion;
 abstract class AbstractCommand extends Command {
 
   protected function configure() {
-    $this->addOption('yes', NULL, InputOption::VALUE_NONE, 'Answer yes to any questions');
+    $this->addOption('yes', NULL, InputOption::VALUE_NONE, '(DEPRECATED) Alias for --no-interaction. All questions confirmed with their default choices.');
+  }
+
+  protected function initialize(InputInterface $input, OutputInterface $output) {
+    if ($input->hasOption('yes') && $input->getOption('yes')) {
+      $output->writeln('<error>ALERT</error>: <comment>The option "--yes" is a deprecated alias. Please use "--no-interaction" or "-n".</comment>');
+      // IMHO, `--yes` is a more intuitive name. However, it implies that prompts are boolean, and it's
+      // a little ambiguous what it means for multiple-choice questions.
+      // By comparison, `--no-interaction` is the standardized name from Symfony Console. It's less ambiguous.
+      // But at least
+      $input->setOption('no-interaction', TRUE);
+      $input->setInteractive(FALSE);
+    }
+    parent::initialize($input, $output);
   }
 
   public function run(InputInterface $input, OutputInterface $output) {

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -125,7 +125,7 @@ class InitCommand extends AbstractCommand {
       $output->writeln("requested command requires splitting the names. You may continue with");
       $output->writeln("split names, or you may cancel and try again with a simpler name.");
       $output->writeln("");
-      if (!$this->confirm($input, $output, "Continue with current (split) name? [Y/n] ")) {
+      if (!Civix::io()->confirm("Continue with current (split) name?")) {
         return 1;
       }
     }
@@ -182,7 +182,7 @@ class InitCommand extends AbstractCommand {
         return FALSE;
       }
 
-      if ($input->getOption('enable') === 'yes' || $this->confirm($input, $output, "Enable extension ($key) in \"$siteName\"? [Y/n] ")) {
+      if (Civix::io()->confirm("Enable extension \"$key\" in \"$siteName\"?")) {
         $output->writeln("<info>Enable extension ($key) in</info> $siteName");
         if (!$civicrm_api3->Extension->install(['key' => $key])) {
           $output->writeln("<error>Install error: " . $civicrm_api3->errorMsg() . "</error>");


### PR DESCRIPTION
Overview
-------------

Address the inconsistent behavior of `--yes` by using the (more consistent) option `--no-interaction`.

Fix #391

Before
---------

* `civix` inherits the option `--no-interaction` (`-n`) from Symfony Console.
* `civix` also defines the option `--yes`, but this is only used for 1-2 prompts. Most prompts ignore it.
    * (*I suspect it lost a lot relevance when logic was migrated from `Command` classes to the `Generator`.*)

After
------

* `civix` inherits the option `--no-interaction` (`-n`) from Symfony Console.
* `civix --yes` is a deprecated alias for `civix --no-interaction`.
