### PR TITLE
generate:api gives error and stops before creating phpunit.xml. Similarly generate:test gives a warning and the test suite name is pretruncated.

### DIFF
--- a/src/CRM/CivixBundle/Generator.php
+++ b/src/CRM/CivixBundle/Generator.php
@@ -695,6 +695,9 @@ class Generator {
    */
   public function addPhpunit(): void {
     $ctx = $this->createDefaultCtx();
+    $info = new Info($this->baseDir->string('info.xml'));
+    $info->load($ctx);
+    $ctx['fullName'] = $info->getKey();
     $phpUnitInitFiles = new PHPUnitGenerateInitFiles();
     $phpUnitInitFiles->initPhpunitXml($this->baseDir->string('phpunit.xml.dist'), $ctx, Civix::output());
     $phpUnitInitFiles->initPhpunitBootstrap($this->baseDir->string('tests', 'phpunit', 'bootstrap.php'), $ctx, Civix::output());


### PR DESCRIPTION
I made up the word pretruncated.

In https://github.com/totten/civix/pull/355 it added a use of `$ctx['fullName']` to name the test suite, but it seems like maybe this never worked unless it was also building the info.xml at the same time as making phpunit.xml?

This PR updates it to load it from the info since fullName never gets set.

e.g. At the time this was the code and you can see here fullName is never set: https://github.com/totten/civix/blob/fb21c7f4ac2c0e8786a16a73b733ab83b3cdc625/src/CRM/CivixBundle/Command/AddTestCommand.php#L60-L73

And in the current code the "generator" only has access to the "default ctx", and not this ctx, which also doesn't have fullName anyway:
* https://github.com/totten/civix/blob/b4c7e5fe832cb88a91b503a6f7ea436e7637f749/src/CRM/CivixBundle/Command/AddTestCommand.php#L59-L67
* https://github.com/totten/civix/blob/b4c7e5fe832cb88a91b503a6f7ea436e7637f749/src/CRM/CivixBundle/Generator.php#L697
