### PR TITLE
info.xml - Add explanatory comments for "compatibility" tags

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -55,14 +55,25 @@ class Info extends XML {
     $xml->addChild('releaseDate', date('Y-m-d'));
     $xml->addChild('version', '1.0.0');
     $xml->addChild('develStage', 'alpha');
-    $xml->addChild('compatibility')->addChild('ver', $ctx['compatibilityVerMin']);
+
+    $compatibility = $xml->addChild('compatibility');
+    $compatibility->addAttribute('mode', 'semver');
+    $compatibility->addChild('comments', 'Semantic versioning. For example, compatibility with "6.1" implies compatibility with "6.2".');
+    $compatibility->addChild('ver', $ctx['compatibilityVerMin']);
+
     $phpCompatibility = $xml->addChild('php_compatibility');
+    $phpCompatibility->addAttribute('mode', 'list');
+    $phpCompatibility->addChild('comments', 'Listed versions. For example, specify both "8.1" and "8.2".');
     foreach (self::CURRENT_PHP_VERSIONS as $PHP_VERSION) {
       $phpCompatibility->addChild('ver', $PHP_VERSION);
     }
     // Add smarty compatibility. New extensions should support Smarty5, anything else can
     // be manually added by discretion.
-    $xml->addChild('smarty_compatibility')->addChild('ver', 5);
+    $smartyCompatibility = $xml->addChild('smarty_compatibility');
+    $smartyCompatibility->addAttribute('mode', 'list');
+    $smartyCompatibility->addChild('comments', 'Listed versions. For example, specify both "4" and "5".');
+    $smartyCompatibility->addChild('ver', 5);
+
     $xml->addChild('comments', 'This is a new, undeveloped module');
 
     // APIv4 will look for classes+files matching 'Civi/Api4', and


### PR DESCRIPTION
Follow-up to #405. When creating a new extension, the `info.xml` now generates `<smarty_compatibility>` and  `<php_compatibility>`. The semantics are confusingly different from `<compatibility>`. This adds clarifying comments.

Before
-------

```xml
  <compatibility>
    <ver>6.7</ver>
  </compatibility>
  <php_compatibility>
    <ver>8.0</ver>
    <ver>8.1</ver>
    <ver>8.2</ver>
    <ver>8.3</ver>
    <ver>8.4</ver>
  </php_compatibility>
  <smarty_compatibility>
    <ver>5</ver>
  </smarty_compatibility>
```

After
--------

```xml

  <compatibility mode="semver">
    <comments>Semantic versioning. For example, compatibility with "6.1" implies compatibility with "6.2".</comments>
    <ver>6.7</ver>
  </compatibility>
  <php_compatibility mode="list">
    <comments>Listed versions. For example, specify both "8.1" and "8.2".</comments>
    <ver>8.0</ver>
    <ver>8.1</ver>
    <ver>8.2</ver>
    <ver>8.3</ver>
    <ver>8.4</ver>
  </php_compatibility>
  <smarty_compatibility mode="list">
    <comments>Listed versions. For example, specify both "4" and "5".</comments>
    <ver>5</ver>
  </smarty_compatibility>
```

Technical Details
-----------------

Most operations around `info.xml` are built with PHP's SimpleXML -- but doesn't support working with doc nodes (`<!-- ... -->`). Instead, we generate the `<comments>` tag. As far as core's `CRM_Extension_Info` is concerned, I don't see any particular problems with that.