### PR TITLE
dev/core#6550 Update type hints to support upgrading

### DIFF
--- a/src/CRM/CivixBundle/Command/AbstractCommand.php
+++ b/src/CRM/CivixBundle/Command/AbstractCommand.php
@@ -28,7 +28,7 @@ abstract class AbstractCommand extends Command {
     parent::initialize($input, $output);
   }
 
-  public function run(InputInterface $input, OutputInterface $output) {
+  public function run(InputInterface $input, OutputInterface $output): int {
     try {
       \Civix::ioStack()->push($input, $output);
       return parent::run($input, $output);


### PR DESCRIPTION
The type hint is required when upgrading symfony and it is Ok to have it with the current version