### PR TITLE
Only check for 5.74 at runtime if min compatibility is lower

### DIFF
--- a/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
+++ b/src/CRM/CivixBundle/Resources/views/Code/module.civix.php.php
@@ -111,6 +111,7 @@ function _<?php echo $mainFile ?>_civix_class_loader($class) {
 <?php $_clPrefix = 'CiviMix\\Schema\\' . \CRM\CivixBundle\Utils\Naming::createCamelName($mainFile) . '\\' ?>
 <?php $_localBase = $_namespace . '_DAO_Base'; ?>
   if ($class === <?php var_export($_localBase); ?>) {
+<?php if (version_compare($_compatibility, '5.74.beta', '<')) { ?>
     if (version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')) {
       class_alias('CRM_Core_DAO_Base', <?php var_export($_localBase); ?>);
       // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
@@ -120,6 +121,13 @@ function _<?php echo $mainFile ?>_civix_class_loader($class) {
       class_alias($realClass, $class);
       // ^^ Abstract names -- discourage IDE's from picking up on this association.
     }
+<?php
+}
+else {
+?>
+    class_alias('CRM_Core_DAO_Base', <?php var_export($_localBase); ?>);
+    // ^^ Materialize concrete names -- encourage IDE's to pick up on this association.
+<?php } ?>
     return;
   }
 


### PR DESCRIPTION
## Overview
In `module.civix.php.php`, only emit the runtime `version_compare(CRM_Utils_System::version(), '5.74.beta', '>=')` check for DAO base class alias if `$_compatibility` is less than `'5.74.beta'`.

## Technical Details
When an extension's `<compatibility>` target is already `>= 5.74.beta`, we know CiviCRM will always be at least `5.74.beta`, so `class_alias('CRM_Core_DAO_Base', ...)` can be called directly without wrapping it in an unnecessary runtime version check.