### PR TITLE
Exclude settings from SearchDisplay exports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
         "civicrm/cv-lib": "~0.3.66",
         "civicrm/composer-compile-plugin": "~0.18",
         "civicrm/composer-downloads-plugin": "~2.1|^3",
-        "civicrm/php-array-doc": "~1.0.0",
+        "civicrm/php-array-doc": "~1.0.1 | ~1.1.1",
         "symfony/console": "^4|^5",
         "symfony/filesystem": "^4|^5",
         "symfony/process": "^4|^5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "166c11efb30b82e10b40ee6a9465ba23",
+    "content-hash": "daf63c6c7d1ca4c6a3d3b1cee95e0f26",
     "packages": [
         {
             "name": "civicrm/composer-compile-plugin",
@@ -154,16 +154,16 @@
         },
         {
             "name": "civicrm/php-array-doc",
-            "version": "v1.0.0",
+            "version": "v1.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/totten/php-array-doc.git",
-                "reference": "529367e43ac403b39b622ec082d72f497b5b36c4"
+                "reference": "c74d43c46081c793d4140ae7bc7d81e2aaf04689"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/totten/php-array-doc/zipball/529367e43ac403b39b622ec082d72f497b5b36c4",
-                "reference": "529367e43ac403b39b622ec082d72f497b5b36c4",
+                "url": "https://api.github.com/repos/totten/php-array-doc/zipball/c74d43c46081c793d4140ae7bc7d81e2aaf04689",
+                "reference": "c74d43c46081c793d4140ae7bc7d81e2aaf04689",
                 "shasum": ""
             },
             "require": {
@@ -187,9 +187,9 @@
             ],
             "support": {
                 "issues": "https://github.com/totten/php-array-doc/issues",
-                "source": "https://github.com/totten/php-array-doc/tree/v1.0.0"
+                "source": "https://github.com/totten/php-array-doc/tree/v1.0.1"
             },
-            "time": "2026-02-13T07:47:20+00:00"
+            "time": "2026-06-08T22:44:02+00:00"
         },
         {
             "name": "psr/container",
@@ -1656,5 +1656,5 @@
     "platform-overrides": {
         "php": "7.4.0"
     },
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -32,11 +32,13 @@ class PhpData implements Builder {
 
   /**
    * @var string[]
+   *   Ex: ['title', 'description'] means "Translate individual fields named `title` or `description`"
    */
   private $keysToTranslate;
 
   /**
    * @var string[]
+   *   Ex: ['extra'] means "Skip translation for subtrees named `extra`; e.g. skip `extra.title`".
    */
   private $keysToExcludeTs = [];
 

--- a/src/CRM/CivixBundle/Builder/PhpData.php
+++ b/src/CRM/CivixBundle/Builder/PhpData.php
@@ -4,10 +4,8 @@ namespace CRM\CivixBundle\Builder;
 use CRM\CivixBundle\Builder;
 use CRM\CivixBundle\Utils\Files;
 use CRM\CivixBundle\Utils\Path;
-use PhpArrayDocument\ArrayItemNode;
 use PhpArrayDocument\PhpArrayDocument;
 use PhpArrayDocument\Printer;
-use PhpArrayDocument\ScalarNode;
 use Symfony\Component\Console\Output\OutputInterface;
 
 /**
@@ -36,6 +34,11 @@ class PhpData implements Builder {
    * @var string[]
    */
   private $keysToTranslate;
+
+  /**
+   * @var string[]
+   */
+  private $keysToExcludeTs = [];
 
   /**
    * @var string
@@ -97,6 +100,16 @@ class PhpData implements Builder {
   }
 
   /**
+   * Specify fields (and their children) that will not be wrapped in E::ts()
+   *
+   * @param array $keysToExclude
+   * @return void
+   */
+  public function excludeTs(array $keysToExclude) {
+    $this->keysToExcludeTs = $keysToExclude;
+  }
+
+  /**
    * Adds `use Foo_ExtensionUtil as E;` to the top of the file
    *
    * @param string $extensionUtilClass
@@ -147,26 +160,43 @@ class PhpData implements Builder {
 
     $doc->getRoot()->importData($this->data);
 
-    foreach ($doc->getRoot()->walkNodes(ArrayItemNode::class) as $arrayItem) {
-      /**
-       * @var \PhpArrayDocument\ArrayItemNode $arrayItem
-       */
-      if (in_array($arrayItem->getKey(), $this->keysToTranslate ?: [], true) && $arrayItem->getValue() instanceof ScalarNode) {
-        // Only use ts if value is not empty
-        if ($arrayItem->getValue()->getScalar()) {
-          $arrayItem->getValue()->setFactory($ts);
-        }
-      }
-      if (in_array($arrayItem->getKey(), $this->useCallbacks, true)) {
-        $arrayItem->getValue()->setDeferred(TRUE);
-      }
-      if (in_array($arrayItem->getKey(), $this->literals, true)) {
-        $arrayItem->getValue()->setFactory('constant');
-      }
-    }
+    $this->applyTranslations($doc->getRoot(), $this->keysToExcludeTs ?: [], $ts);
 
     $content = (new Printer())->print($doc);
     file_put_contents($this->path, $content);
+  }
+
+  /**
+   * Recursively processes nodes and sets factory/deferred flags.
+   *
+   * @param \PhpArrayDocument\BaseNode $node
+   * @param array $excludeKeys
+   * @param string $ts
+   * @param bool $isExcluded
+   * @return void
+   */
+  private function applyTranslations(\PhpArrayDocument\BaseNode $node, array $excludeKeys, string $ts, bool $isExcluded = FALSE) {
+    if ($node instanceof \PhpArrayDocument\ArrayNode) {
+      foreach ($node->getItems() as $arrayItem) {
+        $key = $arrayItem->getKey();
+        $itemExcluded = $isExcluded || in_array($key, $excludeKeys, TRUE);
+        $value = $arrayItem->getValue();
+
+        if (in_array($key, $this->keysToTranslate ?: [], TRUE) && !$itemExcluded && $value instanceof \PhpArrayDocument\ScalarNode) {
+          if ($value->getScalar()) {
+            $value->setFactory($ts);
+          }
+        }
+        if (in_array($key, $this->useCallbacks, TRUE)) {
+          $value->setDeferred(TRUE);
+        }
+        if (in_array($key, $this->literals, TRUE)) {
+          $value->setFactory('constant');
+        }
+
+        $this->applyTranslations($value, $excludeKeys, $ts, $itemExcluded);
+      }
+    }
   }
 
 }

--- a/src/CRM/CivixBundle/Builder/PhpDataTest.php
+++ b/src/CRM/CivixBundle/Builder/PhpDataTest.php
@@ -1,0 +1,133 @@
+<?php
+
+namespace CRM\CivixBundle\Builder;
+
+/**
+ * @group unit
+ */
+class PhpDataTest extends \PHPUnit\Framework\TestCase {
+
+  private $tempDir;
+
+  public function setUp(): void {
+    parent::setUp();
+    $this->tempDir = sys_get_temp_dir() . '/civix_test_' . uniqid();
+    mkdir($this->tempDir);
+  }
+
+  public function tearDown(): void {
+    parent::tearDown();
+    if (is_dir($this->tempDir)) {
+      array_map('unlink', glob("$this->tempDir/*"));
+      rmdir($this->tempDir);
+    }
+  }
+
+  public function testExcludeTsWithTopLevelKey() {
+    $testFile = $this->tempDir . '/test_exclude.php';
+    $ctx = [];
+
+    $builder = new PhpData($testFile);
+    $builder->useExtensionUtil('TestExt_ExtensionUtil');
+    $builder->useTs(['title', 'label', 'description']);
+    $builder->excludeTs(['metadata']);
+
+    $builder->set([
+      'title' => 'Main Title',
+      'label' => 'Main Label',
+      'metadata' => [
+        'title' => 'Metadata Title',
+        'label' => 'Metadata Label',
+        'description' => 'Metadata Description',
+      ],
+    ]);
+
+    $output = new \Symfony\Component\Console\Output\BufferedOutput();
+    $builder->save($ctx, $output);
+
+    $content = file_get_contents($testFile);
+
+    // Main title and label should use E::ts
+    $this->assertStringContainsString("E::ts('Main Title')", $content);
+    $this->assertStringContainsString("E::ts('Main Label')", $content);
+
+    // Metadata fields should NOT use E::ts
+    $this->assertStringNotContainsString("E::ts('Metadata Title')", $content);
+    $this->assertStringNotContainsString("E::ts('Metadata Label')", $content);
+    $this->assertStringNotContainsString("E::ts('Metadata Description')", $content);
+
+    // Metadata fields should be plain strings
+    $this->assertStringContainsString("'Metadata Title'", $content);
+    $this->assertStringContainsString("'Metadata Label'", $content);
+    $this->assertStringContainsString("'Metadata Description'", $content);
+  }
+
+  public function testExcludeTsWithNestedStructure() {
+    $testFile = $this->tempDir . '/test_nested.php';
+    $ctx = [];
+
+    $builder = new PhpData($testFile);
+    $builder->useExtensionUtil('TestExt_ExtensionUtil');
+    $builder->useTs(['title', 'label']);
+    $builder->excludeTs(['config']);
+
+    $builder->set([
+      'title' => 'Root Title',
+      'config' => [
+        'title' => 'Config Title',
+        'nested' => [
+          'title' => 'Deep Config Title',
+          'label' => 'Deep Config Label',
+        ],
+      ],
+    ]);
+
+    $output = new \Symfony\Component\Console\Output\BufferedOutput();
+    $builder->save($ctx, $output);
+
+    $content = file_get_contents($testFile);
+
+    // Root title should use E::ts
+    $this->assertStringContainsString("E::ts('Root Title')", $content);
+
+    // All config fields (even nested) should NOT use E::ts
+    $this->assertStringNotContainsString("E::ts('Config Title')", $content);
+    $this->assertStringNotContainsString("E::ts('Deep Config Title')", $content);
+    $this->assertStringNotContainsString("E::ts('Deep Config Label')", $content);
+  }
+
+  public function testExcludeTsWithMultipleExcludedKeys() {
+    $testFile = $this->tempDir . '/test_multiple.php';
+    $ctx = [];
+
+    $builder = new PhpData($testFile);
+    $builder->useExtensionUtil('TestExt_ExtensionUtil');
+    $builder->useTs(['title', 'description']);
+    $builder->excludeTs(['metadata', 'raw_data']);
+
+    $builder->set([
+      'title' => 'Main Title',
+      'metadata' => [
+        'title' => 'Meta Title',
+      ],
+      'raw_data' => [
+        'description' => 'Raw Description',
+      ],
+      'description' => 'Main Description',
+    ]);
+
+    $output = new \Symfony\Component\Console\Output\BufferedOutput();
+    $builder->save($ctx, $output);
+
+    $content = file_get_contents($testFile);
+
+    // Main fields should use E::ts
+    $this->assertStringContainsString("E::ts('Main Title')", $content);
+    $this->assertStringContainsString("E::ts('Main Description')", $content);
+
+    // Excluded sections should NOT use E::ts
+    $this->assertStringNotContainsString("E::ts('Meta Title')", $content);
+    $this->assertStringNotContainsString("E::ts('Raw Description')", $content);
+  }
+
+}

--- a/upgrades/26.06.0.up.php
+++ b/upgrades/26.06.0.up.php
@@ -1,0 +1,121 @@
+<?php
+
+use CRM\CivixBundle\Generator;
+use CRM\CivixBundle\Utils\Files;
+use PhpArrayDocument\Printer;
+
+/**
+ * Upgrade managed/SavedSearch_*.mgd.php files to 6.15 (translated) or 6.16 (bare) standard.
+ */
+return function (Generator $gen) {
+  $io = \Civix::io();
+  $fieldsToCheck = ['title', 'title_plural', 'label', 'description'];
+  // $fieldsToCheck = ['label'];
+
+  $printNode = function (\PhpArrayDocument\BaseNode $node) {
+    $printer = new \PhpArrayDocument\Printer();
+    // $doc = new \PhpArrayDocument\PhpArrayDocument();
+    $method = new ReflectionMethod($printer, 'printNode');
+    $method->setAccessible(TRUE);
+    return $method->invoke($printer, $node);
+  };
+
+  $findSavedSearchStrings = function (\PhpArrayDocument\BaseNode $root) use ($fieldsToCheck, $printNode): \Generator {
+    yield from [];
+    foreach ($fieldsToCheck as $fieldName) {
+      $nodes = $root->findPath(['*', 'params', 'values', 'settings', 'columns', '*', $fieldName]);
+      foreach ($nodes as $fieldNode) {
+        if ($fieldNode instanceof \PhpArrayDocument\ScalarNode && $fieldNode->getScalar() !== '') {
+          yield $fieldNode;
+        }
+      }
+    }
+  };
+
+  $mgdFiles = $gen->baseDir->search('find:managed/SavedSearch_*.mgd.php');
+  if (empty($mgdFiles)) {
+    $io->note('No managed/SavedSearch_*.mgd.php files found. Skipping upgrade.');
+    return;
+  }
+
+  $io->title('Translation support for Saved Searches');
+
+  $reports = [];
+  $expressionCount = 0;
+  foreach ($mgdFiles as $mgdFile) {
+    $relPath = Files::relativize($mgdFile, $gen->baseDir->string());
+    /**
+     * @var \PhpArrayDocument\PhpArrayDocument $document
+     */
+    $document = (new \PhpArrayDocument\Parser())->parse(file_get_contents($relPath));
+    $expressions = [];
+    foreach ($findSavedSearchStrings($document->getRoot()) as $stringNode) {
+      $expressions[] = $printNode($stringNode);
+    }
+    $expressions = array_unique($expressions);
+    sort($expressions);
+
+    $report = ['File' => basename($relPath), 'Expressions' => implode("\n", $expressions)];
+    $expressionCount += count($expressions);
+    if (empty($report['Expressions'])) {
+      $report['Expressions'] = '*NO STRINGS*';
+    }
+    $reports[] = $report;
+  }
+  if (empty($expressionCount)) {
+    $io->note('No relevant strings found. Skipping upgrade.');
+    return;
+  }
+
+  $io->note([
+    'In CiviCRM v6.16, SearchKit can perform multilingual translation of Saved Searches (labels, descriptions, etc). This is useful for organizations that operate in multiple locales.',
+    'To support multilingual, you should remove E::ts() and allow SearchKit to lookup the translations.',
+    'However, removing E::ts() will disable translation on older versions of CiviCRM (<=v6.15).',
+    sprintf('You have %d relevant strings.', $expressionCount),
+  ]);
+
+  if ($io->confirm('Would you like to review affected strings?')) {
+    $io->table(array_keys($reports[0]), $reports);
+  }
+
+  if (Civix::checker()->coreVersionIs('>=', '6.16')) {
+    $action = $io->confirm('Continue to remove old E::ts() from relevant strings?') ? 'r' : 'n';
+  }
+  else {
+    $action = $io->choice('How you would like to handle the migration?', [
+      'r' => 'Require CiviCRM v6.16+. Remove E::ts() from strings. Block older versions of CiviCRM.',
+      'p' => 'Prefer CiviCRM v6.16+. Remove E::ts() from strings. Older versions of CiviCRM are allowed, but translation may not work.',
+      'n' => 'No change. Leave the current strings and current CiviCRM requirements.',
+    ], 'p');
+  }
+
+  if ($action === 'r') {
+    $gen->updateInfo(function(\CRM\CivixBundle\Builder\Info $info) {
+      $info->raiseCompatibilityMinimum('6.16');
+    });
+  }
+  if ($action === 'r' || $action === 'p') {
+    foreach ($mgdFiles as $mgdFile) {
+      $relPath = Files::relativize($mgdFile, $gen->baseDir->string());
+      $io->section("Update strings in $relPath");
+      /**
+       * @var \PhpArrayDocument\PhpArrayDocument $doc
+       */
+      $doc = (new \PhpArrayDocument\Parser())->parse(file_get_contents($mgdFile));
+
+      foreach ($findSavedSearchStrings($doc->getRoot()) as $stringNode) {
+        $stringNode->setFactory(NULL);
+      }
+
+      $content = (new Printer())->print($doc);
+      file_put_contents($mgdFile, $content);
+    }
+  }
+  if ($action === 'n') {
+    $io->note([
+      'No changes will be made.',
+      "If you wish run this in the future, call: civix upgrade --start=26.0.0",
+    ]);
+  }
+
+};


### PR DESCRIPTION
Settings should not be translated as of https://github.com/civicrm/civicrm-core/pull/33901

See https://github.com/civicrm/civicrm-core/pull/35782 for a similar patch to the Api4 Explorer.

- Introduced `excludeTs()` method to PhpData for skipping translation wrapping on specified keys and their children.
- Updated tests to verify exclusion behavior with nested and multiple keys.