### PR TITLE
Class Scanner - Recommend general adoption

### DIFF
--- a/src/CRM/CivixBundle/Builder/Info.php
+++ b/src/CRM/CivixBundle/Builder/Info.php
@@ -168,6 +168,43 @@ class Info extends XML {
     return str_replace('/', '_', $this->getNamespace()) . '_ExtensionUtil';
   }
 
+  public function getRequiredExtensions(): array {
+    $requires = [];
+    $xml = $this->xml;
+    if ($xml->requires) {
+      foreach ($xml->requires->ext as $ext) {
+        $requires[] = (string) $ext;
+      }
+    }
+    return $requires;
+  }
+
+  public function setRequiredExtensions(array $updatedRequires): void {
+    $currentRequires = $this->getRequiredExtensions();
+    $removals = array_diff($currentRequires, $updatedRequires);
+    $additions = array_diff($updatedRequires, $currentRequires);
+
+    $xml = $this->get();
+
+    foreach ($removals as $removal) {
+      $nodes = $xml->xpath('requires/ext[text() = "' . $removal . '")]');
+      foreach ($nodes as $node) {
+        Civix::output()->writeln("<info>Unregister</info> " . $node);
+        unset($node[0]);
+      }
+    }
+
+    if ($additions) {
+      if (empty($xml->xpath('requires'))) {
+        $xml->addChild('requires');
+      }
+      $requireXml = $xml->requires;
+      foreach ($additions as $addition) {
+        $requireXml->addChild('ext', $addition);
+      }
+    }
+  }
+
   /**
    * Get the namespace into which civix should place files
    * @return string

--- a/src/CRM/CivixBundle/Command/InitCommand.php
+++ b/src/CRM/CivixBundle/Command/InitCommand.php
@@ -18,8 +18,6 @@ use CRM\CivixBundle\Utils\Path;
 
 class InitCommand extends AbstractCommand {
 
-  protected $defaultMixins = ['setting-php@1', 'mgd-php@1', 'smarty-v2@1'];
-
   protected function configure() {
     Civix::templating();
     $this
@@ -149,7 +147,7 @@ class InitCommand extends AbstractCommand {
       $basedir->string('images'),
       $basedir->string($ctx['namespace']),
     ]);
-    $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), $this->getMixins($input));
+    $ext->builders['mixins'] = new Mixins($info, $basedir->string('mixin'), $this->getMixins($input, $ctx['compatibilityVerMin']));
     $ext->builders['info'] = $info;
     $ext->builders['module'] = new Module(Civix::templating());
     $ext->builders['license'] = new License($licenses->get($ctx['license']), $basedir->string('LICENSE.txt'), FALSE);
@@ -239,10 +237,18 @@ class InitCommand extends AbstractCommand {
     return $result;
   }
 
-  protected function getMixins(InputInterface $input) {
+  protected function getMixins(InputInterface $input, string $minimumVersion) {
     $requested = explode(',', implode(',', $input->getOption('mixins')));
-    $merged = array_unique(array_merge($this->defaultMixins, $requested));
+    $merged = array_unique(array_merge($this->getDefaultMixins($minimumVersion), $requested));
     return array_filter($merged);
+  }
+
+  protected function getDefaultMixins(string $minimumVersion): array {
+    $defaults = ['setting-php@1', 'mgd-php@1', 'smarty-v2@1'];
+    if (version_compare($minimumVersion, '5.51', '>=')) {
+      $defaults[] = 'scan-classes@1';
+    }
+    return $defaults;
   }
 
 }

--- a/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
+++ b/src/CRM/CivixBundle/Parse/PrimitiveFunctionVisitor.php
@@ -59,6 +59,20 @@ class PrimitiveFunctionVisitor {
     return $instance->run();
   }
 
+  /**
+   * @param string $code
+   *   Fully formed PHP code
+   * @return array
+   *   List of functions defined in this file.
+   */
+  public static function getAllNames(string $code): array {
+    $names = [];
+    static::visit($code, function (?string &$functionName, string &$signature, string &$code) use (&$names) {
+      $names[] = $code;
+    });
+    return $names;
+  }
+
   public function __construct(string $code, callable $filter) {
     $this->tokens = Token::tokenize($code);
     $this->filter = $filter;

--- a/upgrades/25.10.0.up.php
+++ b/upgrades/25.10.0.up.php
@@ -1,0 +1,73 @@
+<?php
+
+/**
+ * Look for common problems with undeclared dependencies.
+ */
+return function (\CRM\CivixBundle\Generator $gen) {
+  $checker = \Civix::checker();
+
+  $extClasses = [
+    ['Legacy Custom Search', 'legacycustomsearch', ';CRM_Contact_Form_Search_Custom_Base;i'],
+    ['CiviRules', 'org.civicoop.civirules', ';CRM_Civirules;i'],
+  ];
+  foreach ($extClasses as $extClass) {
+    [$extTitle, $extKey, $baseClassPattern] = $extClass;
+
+    \Civix::io()->section("Dependency check: $extTitle ($extKey)");
+
+    if ($gen->infoXml->getKey() === $extKey) {
+      continue;
+    }
+    if ($checker->hasRequirement($extKey)) {
+      Civix::io()->writeln("<info>[OK]</info> Already declares requirement for \"$extKey\".");
+      continue;
+    }
+
+    $matches = $checker->grep($baseClassPattern, ['CRM', 'Civi'], '*.php');
+    if (empty($matches)) {
+      Civix::io()->writeln("<info>[OK]</info> No evidence of hidden dependency.");
+      continue;
+    }
+    $relMatches = array_map(fn($f) => \CRM\CivixBundle\Utils\Files::relativize($f, Civix::extDir()), $matches);
+
+    Civix::io()->warning([
+      "The following files have markers which appear related to \"$extKey\":",
+      \CRM\CivixBundle\Utils\Formatting::ol("%s\n", $relMatches),
+      "However, \"info.xml\" does NOT declare a formal dependency on \"$extKey\".",
+    ]);
+
+    Civix::io()->note([
+      "Why would this be?",
+      "It's possible that \"$extKey\" is truly REQUIRED -- and it SHOULD be listed in \"info.xml\".",
+      "It's possible that \"$extKey\" is truly OPTIONAL -- and it should NOT be listed in \"info.xml\".",
+      "This is a subjective question which civix cannot solve automatically. We need you to do decide.",
+    ]);
+
+    // Prefer to have no default - but for purposes of automated tests, we'll assume that existing code is accurate.
+    $default = Civix::input()->isInteractive() ? NULL : 'o';
+    $choice = \Civix::io()->choice("Is the extension \"$extKey\" required or optional?", [
+      'r' => 'Required',
+      'o' => 'Optional',
+      'a' => 'Abort',
+    ], $default);
+
+    switch ($choice) {
+      case 'r':
+        $gen->updateInfo(function (\CRM\CivixBundle\Builder\Info $info) use ($extKey) {
+          $requires = $info->getRequiredExtensions();
+          $requires[] = $extKey;
+          $info->setRequiredExtensions($requires);
+        });
+        break;
+
+      case 'o':
+        // Leave it alone...
+        // Might be nice to record this decision somewhere, but I'm not sure where.
+        break;
+
+      case 'a':
+        throw new \RuntimeException('User stopped upgrade');
+    }
+  }
+
+};

--- a/upgrades/25.10.1.up.php
+++ b/upgrades/25.10.1.up.php
@@ -1,0 +1,118 @@
+<?php
+
+/**
+ * Recommend scan-classes (in general).
+ */
+return function (\CRM\CivixBundle\Generator $gen) {
+  $checker = \Civix::checker();
+  if ($checker->hasMixin('/^scan-classes@/')) {
+    return;
+  }
+  $hookScanClasses = $gen->infoXml->getFile() . '_civicrm_scanClasses';
+  if (in_array($hookScanClasses, $checker->getMyGlobalFunctions())) {
+    return;
+  }
+
+  \Civix::io()->note([
+    "In CiviCRM v5.51+, class-scanning empowers you to write more modular code.",
+    "We suggest enabling the standard scanner (\"scan-classes@1\") for most extensions.",
+    "In some cases, you may omit scanning or use a custom scanner. Review this table for relevant notices:",
+  ]);
+
+  $indicators = [];
+  $addIndicator = function ($level, $name, $messages = []) use (&$indicators) {
+    $messages = implode("\n", (array) $messages);
+    $indicators[$name] = ["<info>$level</info>", "<comment>$name</comment>" . ($messages ? ": $messages" : '')];
+  };
+
+  $default = 's';
+
+  if (!file_exists(Civix::extDir('Civi/Api4'))) {
+    $addIndicator('OK', 'Civi\Api4');
+  }
+  else {
+    $addIndicator('IMPORTANT', 'Civi\Api4', "You must enable scanning to ensure future compatibility.\n(See https://github.com/civicrm/civicrm-core/pull/33371)");
+  }
+
+  if ($checker->coreVersionIs('>=', '5.51')) {
+    $addIndicator('OK', 'Core Compatibility', sprintf('You already require CiviCRM <comment>v%s+</comment>.', $gen->infoXml->getCompatibilityVer()));
+  }
+  else {
+    $addIndicator('IMPORTANT', 'Core Compatibility', 'Scanner requires CiviCRM v5.51+.');
+  }
+
+  // These are some cases where people have undeclared dependencies.
+  $extClasses = [
+    ['Legacy Custom Search', 'legacycustomsearch', 'CRM_Contact_Form_Search_Custom_Base'],
+    ['CiviRules', 'org.civicoop.civirules', 'CRM_Civirules'],
+  ];
+  foreach ($extClasses as $extClass) {
+    [$extTitle, $extKey, $baseClassPattern] = $extClass;
+    if ($gen->infoXml->getKey() !== $extKey && !$checker->hasRequirement($extKey) && $checker->hasSubclassesOf($baseClassPattern)) {
+      $default = 'c';
+    }
+  }
+
+  if (file_exists(Civix::extDir('CRM')) || file_exists(Civix::extDir('Civi'))) {
+    $addIndicator('REVIEW', 'Optional Dependencies', [
+      'If you have any, then use the <comment>custom scanner</comment>.',
+      'An "optional dependency" is another extension that you connect with -- but do not require.',
+      'For example, your extension could provide an optional CiviRules trigger to benefit site-builders,',
+      'even though the extension does not require CiviRules for itself. Any optional dependencies',
+      'may lead to errors in the standard scanner. To avoid this, use a <comment>custom scanner</comment>.',
+    ]);
+  }
+
+  ksort($indicators);
+  $n = 0;
+  foreach ($indicators as &$indicator) {
+    array_unshift($indicator, ++$n);
+  }
+  \Civix::io()->table(['#', 'Severity', 'Check'], $indicators);
+
+  $choice = \Civix::io()->choice('What kind of class-scanner should we use?', [
+    's' => 'Standard scanner (scan-classes@1)',
+    'c' => 'Custom scanner (hook_civicrm_scanClasses)',
+    'n' => 'None (Disable scanning)',
+    'a' => 'Abort',
+  ], $default);
+
+  switch ($choice) {
+    case 's':
+      $gen->addMixins(['scan-classes@1.0']);
+      break;
+
+    case 'c':
+      $gen->updateModulePhp(function (\CRM\CivixBundle\Builder\Info $info, string $content) use ($hookScanClasses): string {
+        return implode("\n", [
+          $content,
+          '',
+          '/**',
+          ' * Implements hook_civicrm_scanClasses',
+          ' *',
+          ' * @see CRM_Utils_Hook::scanClasses()',
+          ' */',
+          'function ' . $hookScanClasses . '(array &$classes) {',
+          '  // Example 1: Declare the exact classes that should be scanned.',
+          '  // $classes[] = "CRM_Example_Class";',
+          '',
+          '  // Example 2: Scan specific subfolder(s)',
+          '  \Civi\Core\ClassScanner::scanFolders($classes, __DIR__, \'Civi/Api4\', \'\\\\\');',
+          '  // \Civi\Core\ClassScanner::scanFolders($classes, __DIR__, \'Civi/Foobar\', \'\\\\\');',
+          '  // \Civi\Core\ClassScanner::scanFolders($classes, __DIR__, \'CRM/Foobar\', \'_\');',
+          '',
+          '  // Example 3: Scan specific folder(s), with exclusions',
+          '  // \Civi\Core\ClassScanner::scanFolders($classes, __DIR__, \'Civi\', \'\\\\\', \';...regex...;\');',
+          '}',
+        ]);
+      });
+      break;
+
+    case 'n':
+      break;
+
+    case 'a':
+      throw new \RuntimeException('User stopped upgrade');
+  }
+
+};


### PR DESCRIPTION
Overview
-------------

The class-scanner allows you to create new PHP files with services and listeners -- without needing to hand-edit or re-generate the main `*.php` files. This encourages modular development, and it makes it easier to copy/borrow/move snippets of code. The PR encourages adoption with main two revisions:

1. `civix generate:module`: On CiviCRM v5.51+, enable `scan-classes@1` by default for new extensions.
2. `civix upgrade`: Prompt the developer to enable the scanner. Include the known counter-indicators (*i.e. exceptions where you may not want it*) and alternatives (*e.g. custom scanner*).

This is generally an outgrowth of work on https://github.com/civicrm/civicrm-core/pull/33371, and it aligns with @ufundo's argument (*which I mostly agree with*) that class-scanning is a good general practice. It specifically expands on @colemanw's #412 (*and borrows [some ideas](https://github.com/totten/civix/pull/412#issuecomment-3340895083) from that discussion*), but this is a bit more comprehensive and more nuanced. In my local system, phpunit is happier. (We'll see if Jenkins agrees.)

Technical Details
------------------

There's not much to see in the `civix generate:module`. Most of the action comes in `civix upgrade`.

Here is a preview of `civix upgrade` on `mosaico`, which  should be fairly typical:

<img width="802" height="612" alt="Screenshot 2025-10-03 at 9 28 47 PM" src="https://github.com/user-attachments/assets/9ecfa668-7048-4611-984f-811e03feec3e" />

Or here's an example with a more difficult extension (where its `<compatibility>` is older and it has legacy custom-searches):

<img width="806" height="608" alt="Screenshot 2025-10-03 at 9 27 59 PM" src="https://github.com/user-attachments/assets/9c37abc8-b352-4e82-8440-4a8ff4f72479" />

Based on anecdotal reading of `universe`, I believe there are some common cases where extensions have undeclared dependencies. I've added heuristics to detect two of them:

* Extensions which extend `CRM_Civirules*` but don't declare a full dependency on `org.civicoop.civirules`.
* Extensions which extend `CRM_Contact_Form_Search_Custom_Base` but don't declare a full dependency on `legacycustomsearches`.

If it finds these clues, then it switches its default recommendation (`scan-classes@1` => `hook_scanClasses`). It's OK to add more heuristics. 

Of course, it would be even better if we find a design that supports a standard scanner (with little/no configuration) while still supporting these. I look forward to talking more with @jaapjansma @ufundo etal in a couple weeks about that.