### PR TITLE
Pathload is provided by civicrm-core@5.74 (not 5.73)

### DIFF
--- a/src/CRM/CivixBundle/Checker.php
+++ b/src/CRM/CivixBundle/Checker.php
@@ -38,7 +38,7 @@ class Checker {
    * @return bool
    */
   public function coreHasPathload(): bool {
-    return $this->coreVersionIs('>=', '5.73.beta1');
+    return $this->coreVersionIs('>=', '5.74.beta1');
   }
 
   /**


### PR DESCRIPTION
civix will include or exclude a compatiblity-file (`pathload-0.php`) depending on the target version of CiviCRM. The PR fixes a slight misalignment on the boundary.

| | `<ver>5.72</ver>`| `<ver>5.73</ver>`| `<ver>5.74</ver>` |
| -- | -- | -- | -- |
| Before (Incorrect) | Include compat file | Exclude compat file | Exclude compat file |
| After (Correct) | Include compat file | __Include compat file__ | Exclude compat file |

Presumably, the corresponding update for civicrm-core was drafted during development of 5.73 -- but was actually merged into 5.74.