### PR TITLE
civix inspect:fun - Add recursion and more guards

### DIFF
--- a/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
+++ b/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
@@ -23,6 +23,7 @@ class InspectFunctionCommand extends AbstractCommand {
       ->addOption('name', NULL, InputOption::VALUE_REQUIRED, 'Pattern describing the function-names you wnt to see')
       ->addOption('body', NULL, InputOption::VALUE_REQUIRED, 'Pattern describing function bodies that you want to see')
       ->addOption('files-with-matches', 'l', InputOption::VALUE_NONE, 'Print only file names')
+      ->addOption('file-size-max', NULL, InputOption::VALUE_REQUIRED, 'Only scan files within this limit (KB)', 1024)
       ->addArgument('files', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'List of files')
       ->setHelp('Search PHP functions
 
@@ -68,6 +69,11 @@ Example: Find all functions named like "_civicrm_permission" AND having a body w
         continue;
       }
       if (!preg_match(self::PHP_FILES, $file)) {
+        continue;
+      }
+      $size = ceil(filesize($file) / 1024);
+      if ($size > $input->getOption('file-size-max')) {
+        $output->writeln(sprintf('<error>WARNING</error> Skip file "%s". Size (%d KB) exceeds limit (%s KB)', $file, $size, $input->getOption('file-size-max')));
         continue;
       }
 

--- a/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
+++ b/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
@@ -25,6 +25,7 @@ class InspectFunctionCommand extends AbstractCommand {
       ->addOption('body', NULL, InputOption::VALUE_REQUIRED, 'Pattern describing function bodies that you want to see')
       ->addOption('files-with-matches', 'l', InputOption::VALUE_NONE, 'Print only file names')
       ->addOption('file-size-max', NULL, InputOption::VALUE_REQUIRED, 'Only scan files within this limit (KB)', 1024)
+      ->addOption('exclude-dir', NULL, InputOption::VALUE_REQUIRED)
       ->addArgument('files', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'List of files')
       ->setHelp('Search PHP functions
 
@@ -36,6 +37,9 @@ Example: Find all functions which call civicrm_api3()
 
 Example: Find all functions named like "_civicrm_permission" AND having a body with "label"
   civix inspect:fun --name=/_civicrm_permission/ --body=/label/ *.php
+
+Example: Find all functions which call civicrm_api3()
+  civix inspect:fun --body=/civicrm_api3/ *.php --exclude-dir=\'/^(vendor|packages)/\'
 ');
   }
 
@@ -67,8 +71,10 @@ Example: Find all functions named like "_civicrm_permission" AND having a body w
         continue;
       }
       if (is_dir($file)) {
-        $todo = array_merge($todo, glob("$file/*"));
-        sort($todo);
+        if (empty($input->getOption('exclude-dir')) || !preg_match($input->getOption('exclude-dir'), basename($file))) {
+          $todo = array_merge($todo, glob("$file/*"));
+          sort($todo);
+        }
         continue;
       }
       if (!preg_match(self::PHP_FILES, $file)) {

--- a/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
+++ b/src/CRM/CivixBundle/Command/InspectFunctionCommand.php
@@ -53,6 +53,7 @@ Example: Find all functions named like "_civicrm_permission" AND having a body w
     }
 
     $todo = $input->getArgument('files');
+    sort($todo);
     while (!empty($todo)) {
       $file = array_shift($todo);
       $file = rtrim($file, DIRECTORY_SEPARATOR . '/');
@@ -66,6 +67,7 @@ Example: Find all functions named like "_civicrm_permission" AND having a body w
       }
       if (is_dir($file)) {
         $todo = array_merge($todo, glob("$file/*"));
+        sort($todo);
         continue;
       }
       if (!preg_match(self::PHP_FILES, $file)) {

--- a/src/CRM/CivixBundle/Parse/ParseException.php
+++ b/src/CRM/CivixBundle/Parse/ParseException.php
@@ -1,0 +1,6 @@
+<?php
+
+namespace CRM\CivixBundle\Parse;
+
+class ParseException extends \Exception {
+}

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
@@ -92,7 +92,12 @@ class PrimitiveFunctionVisitor {
     $pad1 = $this->fastForward('(');
     $signature = $this->parseSection('(', ')');
 
-    $pad2 = $this->fastForward('{');
+    $pad2 = $this->fastForward(['{', ';']);
+    if ($this->peek()->is(';')) {
+      // Abstract functions don't have bodies. For the moment, we don't care about visiting them.
+      // but maybe that changes at some point...
+      return 'function' . $pad0 . $function . $pad1 . '(' . $signature . ')' . $pad2 . $this->consume()->value();
+    }
     $codeBlock = $this->parseSection('{', '}');
 
     $result = ($this->filter)($function, $signature, $codeBlock);

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
@@ -68,7 +68,11 @@ class PrimitiveFunctionVisitor {
     $output = '';
 
     while (($peek = $this->peek()) !== NULL) {
-      if ($peek->is(T_FUNCTION)) {
+      if ($peek->is(T_USE)) {
+        $statement = $this->fastForward(';');
+        $output .= $statement;
+      }
+      elseif ($peek->is(T_FUNCTION)) {
         $output .= $this->parseFunction();
       }
       else {

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
@@ -67,7 +67,7 @@ class PrimitiveFunctionVisitor {
   public function run(): string {
     $output = '';
 
-    while (($peek = $this->peek()) !== NULL) {
+    while (($peek = $this->peek(FALSE)) !== NULL) {
       if ($peek->is(T_USE)) {
         $statement = $this->fastForward(';');
         $output .= $statement;
@@ -146,20 +146,26 @@ class PrimitiveFunctionVisitor {
     return $section;
   }
 
-  private function consume(): ?Token {
+  private function consume(bool $required = TRUE): ?Token {
     if ($this->currentIndex < count($this->tokens)) {
       return $this->tokens[$this->currentIndex++];
+    }
+    if ($required) {
+      throw new ParseException("Unexpected end of file. Cannot consume next token.");
     }
     return NULL;
   }
 
-  private function peek(): ?Token {
+  private function peek(bool $required = TRUE): ?Token {
+    if ($required && !isset($this->tokens[$this->currentIndex])) {
+      throw new ParseException("Unexpected end of file. Cannot peek at next token.");
+    }
     return $this->tokens[$this->currentIndex] ?? NULL;
   }
 
   private function fastForward($expectedToken): string {
     $output = '';
-    while (($token = $this->peek()) !== NULL) {
+    while (($token = $this->peek(FALSE)) !== NULL) {
       if ($token->is($expectedToken)) {
         break;
       }

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
@@ -157,6 +157,21 @@ class PrimitiveFunctionVisitorTest extends \PHPUnit\Framework\TestCase {
     $this->assertEquals($input, $output);
   }
 
+  public function testUseFunction(): void {
+    $input = '<' . '?php ';
+    $input .= 'namespace foo;';
+    $input .= 'use function bar;';
+    $input .= 'class Whiz { function bang() {} }';
+
+    // For the moment, we don't really care about visiting abstract functions. But maybe that changes sometime.
+    $visited = [];
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) use (&$visited) {
+      $visited[] = $func;
+    });
+    $this->assertEquals(['bang'], $visited);
+    $this->assertEquals($input, $output);
+  }
+
   public function testComplexFileVisitOrder(): void {
     $input = $this->getComplexFile();
 

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitorTest.php
@@ -141,6 +141,22 @@ class PrimitiveFunctionVisitorTest extends \PHPUnit\Framework\TestCase {
     $this->assertEquals($input, $output);
   }
 
+  public function testInterface(): void {
+    $input = '<' . '?php ';
+    $input .= "interface Food {";
+    $input .= "  public function apple();\n";
+    $input .= "  public function banana();\n";
+    $input .= "}\n";
+
+    // For the moment, we don't really care about visiting abstract functions. But maybe that changes sometime.
+    $visited = [];
+    $output = PrimitiveFunctionVisitor::visit($input, function (&$func, &$sig, &$code) use (&$visited) {
+      $visited[] = $func;
+    });
+    $this->assertEquals([], $visited);
+    $this->assertEquals($input, $output);
+  }
+
   public function testComplexFileVisitOrder(): void {
     $input = $this->getComplexFile();
 

--- a/src/CRM/CivixBundle/Parse/Token.php
+++ b/src/CRM/CivixBundle/Parse/Token.php
@@ -95,7 +95,7 @@ class Token {
     if (is_string($expect)) {
       return $this->value === $expect;
     }
-    throw new \RuntimeException("Token::is() expects type ID or literal value");
+    throw new ParseException("Token::is() expects type ID or literal value");
   }
 
   public function assert($expect): void {
@@ -112,7 +112,8 @@ class Token {
     else {
       $expectPretty = json_encode($expect, JSON_UNESCAPED_SLASHES);
     }
-    throw new \RuntimeException(sprintf('Token %s does not match expectation %s', $this->__toString(), $expectPretty));
+
+    throw new ParseException(sprintf('Token %s does not match expectation %s', $this->__toString(), $expectPretty));
   }
 
   public function __toString(): string {


### PR DESCRIPTION
## Add recursion

Consider this command:
```
civix inspect:fun --code=/foo/ my_folder
```

Before, it would fail on `my_folder`. Now, it recurses.

## More guards

When doing a recursive search on `universe`, it encountered more edge-cases where parsing failed. Fix the fixable cases; and for the others, display better warnings/errors.