### PR TITLE
scripts/run-tests.sh - Accept option --civix-phar and --civix-src

### DIFF
--- a/scripts/run-tests.sh
+++ b/scripts/run-tests.sh
@@ -2,6 +2,16 @@
 set -e
 
 ## Run PHPUnit tests. This is a small wrapper for `phpunit` which does some setup for the E2E enviroment.
+##
+## You may optionally specify whether to run E2E tests using the raw civix source or compiled civix.phar.
+##
+## usage: ./scripts/run-tests.sh [--civix-src|--civix-phar] [phpunit-args...]
+
+################################################
+CIVIX_BUILD_TYPE=src
+case "$1" in
+  --civix-src|--civix-phar) CIVIX_BUILD_TYPE="$1" ; shift ; ;;
+esac
 
 ################################################
 ## Didn't set a workspace? Educated guess...
@@ -12,6 +22,19 @@ fi
 if [ -z "$CIVIX_WORKSPACE" ]; then
   echo "Missing env var: CIVIX_WORKSPACE"
   exit 1
+fi
+
+################################################
+if [ "$CIVIX_BUILD_TYPE" = "--civix-phar" ]; then
+  if [ ! -f "box.json" -o ! -f "scripts/build.sh" ]; then
+    echo "Must call from civix root dir"
+    exit 1
+  fi
+  ./scripts/build.sh
+  CIVIX_TEST_BINARY="$PWD"/bin/civix.phar
+  export CIVIX_TEST_BINARY
+else
+  unset CIVIX_TEST_BINARY
 fi
 
 ################################################

--- a/tests/e2e/CivixProjectTestTrait.php
+++ b/tests/e2e/CivixProjectTestTrait.php
@@ -85,6 +85,7 @@ trait CivixProjectTestTrait {
           $baseCommand = ['php', (dirname(__DIR__, 2) . '/bin/civix')];
         }
         $baseCommand[] = $subCommand;
+        $baseCommand[] = '-v';
         return new SubProcessCommandTester($baseCommand);
 
       case 'off':


### PR DESCRIPTION
This will make it easier for the test-matrix to include E2E tests of the PHAR build.

This parallels the options in `scripts/make-snapshots.sh` (although the flag-name is slightly different -- most options for `run-tests.sh` are supposed to pass-through to `phpunit`, but these options don't).