### PR TITLE
[REGRESSION] Prevent using ts() on empty strings or NULL

### DIFF
--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -152,7 +152,10 @@ class PhpData implements Builder {
        * @var \PhpArrayDocument\ArrayItemNode $arrayItem
        */
       if (in_array($arrayItem->getKey(), $this->keysToTranslate ?: [], true) && $arrayItem->getValue() instanceof ScalarNode) {
-        $arrayItem->getValue()->setFactory($ts);
+        // Only use ts if value is not empty
+        if ($arrayItem->getValue()->getScalar()) {
+          $arrayItem->getValue()->setFactory($ts);
+        }
       }
       if (in_array($arrayItem->getKey(), $this->useCallbacks, true)) {
         $arrayItem->getValue()->setDeferred(TRUE);


### PR DESCRIPTION
Empty strings and null values should not be wrapped in `ts()`.
This looks to have regressed with 23a7e41537edde1771d9dd7cef670b42e900a732.