### PR TITLE
composer.json - Update civicrm/php-array-doc. Fix some PHP warnings.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "civicrm/cv-lib": "~0.3.66",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
-        "civicrm/php-array-doc": "~0.1.7",
+        "civicrm/php-array-doc": "~1.0.0",
         "symfony/console": "^4|^5",
         "symfony/filesystem": "^4|^5",
         "symfony/process": "^4|^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ba738f4b89d149ebf00a5cbb7281d41",
+    "content-hash": "9b1e8e6eebdc555bc35aacec982522ec",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -154,16 +154,16 @@
         },
         {
             "name": "civicrm/php-array-doc",
-            "version": "v0.1.7",
+            "version": "v1.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/totten/php-array-doc.git",
-                "reference": "19b735ab05da3103a9f614d7daf480ed7c88fbab"
+                "reference": "529367e43ac403b39b622ec082d72f497b5b36c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/totten/php-array-doc/zipball/19b735ab05da3103a9f614d7daf480ed7c88fbab",
-                "reference": "19b735ab05da3103a9f614d7daf480ed7c88fbab",
+                "url": "https://api.github.com/repos/totten/php-array-doc/zipball/529367e43ac403b39b622ec082d72f497b5b36c4",
+                "reference": "529367e43ac403b39b622ec082d72f497b5b36c4",
                 "shasum": ""
             },
             "require": {
@@ -187,9 +187,9 @@
             ],
             "support": {
                 "issues": "https://github.com/totten/php-array-doc/issues",
-                "source": "https://github.com/totten/php-array-doc/tree/v0.1.7"
+                "source": "https://github.com/totten/php-array-doc/tree/v1.0.0"
             },
-            "time": "2024-12-07T23:13:40+00:00"
+            "time": "2026-02-13T07:47:20+00:00"
         },
         {
             "name": "psr/container",
@@ -1659,5 +1659,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
Noticed some issues while testing issues around #434. (Update includes https://github.com/totten/php-array-doc/pull/4 and https://github.com/totten/php-array-doc/pull/5)