### PR TITLE
(REF) Relax coupling to SymfonyStyle

### DIFF
--- a/src/CRM/CivixBundle/Command/AddApiCommand.php
+++ b/src/CRM/CivixBundle/Command/AddApiCommand.php
@@ -3,6 +3,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use Civix;
+use CRM\CivixBundle\Utils\CivixStyle;
 use CRM\CivixBundle\Utils\Files;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -12,7 +13,6 @@ use CRM\CivixBundle\Builder\Dirs;
 use CRM\CivixBundle\Builder\PhpData;
 use CRM\CivixBundle\Utils\Path;
 use Exception;
-use Symfony\Component\Console\Style\SymfonyStyle;
 
 class AddApiCommand extends AbstractCommand {
   const API_VERSION = 3;
@@ -47,7 +47,7 @@ action names.
   }
 
   protected function execute(InputInterface $input, OutputInterface $output): int {
-    $io = new SymfonyStyle($input, $output);
+    $io = new CivixStyle($input, $output);
 
     // load Civi to get access to civicrm_api_get_function_name
     Civix::boot(['output' => $output]);

--- a/src/CRM/CivixBundle/Command/MixinCommand.php
+++ b/src/CRM/CivixBundle/Command/MixinCommand.php
@@ -11,7 +11,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use CRM\CivixBundle\Utils\Path;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Style\OutputStyle;
 
 class MixinCommand extends AbstractCommand {
 
@@ -106,7 +106,7 @@ class MixinCommand extends AbstractCommand {
     }
   }
 
-  protected function showList(SymfonyStyle $io, Mixins $mixins) {
+  protected function showList(OutputStyle $io, Mixins $mixins) {
     $mixlib = Civix::mixlib();
     $mixinBackports = preg_grep(';@;', array_keys(Civix::mixinBackports()));
 

--- a/src/CRM/CivixBundle/Command/MixinCommand.php
+++ b/src/CRM/CivixBundle/Command/MixinCommand.php
@@ -4,6 +4,7 @@ namespace CRM\CivixBundle\Command;
 
 use CRM\CivixBundle\Builder\Mixins;
 use Civix;
+use CRM\CivixBundle\Utils\CivixStyle;
 use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -72,7 +73,7 @@ class MixinCommand extends AbstractCommand {
       $info->save($ctx, $output);
     }
     else {
-      $io = new SymfonyStyle($input, $output);
+      $io = new CivixStyle($input, $output);
       $this->showList($io, $mixins);
     }
 

--- a/src/CRM/CivixBundle/Generator.php
+++ b/src/CRM/CivixBundle/Generator.php
@@ -14,7 +14,7 @@ use CRM\CivixBundle\Utils\Naming;
 use CRM\CivixBundle\Utils\Path;
 use PhpArrayDocument\Parser;
 use PhpArrayDocument\Printer;
-use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Console\Style\OutputStyle;
 
 /**
  * The "Generator" class is a utility provided to various upgrade-scripts.
@@ -34,7 +34,7 @@ class Generator {
   private $output;
 
   /**
-   * @var \Symfony\Component\Console\Style\SymfonyStyle
+   * @var \Symfony\Component\Console\Style\OutputStyle
    * @readonly
    */
   private $io;
@@ -910,12 +910,12 @@ class Generator {
       $fmt = sprintf('% 5d', 1 + $i);
       if ($focusStart !== NULL && $focusEnd !== NULL && $i >= $focusStart && $i <= $focusEnd) {
         $this->io->write("<error>*{$fmt}: ");
-        $this->io->write($lines[$i], SymfonyStyle::OUTPUT_RAW);
+        $this->io->write($lines[$i], OutputStyle::OUTPUT_RAW);
         $this->io->write("</error>");
       }
       else {
         $this->io->write("<comment> {$fmt}:</comment> ");
-        $this->io->writeln($lines[$i], SymfonyStyle::OUTPUT_RAW);
+        $this->io->writeln($lines[$i], OutputStyle::OUTPUT_RAW);
       }
     }
   }

--- a/src/CRM/CivixBundle/Utils/CivixStyle.php
+++ b/src/CRM/CivixBundle/Utils/CivixStyle.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace CRM\CivixBundle\Utils;
+
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class CivixStyle extends SymfonyStyle {
+
+}

--- a/src/CRM/CivixBundle/Utils/IOStack.php
+++ b/src/CRM/CivixBundle/Utils/IOStack.php
@@ -2,8 +2,6 @@
 
 namespace CRM\CivixBundle\Utils;
 
-use Symfony\Component\Console\Style\SymfonyStyle;
-
 class IOStack {
 
   protected $stack = [];
@@ -12,7 +10,7 @@ class IOStack {
     array_unshift($this->stack, [
       'input' => $input,
       'output' => $output,
-      'io' => new SymfonyStyle($input, $output),
+      'io' => new CivixStyle($input, $output),
     ]);
   }
 

--- a/upgrades/19.06.2.up.php
+++ b/upgrades/19.06.2.up.php
@@ -17,7 +17,7 @@
  * existing unit-tests to use the name base-classes.
  */
 return function (\CRM\CivixBundle\Generator $gen) {
-  /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+  /* @var \Symfony\Component\Console\Style\OutputStyle $io */
   $io = \Civix::io();
 
   $testFiles = \CRM\CivixBundle\Utils\Files::findFiles($gen->baseDir->string('tests'), '*.php');

--- a/upgrades/20.06.0.up.php
+++ b/upgrades/20.06.0.up.php
@@ -5,7 +5,7 @@
  * You can remove this.  The option has been inert and will raise errors in newer versions of PHPUnit.
  */
 return function (\CRM\CivixBundle\Generator $gen) {
-  /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+  /* @var \Symfony\Component\Console\Style\OutputStyle $io */
   $io = \Civix::io();
 
   $files = array_filter([

--- a/upgrades/22.05.0.up.php
+++ b/upgrades/22.05.0.up.php
@@ -1,7 +1,7 @@
 <?php
 
 return function (\CRM\CivixBundle\Generator $gen) {
-  /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+  /* @var \Symfony\Component\Console\Style\OutputStyle $io */
   $io = \Civix::io();
   $prefix = $gen->infoXml->getFile();
 

--- a/upgrades/22.05.2.up.php
+++ b/upgrades/22.05.2.up.php
@@ -24,7 +24,7 @@ return function (\CRM\CivixBundle\Generator $gen) {
     ];
 
     $newContent = EvilEx::rewriteMultilineChunk($content, $hookBody, function(array $matchLines) use ($hookFunc, $content, $gen, $hasSettingMixin, &$action) {
-      /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+      /* @var \Symfony\Component\Console\Style\OutputStyle $io */
       $io = \Civix::io();
       $matchLineKeys = array_keys($matchLines);
       $allLines = explode("\n", $content);

--- a/upgrades/22.10.0.up.php
+++ b/upgrades/22.10.0.up.php
@@ -10,7 +10,7 @@
 return function (\CRM\CivixBundle\Generator $gen) {
 
   $gen->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($gen) {
-    /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+    /* @var \Symfony\Component\Console\Style\OutputStyle $io */
     $io = \Civix::io();
 
     $loaders = $info->getClassloaders();

--- a/upgrades/23.01.0.up.php
+++ b/upgrades/23.01.0.up.php
@@ -2,7 +2,7 @@
 use CRM\CivixBundle\Utils\Formatting;
 
 return function (\CRM\CivixBundle\Generator $gen) {
-  /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+  /* @var \Symfony\Component\Console\Style\OutputStyle $io */
   $io = \Civix::io();
 
   $previewChanges = [];

--- a/upgrades/23.02.1.up.php
+++ b/upgrades/23.02.1.up.php
@@ -8,7 +8,7 @@
 return function (\CRM\CivixBundle\Generator $gen) {
 
   $gen->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($gen) {
-    /* @var \Symfony\Component\Console\Style\SymfonyStyle $io */
+    /* @var \Symfony\Component\Console\Style\OutputStyle $io */
     $io = \Civix::io();
 
     $loaders = $info->getClassloaders();


### PR DESCRIPTION
`symfony/console` defines a general helper `OutputStyle` (combination of the traditional/lower-tech `OutputInterface` and the newer/more-semantic `StyleInterface`). And it defines a specific implementation of this helper, `SymfonyStyle`.

In a draft to address #391, it was useful to be able override/extend `SymfonyStyle`. We ultimately didn't need that draft, but I think the refactoring there is "better in than out".