### PR TITLE
Add smarty compatibility and php_compatibility tags on civix generate

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -12,6 +12,7 @@ use SimpleXMLElement;
 class Info extends XML {
 
   const MINIMUM_COMPATIBILITY_NEW_EXTENSION = '5.36';
+  const CURRENT_PHP_VERSIONS = ['8.0', '8.1', '8.2', '8.3', '8.4'];
 
   public function init(&$ctx) {
     $ctx += [
@@ -55,6 +56,13 @@ class Info extends XML {
     $xml->addChild('version', '1.0.0');
     $xml->addChild('develStage', 'alpha');
     $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin']);
+    $phpCompatibility = $xml->addChild('php_compatibility');
+    foreach (self::CURRENT_PHP_VERSIONS as $PHP_VERSION) {
+      $phpCompatibility->addChild('ver', $PHP_VERSION);
+    }
+    // Add smarty compatibility. New extensions should support Smarty5, anything else can
+    // be manually added by discretion.
+    $xml->addChild('smarty_compatibility')->addChild('ver', 5);
     $xml->addChild('comments', 'This is a new, undeveloped module');
 
     // APIv4 will look for classes+files matching 'Civi/Api4', and


### PR DESCRIPTION
@totten basic version of adding php_compatibility & smarty_compatibilty tags on civix:generate 

I'm now hitting the issue where I'm dropping php 8.0 support in extensions because the versions of packages that work with 8.0 conflict with drupal versions of the same package - obviously there are multiple issues in play here but my specific concern is that there is limited visibility on extensions not supporting the php or smarty version that is in use. To be able to block downloads or pro-actively warn people we need more extensions to specify the version in play - so I think the first focus is

- civix generate
- civix upgrade
- core extensions

Note I've been deliberately forward-looking with Smarty - I don't see people specifying support for older smarty versions being particularly meaningful. Extended reports does not fully work with Smarty 2 (but probably in an obscure way) but generally people need to know Smarty5 works not the older ones