### PR TITLE
Bump PHP minimum (7.3 => 7.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Civix is a command-line tool for building CiviCRM extensions. It is distributed 
 
 ## Requirements
 
-* PHP 7.3+
+* PHP 7.4+
 * CiviCRM 5.x (*Recommended: any release from the prior 12 months*)
 * (For MAMP, WAMP, XAMPP, etc) PHP command-line configuration (http://wiki.civicrm.org/confluence/display/CRMDOC/Setup+Command-Line+PHP)
 * (For CentOS/RHEL) Compatible version of libxml2 (https://github.com/totten/civix/issues/19)

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "homepage": "https://github.com/totten/civix",
     "license": "AGPL-3.0",
     "require": {
-        "php": ">=7.3.0",
+        "php": ">=7.4.0",
         "civicrm/cv-lib": "~0.3.60",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
@@ -35,7 +35,7 @@
           "civicrm/composer-downloads-plugin": true
         },
         "platform": {
-          "php": "7.3.0"
+          "php": "7.4.0"
         },
         "bin-dir": "bin"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3a0d3dd240fd0f0a8b48bc1c0a66669c",
+    "content-hash": "be8f6f67396a8f9750bed73e64f23d86",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -1647,11 +1647,11 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=7.3.0"
+        "php": ">=7.4.0"
     },
     "platform-dev": {},
     "platform-overrides": {
-        "php": "7.3.0"
+        "php": "7.4.0"
     },
     "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
In the test-suite for civix, the oldest target is ESR `-2` (i.e. going back a couple ESR cycles). After 6.4 went ESR, that means the oldest config is now PHP 7.4.

```php
$it_s = fn($in) => "the future";
```